### PR TITLE
Fix some transparency issue ontelegram stickers

### DIFF
--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -199,7 +199,7 @@ def export_gif(animation, fp, dpi=96, skip_frames=5):
         file.seek(0)
         frames.append(_png_gif_prepare(Image.open(file)))
 
-    duration = 1000 / animation.frame_rate * (1 + skip_frames) / 2
+    duration = 1000 / animation.frame_rate * (1 + skip_frames)  # why /2 before?
     frames[0].save(
         fp,
         format='GIF',

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -326,7 +326,7 @@ else:
         # get the gif file size
         new_file_size = os.path.getsize(gif_file.name)
         if new_file_size > 1024 * 1024:
-            scales = [600, 512, 480, 400, 360, 300, 256, 200, 150, 100]
+            scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
             scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
             if channel_id.startswith("blueset.wechat"):
                 for scale in scales:

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -223,7 +223,7 @@ def convert_tgs_to_gif(tgs_file: BinaryIO, gif_file: BinaryIO) -> bool:
         # heavy_strip(animation)
         # heavy_strip(animation)
         # animation.tgs_sanitize()
-        export_gif(animation, gif_file, skip_frames=5, dpi=48)
+        export_gif(animation, gif_file, skip_frames=5, dpi=48) # skip_frames = 5 means select one frame in every 5 frames
         return True
     except Exception:
         logging.exception("Error occurred while converting TGS to GIF.")

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -297,41 +297,62 @@ else:
         # 检查视频编码类型是否为VP9
         if metadata['streams'][0]['codec_name'] == 'vp9':
             stream = ffmpeg.input(file.name, vcodec='libvpx-vp9')
-        # generate a palettegen
-        palettegen_file = NamedTemporaryFile(suffix='.png')
-        (
-            stream
-            .output(palettegen_file.name, vf='palettegen=reserve_transparent=on')
-            .overwrite_output()
-            .run()
-        )
-        # generate a gif
-        palettegen = ffmpeg.input(palettegen_file.name)
-
-        stream = (
-            ffmpeg
-            .filter([stream, palettegen], 'paletteuse')
-        )
         if channel_id.startswith("blueset.wechat"):
             # Workaround: Compress GIF for slave channel `blueset.wechat`
             # TODO: Move this logic to `blueset.wechat` in the future
             if metadata.get('fps', 0) > 12:
                 stream = stream.filter("fps", 12, round='up')
-            stream_scale = stream.filter("scale", 600, -2, flags="lanczos")
-
-            stream_scale.output(gif_file.name).overwrite_output().run()
-            # get the gif file size
-            new_file_size = os.path.getsize(gif_file.name)
+            if metadata.get('width', 0) > 600:
+                stream = stream.filter("scale", 600, -2, flags="lanczos")
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run()
+        # get the gif file size
+        new_file_size = os.path.getsize(gif_file.name)
+        if new_file_size > 1024 * 1024:
             scales = [600, 512, 480, 400, 360, 300, 256, 200, 150, 100]
-            if new_file_size > 1024 * 1024:
+            scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
+            if channel_id.startswith("blueset.wechat"):
                 for scale in scales:
                     stream_scale = stream.filter("scale", scale, -2, flags="lanczos")
-                    stream_scale.output(gif_file.name).overwrite_output().run() 
+                    split = (
+                        stream_scale
+                        .split()
+                    )
+                    stream_paletteuse = (
+                        ffmpeg
+                        .filter(
+                            [
+                                split[0],
+                                split[1]
+                                .filter(
+                                    filter_name='palettegen', 
+                                    reserve_transparent='on',
+                                )
+                            ],
+                            filter_name='paletteuse',
+                        )
+                    )
+                    stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run() 
                     new_file_size = os.path.getsize(gif_file.name)
                     if new_file_size < 1024 * 1024:
                         break
-        else:
-            stream.output(gif_file.name).overwrite_output().run()
         file.close()
         gif_file.seek(0)
         return gif_file

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -160,6 +160,22 @@ def chat_id_str_to_id(s: EFBChannelChatIDStr) -> Tuple[ModuleID, ChatID, Optiona
         group_id = ChatID(ids[2])
     return channel_id, chat_uid, group_id
 
+def _png_gif_prepare(image):
+    """ Fork of lottie.exporters.gif.export_gif
+    Adapted from eltiempoes/python-lottie
+    https://github.com/eltiempoes/python-lottie/blob/a9f8be4858adb7eb0bc0e406a870b19c309c8a36/lib/lottie/exporters/gif.py#L10
+    License:
+        AGPL 3.0 (Python Lottie)
+    """
+    if image.mode not in ["RGBA", "RGBa"]:
+        image = image.convert("RGBA")
+    alpha = image.getchannel("A")
+    image = image.convert(image.mode[:-1]) \
+            .convert('P', palette=Image.ADAPTIVE, colors=255) # changed
+    mask = Image.eval(alpha, lambda a: 255 if a <= 128 else 0)
+    image.paste(255, mask=mask)
+    image.info['transparency'] = 255 # added
+    return image
 
 def export_gif(animation, fp, dpi=96, skip_frames=5):
     """ Fork of lottie.exporters.gif.export_gif
@@ -172,7 +188,7 @@ def export_gif(animation, fp, dpi=96, skip_frames=5):
     # Import only upon calling the method due to added binary dependencies
     # (libcairo)
     from lottie.exporters.cairo import export_png
-    from lottie.exporters.gif import _png_gif_prepare
+    # from lottie.exporters.gif import _png_gif_prepare # The code here have some problem, so I copy the function abo ve
 
     start = int(animation.in_point)
     end = int(animation.out_point)

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -322,7 +322,7 @@ else:
                 filter_name='paletteuse',
             )
         )
-        stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run()
+        stream_paletteuse.output(gif_file.name).overwrite_output().run()
         # get the gif file size
         new_file_size = os.path.getsize(gif_file.name)
         if new_file_size > 1024 * 1024:

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -294,6 +294,9 @@ else:
         file.seek(0)
         metadata = ffmpeg.probe(file.name)
         stream = ffmpeg.input(file.name)
+        # 检查视频编码类型是否为VP9
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx')
         if channel_id.startswith("blueset.wechat"):
             # Workaround: Compress GIF for slave channel `blueset.wechat`
             # TODO: Move this logic to `blueset.wechat` in the future


### PR DESCRIPTION
Sending stickers from efb via telegram to WeChat often encounters errors like the one shown below. These errors mostly occur with animated stickers. Other user have such [reports](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251) too.

![WeChat error message image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/fd4bad79-843d-4eab-a25b-ece7565ae111)

After investigating, I found that these errors are likely due to WeChat's [limit](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207145598) of 1 MB for GIF files used as stickers. Reducing the frame rate and figure size of the GIF can help reduce the file size, which is the main approach I took. 

In the process of researching the GIF size limits, I also discovered that even if a sticker has transparency, this transparency is lost when the sticker is sent to WeChat:

![Transparency loss image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/32b5decb-e2e6-4190-af75-2c725149a370)

To address this, I tried fixing the transparency issue. After some research, I found that decoding the WEBM files from Telegram correctly and using palettegen with the reserve_transparent flag, then encoding to GIF can retain transparency in a way that WeChat recognizes. 

![Transparent GIF image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/73cc7b34-fc67-4bad-9849-7cfb6e8aee0e)

There are still some remaining tasks:

- [x] Some TGS stickers still raise error -1
- [x] Non-WEBM stickers still have transparency issues
- [x] Windows

I will merge this pull request once these TODOs are complete.

---
在微信发表情贴图经常会出错,错误信息如下,也有别人[反馈](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251)

![WeChat error message image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/fd4bad79-843d-4eab-a25b-ece7565ae111)

这类型错误主要是因为微信对表情贴图的GIF文件大小有1M的[限制](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207145598)。这个PR中我主要是通过降低GIF的帧率和图片大小来缩小文件,来尽可能避免这种错误。 

在研究GIF大小限制的时候,我还发现发送表情经常会丢失透明背景，而变成黑色背景。即使原图有透明背景,到了微信也会变成不透明的:

![Transparency loss image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/32b5decb-e2e6-4190-af75-2c725149a370)

为了解决这个问题,我试着让GIF保留透明。经过研究,我使用了正确解码Telegram的WEBM文件,然后保留透明背景生成调色板,再编码成GIF的方法,这样就能保留透明背景,微信也能正常显示:

![Transparent GIF image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/73cc7b34-fc67-4bad-9849-7cfb6e8aee0e)


还有一些需要完成的工作:

- [x] 有些TGS表情贴图还是会报错
- [x] 非WEBM的表情贴图透明背景问题还没解决
- [x] Windows下的处理

请求将在TODO完成后合并。