### PR TITLE
Fix high connection counts and fix database quit took forever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ fabric.properties
 readme_translations/locale
 CLAUDE.md
 .claude/settings.local.json
+
+.venv/

--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -195,6 +195,22 @@ class TelegramChannel(MasterChannel):
                     raise ValueError(self._('Admin ID is expected to be an int, but {data} is found.')
                                      .format(data=data['admins'][i]))
 
+            # Validate auxiliary_bots config
+            aux_bots = data.get('auxiliary_bots', [])
+            if aux_bots:
+                if not isinstance(aux_bots, list):
+                    raise ValueError(self._('auxiliary_bots must be a list.'))
+                main_token = data['token']
+                seen_tokens = {main_token}
+                for idx, entry in enumerate(aux_bots):
+                    if not isinstance(entry, dict) or not isinstance(entry.get('token'), str):
+                        raise ValueError(
+                            self._('auxiliary_bots[{idx}] must have a "token" string.').format(idx=idx))
+                    if entry['token'] in seen_tokens:
+                        raise ValueError(
+                            self._('Duplicate token found in auxiliary_bots[{idx}].').format(idx=idx))
+                    seen_tokens.add(entry['token'])
+
             self.config = data.copy()
 
     def info(self, update: Update, context: CallbackContext):

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -1,0 +1,282 @@
+# coding=utf-8
+
+import bisect
+import logging
+import threading
+import time
+from collections import defaultdict, deque
+from typing import Optional, Dict, Tuple, TYPE_CHECKING
+
+import telegram
+import telegram.error
+from telegram.utils.request import Request
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class AuxiliaryBot:
+    """Lightweight wrapper around telegram.Bot for send-only auxiliary bots.
+
+    Each instance has its own independent sliding-window rate limiter
+    and a non-blocking group membership cache with TTL-based refresh.
+    """
+
+    MEMBERSHIP_TTL_MEMBER = 1800.0      # 30 min for confirmed member
+    MEMBERSHIP_TTL_NOT_MEMBER = 300.0   # 5 min for non-member (re-check sooner)
+
+    def __init__(self, token: str, *,
+                 request_kwargs: Optional[dict] = None,
+                 base_url: Optional[str] = None,
+                 base_file_url: Optional[str] = None,
+                 global_limit: int = 30,
+                 global_window: float = 1.0,
+                 chat_limit: int = 20,
+                 chat_window: float = 60.0):
+        kwargs = {}
+        if base_url:
+            kwargs['base_url'] = base_url
+        if base_file_url:
+            kwargs['base_file_url'] = base_file_url
+        if request_kwargs:
+            # Match telegram.ext.Updater: pass a Request instance, not request_kwargs (PTB 13.11+).
+            kwargs['request'] = Request(**request_kwargs)
+
+        self.bot: telegram.Bot = telegram.Bot(token=token, **kwargs)
+
+        # Identity (populated by initialize())
+        self.bot_id: int = 0
+        self.username: str = ""
+        self.disabled: bool = False
+        self._disable_reason: str = ""
+
+        # Rate limiting (same structure as TelegramBotManager)
+        self._rate_limit_lock = threading.Lock()
+        self._global_timestamps: list = []
+        self._chat_timestamps: defaultdict = defaultdict(deque)
+        self.GLOBAL_LIMIT = global_limit
+        self.GLOBAL_WINDOW = global_window
+        self.CHAT_LIMIT = chat_limit
+        self.CHAT_WINDOW = chat_window
+
+        # Membership cache: chat_id -> (is_member, timestamp)
+        self._membership_cache: Dict[int, Tuple[bool, float]] = {}
+        self._membership_lock = threading.Lock()
+        self._pending_probes: set = set()
+
+    def initialize(self) -> bool:
+        """Call get_me() to validate token and cache identity.
+        Returns True on success, False on failure (bot is disabled).
+        """
+        try:
+            me = self.bot.get_me()
+            self.bot_id = me.id
+            self.username = me.username or ""
+            logger.info("Auxiliary bot initialized: @%s (id=%d)", self.username, self.bot_id)
+            return True
+        except telegram.error.Unauthorized as e:
+            self.disabled = True
+            self._disable_reason = str(e)
+            logger.error("Failed to initialize auxiliary bot: %s", e)
+            return False
+        except Exception as e:
+            self.disabled = True
+            self._disable_reason = str(e)
+            logger.error("Failed to initialize auxiliary bot: %s", e)
+            return False
+
+    def _cleanup_old_timestamps(self):
+        """Remove timestamps older than the time window (called under lock)."""
+        current_time = time.time()
+        while self._global_timestamps and self._global_timestamps[0] <= current_time - self.GLOBAL_WINDOW:
+            self._global_timestamps.pop(0)
+        for _chat_id, timestamps in self._chat_timestamps.items():
+            while timestamps and timestamps[0] <= current_time - self.CHAT_WINDOW:
+                timestamps.popleft()
+
+    def peek_delay(self, chat_id: int) -> float:
+        """Check rate limit delay without reserving a slot. Thread-safe."""
+        with self._rate_limit_lock:
+            current_time = time.time()
+            self._cleanup_old_timestamps()
+
+            # Chat-specific check
+            chat_delay = 0.0
+            chat_timestamps = self._chat_timestamps[chat_id]
+            if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
+                safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
+                reference_timestamp = chat_timestamps[safe_index]
+                chat_delay = max(0.0, (reference_timestamp + self.CHAT_WINDOW) - current_time)
+
+            candidate_time = current_time + chat_delay
+
+            # Global limit check — use bisect_right for left bound so the
+            # window is half-open (left_bound, candidate_time], preventing an
+            # infinite loop when timestamps cluster on the boundary.
+            while True:
+                left_bound = candidate_time - self.GLOBAL_WINDOW
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                in_window = right_idx - idx
+                if in_window < self.GLOBAL_LIMIT - 2:
+                    break
+                candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+
+            return max(0.0, candidate_time - current_time)
+
+    def reserve_slot(self, chat_id: int) -> float:
+        """Reserve a send slot and return the delay. Thread-safe."""
+        with self._rate_limit_lock:
+            current_time = time.time()
+            self._cleanup_old_timestamps()
+
+            chat_delay = 0.0
+            chat_timestamps = self._chat_timestamps[chat_id]
+            if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
+                safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
+                reference_timestamp = chat_timestamps[safe_index]
+                chat_delay = max(0.0, (reference_timestamp + self.CHAT_WINDOW) - current_time)
+
+            candidate_time = current_time + chat_delay
+
+            while True:
+                left_bound = candidate_time - self.GLOBAL_WINDOW
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                in_window = right_idx - idx
+                if in_window < self.GLOBAL_LIMIT - 2:
+                    break
+                candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+
+            delay = max(0.0, candidate_time - current_time)
+            bisect.insort(self._global_timestamps, candidate_time)
+            chat_timestamps.append(candidate_time)
+            return delay
+
+    # Tri-state membership results
+    MEMBERSHIP_MEMBER = True
+    MEMBERSHIP_NOT_MEMBER = False
+    MEMBERSHIP_UNKNOWN = None
+
+    def check_membership(self, chat_id: int) -> bool:
+        """Return cached membership status. On cache miss, trigger a
+        background probe and return False (non-blocking).
+
+        Uses stale-while-revalidate: if cached value exists but is expired,
+        return the stale value while refreshing in the background. This avoids
+        false "not a member" results when all bots' caches expire simultaneously.
+        """
+        result = self.check_membership_tri(chat_id)
+        if result is None:
+            return False
+        return result
+
+    def check_membership_tri(self, chat_id: int):
+        """Tri-state membership check: True (member), False (confirmed not member),
+        None (unknown / probe in progress).
+        """
+        stale_value = None
+        need_probe = False
+        with self._membership_lock:
+            entry = self._membership_cache.get(chat_id)
+            if entry is not None:
+                is_member, timestamp = entry
+                ttl = self.MEMBERSHIP_TTL_MEMBER if is_member else self.MEMBERSHIP_TTL_NOT_MEMBER
+                age = time.time() - timestamp
+                if age < ttl:
+                    return is_member
+                need_probe = True
+                stale_value = is_member
+
+        if need_probe:
+            self._start_membership_probe(chat_id)
+            return stale_value
+
+        self._start_membership_probe(chat_id)
+        return None
+
+    def check_membership_sync(self, chat_id: int, timeout: float = 5.0) -> bool:
+        """Blocking membership check. Waits for a pending probe to finish,
+        or runs one synchronously if no cache entry exists."""
+        with self._membership_lock:
+            entry = self._membership_cache.get(chat_id)
+            if entry is not None:
+                is_member, timestamp = entry
+                ttl = self.MEMBERSHIP_TTL_MEMBER if is_member else self.MEMBERSHIP_TTL_NOT_MEMBER
+                if time.time() - timestamp < ttl:
+                    return is_member
+
+        # Trigger probe if not already running
+        self._start_membership_probe(chat_id)
+
+        # Wait for the probe to finish
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._membership_lock:
+                if chat_id not in self._pending_probes:
+                    entry = self._membership_cache.get(chat_id)
+                    if entry is not None:
+                        return entry[0]
+                    return False
+            time.sleep(0.05)
+
+        logger.warning("Membership sync check timed out for bot %d in chat %d", self.bot_id, chat_id)
+        return False
+
+    def update_membership(self, chat_id: int, is_member: bool):
+        """Update the membership cache directly (e.g. from chat_left handler)."""
+        with self._membership_lock:
+            self._membership_cache[chat_id] = (is_member, time.time())
+
+    def _start_membership_probe(self, chat_id: int):
+        """Start a background thread to check membership via get_chat_member API."""
+        with self._membership_lock:
+            if chat_id in self._pending_probes:
+                return
+            self._pending_probes.add(chat_id)
+
+        thread = threading.Thread(
+            target=self._probe_membership,
+            args=(chat_id,),
+            daemon=True,
+            name=f"AuxBotMemberProbe-{self.bot_id}-{chat_id}"
+        )
+        thread.start()
+
+    def _probe_membership(self, chat_id: int):
+        """Background probe: call get_chat_member and update cache."""
+        try:
+            member = self.bot.get_chat_member(chat_id, self.bot_id)
+            is_member = member.status in ('member', 'administrator', 'creator', 'restricted')
+            self.update_membership(chat_id, is_member)
+            logger.debug("Membership probe for bot %d in chat %d: %s (status=%s)",
+                         self.bot_id, chat_id, is_member, member.status)
+        except telegram.error.Unauthorized:
+            self.disabled = True
+            self._disable_reason = "Unauthorized during membership probe"
+            logger.error("Auxiliary bot %d got Unauthorized during membership probe", self.bot_id)
+        except telegram.error.BadRequest as e:
+            self.update_membership(chat_id, False)
+            logger.debug("Membership probe for bot %d in chat %d failed: %s", self.bot_id, chat_id, e)
+        except Exception as e:
+            self.update_membership(chat_id, False)
+            logger.warning("Membership probe failed for bot %d in chat %d: %s", self.bot_id, chat_id, e)
+        finally:
+            with self._membership_lock:
+                self._pending_probes.discard(chat_id)
+
+    def has_pending_probes(self) -> bool:
+        """Check if there are any pending membership probes."""
+        with self._membership_lock:
+            return bool(self._pending_probes)
+
+    def mark_disabled(self, reason: str = ""):
+        """Mark this bot as permanently disabled for this session."""
+        self.disabled = True
+        self._disable_reason = reason
+        logger.error("Auxiliary bot @%s (id=%d) disabled: %s", self.username, self.bot_id, reason)
+
+    def __repr__(self):
+        return f"AuxiliaryBot(@{self.username}, id={self.bot_id}, disabled={self.disabled})"

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -121,27 +121,50 @@ class TelegramBotManager(LocaleMixin):
                 if not cls.enable_retry:
                     return fn(self, *args, **kwargs)
 
+                # Extract chat_id from arguments for logging
+                chat_id = None
+                if args:
+                    chat_id = args[0]
+                elif 'chat_id' in kwargs:
+                    chat_id = kwargs['chat_id']
+
+                # Get recent timestamps for debugging
+                def get_timestamp_info():
+                    if not (chat_id and hasattr(self, '_chat_timestamps') and hasattr(self, '_global_timestamps')):
+                        return ""
+
+                    current_time = time.time()
+                    chat_timestamps = list(self._chat_timestamps.get(chat_id, []))
+                    global_timestamps = self._global_timestamps
+
+                    # Format recent timestamps relative to current time
+                    chat_info = [f"{ts - current_time:.3f}s" for ts in chat_timestamps]
+                    global_info = [f"{ts - current_time:.3f}s" for ts in global_timestamps]
+
+                    return f" [chat_recent: {chat_info}, global_recent: {global_info}]"
+
                 for attempt in range(max_retries + 1):
                     try:
                         return fn(self, *args, **kwargs)
                     except telegram.error.RetryAfter as e:
+                        timestamp_info = get_timestamp_info()
                         if attempt >= max_retries:
-                            cls.logger.error(f"Max retries exceeded for rate limit error: {e}")
+                            cls.logger.error(f"Max retries exceeded for rate limit error: {e} (chat_id: {chat_id}){timestamp_info}")
                             raise
 
                         retry_after = e.retry_after
-                        cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries}")
+                        cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
                         time.sleep(retry_after)
                     except telegram.error.TelegramError as e:
                         if "Too Many Requests" in str(e) or "429" in str(e) or "Flood" in str(e):
+                            timestamp_info = get_timestamp_info()
                             if attempt >= max_retries:
-                                cls.logger.error(f"Max retries exceeded for rate limit error: {e}")
+                                cls.logger.error(f"Max retries exceeded for rate limit error: {e} (chat_id: {chat_id}){timestamp_info}")
                                 raise
 
                             delay = 60
-                            cls.logger.warning(f"Rate limit detected, waiting {delay}s before retry {attempt + 1}/{max_retries}")
-                            if 'chat_id' in kwargs:
-                                chat_id = kwargs['chat_id']
+                            cls.logger.warning(f"Rate limit detected, waiting {delay}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
+                            if chat_id and hasattr(self, '_chat_timestamps'):
                                 for timestamp in self._chat_timestamps[chat_id]:
                                     timestamp += delay
                             time.sleep(delay)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -354,7 +354,7 @@ class TelegramBotManager(LocaleMixin):
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
                 idx = bisect.bisect_left(self._global_timestamps, left_bound)
-                right_idx = bisect.bisect_right(self._global_timestamps, self._global_timestamps[idx] + self.GLOBAL_WINDOW)
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
                     break

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -35,6 +35,7 @@ class DelayedTask(NamedTuple):
     args: tuple        # Function arguments
     kwargs: dict       # Function keyword arguments
     task_id: str       # Unique task identifier
+    cleanup_files: list = []  # Files to delete after task completes
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -102,13 +103,18 @@ class TelegramBotManager(LocaleMixin):
                         # Schedule for delayed execution instead of blocking
                         self.logger.debug(f"Scheduling message for chat {chat_id} with {delay_time:.2f}s delay")
 
+                        # Grab any pending cleanup files before scheduling
+                        cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]  # pylint: disable=protected-access
+                        self._cleanup_tls.pending_cleanup = []  # pylint: disable=protected-access
+
                         # Schedule the delayed execution using the new system
                         task_id = self._schedule_delayed_task(  # pylint: disable=protected-access
                             chat_id=chat_id,
                             delay_time=delay_time,
                             function=fn,
                             args=(self,) + args,
-                            kwargs=kwargs
+                            kwargs=kwargs,
+                            cleanup_files=cleanup_files
                         )
 
                         # Return a placeholder response to indicate message was scheduled
@@ -346,6 +352,7 @@ class TelegramBotManager(LocaleMixin):
         self.CHAT_LIMIT = 20      # messages per minute per chat
         self.CHAT_WINDOW = 60.0
 
+        self._cleanup_tls = threading.local()  # Thread-local for pending cleanup files
         self.logger.debug("Rate limiter initialized...")
 
         # Initialize delayed message queue system
@@ -477,7 +484,7 @@ class TelegramBotManager(LocaleMixin):
         return mock_msg
 
     def _schedule_delayed_task(self, chat_id: int, delay_time: float, function: Callable,
-                              args: tuple, kwargs: dict) -> str:
+                              args: tuple, kwargs: dict, cleanup_files: list = None) -> str:
         """
         Schedule a task for delayed execution.
 
@@ -500,7 +507,8 @@ class TelegramBotManager(LocaleMixin):
             function=function,
             args=args,
             kwargs=kwargs,
-            task_id=task_id
+            task_id=task_id,
+            cleanup_files=cleanup_files or []
         )
 
         with self._delayed_queue_lock:
@@ -544,6 +552,14 @@ class TelegramBotManager(LocaleMixin):
 
                     except Exception as e:
                         self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
+                    finally:
+                        # Clean up temp files associated with this delayed task
+                        for path in task.cleanup_files:
+                            try:
+                                os.unlink(path)
+                                self.logger.debug("Cleaned up delayed task temp file: %s", path)
+                            except OSError as e:
+                                self.logger.warning("Failed to clean up delayed task temp file %s: %s", path, e)
 
                 # Use event wait with timeout instead of sleep for faster shutdown response
                 if not self._delayed_worker_stop.wait(timeout=0.1):

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -8,9 +8,10 @@ import time
 import threading
 from collections import defaultdict, deque
 from functools import wraps
-from typing import List, TYPE_CHECKING, Callable, NamedTuple
+from typing import List, TYPE_CHECKING, Callable, NamedTuple, Deque
 from unittest.mock import Mock
 import heapq
+import bisect
 
 import telegram.constants
 import telegram.error
@@ -268,8 +269,8 @@ class TelegramBotManager(LocaleMixin):
 
         # Initialize sliding window rate limiting
         self._rate_limit_lock = threading.Lock()
-        self._global_timestamps = deque()
-        self._chat_timestamps = defaultdict(deque)
+        self._global_timestamps: list[float] = []  # Sorted list for global timestamps
+        self._chat_timestamps: defaultdict[int, Deque[float]] = defaultdict(deque)
 
         # Rate limits based on Telegram API documentation
         self.GLOBAL_LIMIT = 30    # messages per second
@@ -280,11 +281,11 @@ class TelegramBotManager(LocaleMixin):
         self.logger.debug("Rate limiter initialized...")
 
         # Initialize delayed message queue system
-        self._delayed_queue = []
+        self._delayed_queue: list[tuple[float, int, DelayedTask]] = []
         self._delayed_queue_lock = threading.Lock()
         self._task_counter = 0  # Counter for tie-breaking in heapq
         self._delayed_worker_stop = threading.Event()
-        self._pending_delayed_logs = {}  # Store pending database updates: task_id -> (etm_msg, old_msg_id)
+        self._pending_delayed_logs: dict[str, tuple] = {}  # Store pending database updates: task_id -> (etm_msg, old_msg_id)
         self._pending_logs_lock = threading.Lock()
         self._delayed_worker_thread = threading.Thread(
             target=self._delayed_message_worker,
@@ -308,7 +309,7 @@ class TelegramBotManager(LocaleMixin):
         current_time = time.time()
         # global rate limit
         while self._global_timestamps and self._global_timestamps[0] <= current_time - self.GLOBAL_WINDOW:
-            self._global_timestamps.popleft()
+            self._global_timestamps.pop(0)
 
         # chat-specific rate limit
         for chat_id, timestamps in self._chat_timestamps.items():
@@ -327,37 +328,43 @@ class TelegramBotManager(LocaleMixin):
             tuple: (delay_time, chat_count, global_count) - delay in seconds, current queue counts
         """
         current_time = time.time()
-        sleep_time = 0
+        sleep_time = 0.0
 
         with self._rate_limit_lock:
             self._cleanup_old_timestamps()
 
-            # global rate limit
-            if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 2:
-                # Get the timestamp that is (GLOBAL_LIMIT - 2) positions from the end
-                # This represents when we can safely send the next message
-                safe_index = len(self._global_timestamps) - (self.GLOBAL_LIMIT - 2)
-                if safe_index >= 0 and safe_index < len(self._global_timestamps):
-                    reference_timestamp = self._global_timestamps[safe_index]
-                    next_available_time = reference_timestamp + self.GLOBAL_WINDOW
-                    sleep_time = max(sleep_time, next_available_time - current_time)
-
-            # chat-specific rate limit
+            # --------------------------------------------------
+            # Chat-specific rate limit (FIFO – per-chat window)
+            # --------------------------------------------------
+            chat_delay = 0.0
             chat_timestamps = self._chat_timestamps[chat_id]
             if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
-                # Get the timestamp that is (CHAT_LIMIT - 2) positions from the end
                 safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
-                if safe_index >= 0 and safe_index < len(chat_timestamps):
-                    reference_timestamp = chat_timestamps[safe_index]
-                    next_available_time = reference_timestamp + self.CHAT_WINDOW
-                    sleep_time = max(sleep_time, next_available_time - current_time)
+                reference_timestamp = chat_timestamps[safe_index]
+                chat_delay = max(0.0, (reference_timestamp + self.CHAT_WINDOW) - current_time)
 
-            # Record the actual time this request will be processed
-            actual_time = current_time + max(sleep_time, 0)
-            self._global_timestamps.append(actual_time)
-            self._chat_timestamps[chat_id].append(actual_time)
+            # Earliest candidate time that satisfies chat limit
+            candidate_time = current_time + chat_delay
 
-            chat_count = len(self._chat_timestamps[chat_id])
+            # --------------------------------------------------
+            # Global limit – find the first slot that fits
+            # --------------------------------------------------
+            while True:
+                left_bound = candidate_time - self.GLOBAL_WINDOW
+                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                in_window = len(self._global_timestamps) - idx
+                if in_window < self.GLOBAL_LIMIT - 2:
+                    break
+                # Shift to just after the oldest entry in the current window
+                candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+
+            sleep_time = max(0.0, candidate_time - current_time)
+
+            # Record the scheduled time in both queues
+            bisect.insort(self._global_timestamps, candidate_time)
+            chat_timestamps.append(candidate_time)
+
+            chat_count = len(chat_timestamps)
             global_count = len(self._global_timestamps)
 
         # Log rate limiting status but don't sleep

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -8,7 +8,8 @@ import time
 import threading
 from collections import defaultdict, deque
 from functools import wraps
-from typing import List, TYPE_CHECKING, Callable
+from typing import List, TYPE_CHECKING, Callable, NamedTuple
+import heapq
 
 import telegram.constants
 import telegram.error
@@ -18,6 +19,16 @@ from telegram.ext import CallbackContext, Filters, MessageHandler, Updater, Disp
 
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
+
+
+class DelayedTask(NamedTuple):
+    """Represents a delayed message task."""
+    execute_time: float  # When to execute (timestamp)
+    chat_id: int        # Target chat ID
+    function: Callable  # Function to execute
+    args: tuple        # Function arguments
+    kwargs: dict       # Function keyword arguments
+    task_id: str       # Unique task identifier
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -72,9 +83,31 @@ class TelegramBotManager(LocaleMixin):
                 elif 'chat_id' in kwargs:
                     chat_id = kwargs['chat_id']
 
-                # Apply rate limiting
+                # Calculate rate limiting delay
                 if chat_id:
-                    self._wait_for_rate_limit(chat_id)  # pylint: disable=protected-access
+                    delay_time, chat_count, global_count = self._calculate_rate_limit_delay(chat_id)  # pylint: disable=protected-access
+
+                    if delay_time > 0:
+                        # Schedule for delayed execution instead of blocking
+                        self.logger.debug(f"Scheduling message for chat {chat_id} with {delay_time:.2f}s delay")
+
+                        # Record the timestamp for rate limiting tracking
+                        self._record_rate_limit_timestamp(chat_id, delay_time)  # pylint: disable=protected-access
+
+                                                # Schedule the delayed execution using the new system
+                        task_id = self._schedule_delayed_task(  # pylint: disable=protected-access
+                            chat_id=chat_id,
+                            delay_time=delay_time,
+                            function=fn,
+                            args=(self,) + args,
+                            kwargs=kwargs
+                        )
+
+                        # Return a placeholder response to indicate message was scheduled
+                        placeholder = self._create_delayed_message_placeholder(chat_id, delay_time, task_id)  # pylint: disable=protected-access
+                        return placeholder
+                    else:
+                        self._record_rate_limit_timestamp(chat_id, 0)  # pylint: disable=protected-access
 
                 return fn(self, *args, **kwargs)
 
@@ -248,6 +281,20 @@ class TelegramBotManager(LocaleMixin):
 
         self.logger.debug("Rate limiter initialized...")
 
+        # Initialize delayed message queue system
+        self._delayed_queue = []
+        self._delayed_queue_lock = threading.Lock()
+        self._delayed_worker_stop = threading.Event()
+        self._pending_delayed_logs = {}  # Store pending database updates: task_id -> (etm_msg, old_msg_id)
+        self._pending_logs_lock = threading.Lock()
+        self._delayed_worker_thread = threading.Thread(
+            target=self._delayed_message_worker,
+            name="ETM delayed messages worker",
+            daemon=True
+        )
+        self._delayed_worker_thread.start()
+        self.logger.debug("Delayed message system initialized...")
+
         self.logger.debug("Adding base dispatchers...")
         # New whitelist handler
         whitelist_filter = ~Filters.user(user_id=self.admins)
@@ -269,13 +316,16 @@ class TelegramBotManager(LocaleMixin):
             while timestamps and timestamps[0] <= current_time - self.CHAT_WINDOW:
                 timestamps.popleft()
 
-    def _wait_for_rate_limit(self, chat_id: int):
+    def _calculate_rate_limit_delay(self, chat_id: int):
         """
-        Rate limiting using sliding window algorithm.
-        Allows burst sending up to the limit, then enforces waiting.
+        Calculate rate limiting delay using sliding window algorithm.
+        Returns delay time without blocking.
 
         Args:
             chat_id: Telegram chat ID
+
+        Returns:
+            tuple: (delay_time, chat_count, global_count) - delay in seconds, current queue counts
         """
         current_time = time.time()
         sleep_time = 0
@@ -292,28 +342,189 @@ class TelegramBotManager(LocaleMixin):
             if len(chat_timestamps) >= self.CHAT_LIMIT - 1:
                 sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[0]))
 
-            # Record the actual time this request will be processed
-            actual_time = current_time + sleep_time
-            self._global_timestamps.append(actual_time)
-            self._chat_timestamps[chat_id].append(actual_time)
-
             chat_count = len(self._chat_timestamps[chat_id])
             global_count = len(self._global_timestamps)
 
-        # Sleep outside the lock to avoid blocking other threads
+        # Log rate limiting status but don't sleep
         if sleep_time > 0:
-            self.logger.info(f"Rate limit reached, sleeping {sleep_time:.2f}s for chat {chat_id}. "
+            self.logger.info(f"Rate limit reached, need to delay {sleep_time:.2f}s for chat {chat_id}. "
                            f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
-            time.sleep(sleep_time)
             if chat_count % 100 == 0:
-                self.logger.warning(f"Chat {chat_id} is heavilly queued. "
+                self.logger.warning(f"Chat {chat_id} is heavily queued. "
                                    f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
             if chat_count % 1000 == 0:
-                self.logger.error(f"Chat {chat_id} is heavilly queued. "
+                self.logger.error(f"Chat {chat_id} is heavily queued. "
                                    f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
         else:
             self.logger.debug(f"Rate limit not reached for chat {chat_id}. "
                            f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
+
+        return sleep_time, chat_count, global_count
+
+    def _record_rate_limit_timestamp(self, chat_id: int, delay_time: float):
+        """
+        Record the timestamp for rate limiting after message is scheduled.
+
+        Args:
+            chat_id: Telegram chat ID
+            delay_time: Delay time that was calculated
+        """
+        current_time = time.time()
+        actual_time = current_time + delay_time
+
+        with self._rate_limit_lock:
+            self._global_timestamps.append(actual_time)
+            self._chat_timestamps[chat_id].append(actual_time)
+
+    def _create_delayed_message_placeholder(self, chat_id: int, delay_time: float, task_id: str):
+        """
+        Create a placeholder message object for delayed execution.
+
+        Args:
+            chat_id: Telegram chat ID
+            delay_time: Delay time in seconds
+            task_id: Unique task identifier
+
+        Returns:
+            A mock message object indicating delayed execution
+        """
+        # Import here to avoid circular imports
+        from telegram import Message as TelegramMessage
+        from unittest.mock import Mock
+
+        # Create a mock message object that represents a delayed message
+        mock_msg = Mock(spec=TelegramMessage)
+        mock_msg.chat_id = chat_id
+        mock_msg.message_id = int(time.time() * 1000)  # Use timestamp as temp ID
+        mock_msg.date = int(time.time())
+        mock_msg.text = f"[Message scheduled for delivery in {delay_time:.2f}s due to rate limiting]"
+        mock_msg.is_delayed = True  # Custom attribute to mark as delayed
+        mock_msg.delay_time = delay_time
+        mock_msg.task_id = task_id  # Store task ID for tracking
+        mock_msg._delayed_execution_pending = True  # Flag for database logging
+
+        self.logger.debug(f"Created delayed message placeholder for chat {chat_id} with {delay_time:.2f}s delay")
+        return mock_msg
+
+    def _schedule_delayed_task(self, chat_id: int, delay_time: float, function: Callable,
+                              args: tuple, kwargs: dict) -> str:
+        """
+        Schedule a task for delayed execution.
+
+        Args:
+            chat_id: Telegram chat ID
+            delay_time: Delay in seconds
+            function: Function to execute
+            args: Function arguments
+            kwargs: Function keyword arguments
+
+        Returns:
+            Task ID for tracking
+        """
+        execute_time = time.time() + delay_time
+        task_id = f"{chat_id}_{execute_time}_{id(function)}"
+
+        task = DelayedTask(
+            execute_time=execute_time,
+            chat_id=chat_id,
+            function=function,
+            args=args,
+            kwargs=kwargs,
+            task_id=task_id
+        )
+
+        with self._delayed_queue_lock:
+            heapq.heappush(self._delayed_queue, (execute_time, task))
+
+        self.logger.debug(f"Scheduled delayed task {task_id} for chat {chat_id} in {delay_time:.2f}s")
+        return task_id
+
+    def _delayed_message_worker(self):
+        """
+        Worker thread that processes delayed messages.
+        """
+        self.logger.debug("Delayed message worker started")
+
+        while not self._delayed_worker_stop.is_set():
+            try:
+                current_time = time.time()
+                tasks_to_execute = []
+
+                # Check for tasks ready to execute
+                with self._delayed_queue_lock:
+                    while self._delayed_queue and self._delayed_queue[0][0] <= current_time:
+                        execute_time, task = heapq.heappop(self._delayed_queue)
+                        tasks_to_execute.append(task)
+
+                # Execute ready tasks outside of lock
+                for task in tasks_to_execute:
+                    try:
+                        self.logger.debug(f"Executing delayed task {task.task_id} for chat {task.chat_id}")
+                        result = task.function(*task.args, **task.kwargs)
+                        self.logger.debug(f"Delayed task {task.task_id} completed successfully")
+
+                        # Handle database update for delayed execution
+                        if result and hasattr(result, 'message_id'):
+                            self._handle_delayed_database_update(task.task_id, result)
+
+                    except Exception as e:
+                        self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
+
+                # Sleep for a short time to avoid busy waiting
+                time.sleep(0.1)
+
+            except Exception as e:
+                self.logger.exception(f"Error in delayed message worker: {e}")
+                time.sleep(1)  # Sleep longer on error to avoid spam
+
+        self.logger.debug("Delayed message worker stopped")
+
+    def register_delayed_database_update(self, task_id: str, etm_msg, old_msg_id=None):
+        """
+        Register a pending database update for a delayed task.
+
+        Args:
+            task_id: Task identifier from delayed execution
+            etm_msg: ETMMsg object to log
+            old_msg_id: Optional old message ID for updates
+        """
+        with self._pending_logs_lock:
+            self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id)
+        self.logger.debug(f"Registered delayed database update for task {task_id}")
+
+    def _handle_delayed_database_update(self, task_id: str, real_tg_msg):
+        """
+        Handle database update when delayed task completes.
+
+        Args:
+            task_id: Task identifier
+            real_tg_msg: The real Telegram message that was sent
+        """
+        with self._pending_logs_lock:
+            if task_id in self._pending_delayed_logs:
+                etm_msg, old_msg_id = self._pending_delayed_logs.pop(task_id)
+
+                # Update the ETM message with real Telegram data
+                from .msg_type import get_msg_type
+                etm_msg.type_telegram = get_msg_type(real_tg_msg)
+                etm_msg.put_telegram_file(real_tg_msg)
+
+                # Update database with real message
+                from . import TelegramChannel
+                if hasattr(self, 'channel') and isinstance(self.channel, TelegramChannel):
+                    self.channel.db.add_or_update_message_log(etm_msg, real_tg_msg, old_msg_id)
+                    self.logger.debug(f"Updated database with real message for delayed task {task_id}")
+                else:
+                    self.logger.warning(f"Cannot update database - channel not available for task {task_id}")
+            else:
+                self.logger.warning(f"No pending database update found for task {task_id}")
+
+    def stop_delayed_worker(self):
+        """Stop the delayed message worker thread."""
+        if hasattr(self, '_delayed_worker_stop'):
+            self._delayed_worker_stop.set()
+        if hasattr(self, '_delayed_worker_thread') and self._delayed_worker_thread.is_alive():
+            self._delayed_worker_thread.join(timeout=5)
 
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
@@ -779,6 +990,9 @@ class TelegramBotManager(LocaleMixin):
 
     def graceful_stop(self):
         """Gracefully stop the bot"""
+        # Stop the delayed message worker first
+        self.stop_delayed_worker()
+        # Then stop the updater
         self.updater.stop()
 
     def _detect_empty_file(self, file, chat, caption, prefix, suffix):

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -116,7 +116,8 @@ class TelegramBotManager(LocaleMixin):
             @wraps(fn)
             def rate_limit_error_handler(self: 'TelegramBotManager', *args, **kwargs):
                 max_retries = 3
-                base_delay = 60
+                if not cls.enable_retry:
+                    return fn(self, *args, **kwargs)
 
                 for attempt in range(max_retries + 1):
                     try:
@@ -135,7 +136,7 @@ class TelegramBotManager(LocaleMixin):
                                 cls.logger.error(f"Max retries exceeded for rate limit error: {e}")
                                 raise
 
-                            delay = base_delay * (2 ** attempt)  # Exponential backoff
+                            delay = 60
                             cls.logger.warning(f"Rate limit detected, waiting {delay}s before retry {attempt + 1}/{max_retries}")
                             if 'chat_id' in kwargs:
                                 chat_id = kwargs['chat_id']

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -375,11 +375,11 @@ class TelegramBotManager(LocaleMixin):
         # Log rate limiting status but don't sleep
         if sleep_time > 0:
             self.logger.info(f"Rate limit reached, need to delay {sleep_time:.2f}s for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{idx}, Scan count: {scan_count}")
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         else:
             self.logger.info(f"Rate limit not reached for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{idx}, Scan count: {scan_count}")
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         return sleep_time, chat_count, global_count
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -679,6 +679,10 @@ class TelegramBotManager(LocaleMixin):
             kwargs['text'] = prefix + text + suffix
             return self._bot_edit_message_text_fallback(**kwargs)
 
+    @Decorators.rate_limit_decorator
+    @Decorators.retry_on_timeout
+    @Decorators.handle_rate_limit_error
+    @Decorators.retry_on_chat_migration
     def _bot_send_message_fallback(self, *args, **kwargs):
         """
         Remove ``parse_mode`` if the server fails to parse.
@@ -695,6 +699,10 @@ class TelegramBotManager(LocaleMixin):
             else:
                 raise e
 
+    @Decorators.rate_limit_decorator
+    @Decorators.retry_on_timeout
+    @Decorators.handle_rate_limit_error
+    @Decorators.retry_on_chat_migration
     def _bot_edit_message_text_fallback(self, *args, **kwargs):
         """
         Remove ``parse_mode`` if the server fails to parse.

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -138,7 +138,7 @@ class TelegramBotManager(LocaleMixin):
                     if not (chat_id and hasattr(self, '_chat_timestamps') and hasattr(self, '_global_timestamps')):
                         return ""
 
-                    current_time = time.time_ns()
+                    current_time = time.time()
                     chat_timestamps = list(self._chat_timestamps.get(chat_id, []))
                     global_timestamps = self._global_timestamps
 
@@ -472,8 +472,8 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             Task ID for tracking
         """
-        execute_time = time.time_ns() + delay_time * 1_000_000_000
-        task_id = f"{chat_id}_{execute_time}_{id(function)}"
+        execute_time = time.time() + delay_time
+        task_id = f"{chat_id}_{time.time_ns() + delay_time * 1_000_000_000}_{id(function)}"
 
         task = DelayedTask(
             execute_time=execute_time,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -624,6 +624,13 @@ class TelegramBotManager(LocaleMixin):
                 filename += ".md"
             elif kwargs.get('parse_mode', '').lower() == 'html':
                 filename += ".html"
+                full_message_html = (
+                    "<html><head><meta charset='utf-8'></head>"
+                    "<body><pre style='white-space:pre-wrap'>" + (prefix + text + suffix) + "</pre></body></html>"
+                )
+                full_message.write(full_message_html.encode('utf-8'))
+                full_message.seek(0)
+                full_message.truncate()
             else:
                 filename += ".txt"
             self.updater.bot.send_document(args[0], full_message, filename=filename,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -691,10 +691,6 @@ class TelegramBotManager(LocaleMixin):
             kwargs['text'] = prefix + text + suffix
             return self._bot_edit_message_text_fallback(**kwargs)
 
-    @Decorators.rate_limit_decorator
-    @Decorators.retry_on_timeout
-    @Decorators.handle_rate_limit_error
-    @Decorators.retry_on_chat_migration
     def _bot_send_message_fallback(self, *args, **kwargs):
         """
         Remove ``parse_mode`` if the server fails to parse.
@@ -711,10 +707,6 @@ class TelegramBotManager(LocaleMixin):
             else:
                 raise e
 
-    @Decorators.rate_limit_decorator
-    @Decorators.retry_on_timeout
-    @Decorators.handle_rate_limit_error
-    @Decorators.retry_on_chat_migration
     def _bot_edit_message_text_fallback(self, *args, **kwargs):
         """
         Remove ``parse_mode`` if the server fails to parse.

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -334,14 +334,12 @@ class TelegramBotManager(LocaleMixin):
 
             # global rate limit
             if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 2:
-                latestglobal_time = max(self._global_timestamps)
-                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - latestglobal_time) + 1)
+                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - self._global_timestamps[-self.GLOBAL_LIMIT + 2]))
 
             # chat-specific rate limit
             chat_timestamps = self._chat_timestamps[chat_id]
             if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
-                latest_chat_time = max(chat_timestamps)
-                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - latest_chat_time) + 1)
+                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[-self.CHAT_LIMIT + 2]))
             # Record the actual time this request will be processed
             actual_time = current_time + sleep_time
             self._global_timestamps.append(actual_time)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -374,11 +374,11 @@ class TelegramBotManager(LocaleMixin):
         # Log rate limiting status but don't sleep
         if sleep_time > 0:
             self.logger.info(f"Rate limit reached, need to delay {sleep_time:.2f}s for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {right_idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         else:
             self.logger.info(f"Rate limit not reached for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {right_idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         return sleep_time, chat_count, global_count
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -91,10 +91,7 @@ class TelegramBotManager(LocaleMixin):
                         # Schedule for delayed execution instead of blocking
                         self.logger.debug(f"Scheduling message for chat {chat_id} with {delay_time:.2f}s delay")
 
-                        # Record the timestamp for rate limiting tracking
-                        self._record_rate_limit_timestamp(chat_id, delay_time)  # pylint: disable=protected-access
-
-                                                # Schedule the delayed execution using the new system
+                        # Schedule the delayed execution using the new system
                         task_id = self._schedule_delayed_task(  # pylint: disable=protected-access
                             chat_id=chat_id,
                             delay_time=delay_time,
@@ -106,8 +103,6 @@ class TelegramBotManager(LocaleMixin):
                         # Return a placeholder response to indicate message was scheduled
                         placeholder = self._create_delayed_message_placeholder(chat_id, delay_time, task_id)  # pylint: disable=protected-access
                         return placeholder
-                    else:
-                        self._record_rate_limit_timestamp(chat_id, 0)  # pylint: disable=protected-access
 
                 return fn(self, *args, **kwargs)
 
@@ -319,7 +314,7 @@ class TelegramBotManager(LocaleMixin):
     def _calculate_rate_limit_delay(self, chat_id: int):
         """
         Calculate rate limiting delay using sliding window algorithm.
-        Returns delay time without blocking.
+        This method is stateful and updates the timestamp queues.
 
         Args:
             chat_id: Telegram chat ID
@@ -341,6 +336,10 @@ class TelegramBotManager(LocaleMixin):
             chat_timestamps = self._chat_timestamps[chat_id]
             if len(chat_timestamps) >= self.CHAT_LIMIT - 1:
                 sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[0]))
+            # Record the actual time this request will be processed
+            actual_time = current_time + sleep_time
+            self._global_timestamps.append(actual_time)
+            self._chat_timestamps[chat_id].append(actual_time)
 
             chat_count = len(self._chat_timestamps[chat_id])
             global_count = len(self._global_timestamps)
@@ -360,21 +359,6 @@ class TelegramBotManager(LocaleMixin):
                            f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
 
         return sleep_time, chat_count, global_count
-
-    def _record_rate_limit_timestamp(self, chat_id: int, delay_time: float):
-        """
-        Record the timestamp for rate limiting after message is scheduled.
-
-        Args:
-            chat_id: Telegram chat ID
-            delay_time: Delay time that was calculated
-        """
-        current_time = time.time()
-        actual_time = current_time + delay_time
-
-        with self._rate_limit_lock:
-            self._global_timestamps.append(actual_time)
-            self._chat_timestamps[chat_id].append(actual_time)
 
     def _create_delayed_message_placeholder(self, chat_id: int, delay_time: float, task_id: str):
         """
@@ -526,9 +510,9 @@ class TelegramBotManager(LocaleMixin):
         if hasattr(self, '_delayed_worker_thread') and self._delayed_worker_thread.is_alive():
             self._delayed_worker_thread.join(timeout=5)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_message(self, *args, prefix: str = '', suffix: str = '', **kwargs):
         """
@@ -578,9 +562,9 @@ class TelegramBotManager(LocaleMixin):
             kwargs['text'] = prefix + text + suffix
             return self._bot_send_message_fallback(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_text(self, prefix='', suffix='', **kwargs):
         """
@@ -660,10 +644,10 @@ class TelegramBotManager(LocaleMixin):
             else:
                 raise e
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_audio(self, *args, **kwargs):
         """
@@ -686,10 +670,10 @@ class TelegramBotManager(LocaleMixin):
         except telegram.error.BadRequest:
             return self.updater.bot.send_document(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_voice(self, *args, **kwargs):
         """
@@ -712,10 +696,10 @@ class TelegramBotManager(LocaleMixin):
         except telegram.error.BadRequest:
             return self.updater.bot.send_document(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_video(self, *args, **kwargs):
         """
@@ -738,10 +722,10 @@ class TelegramBotManager(LocaleMixin):
         except telegram.error.BadRequest:
             return self.updater.bot.send_document(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_document(self, *args, **kwargs):
         """
@@ -759,10 +743,10 @@ class TelegramBotManager(LocaleMixin):
         """
         return self.updater.bot.send_document(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_animation(self, *args, **kwargs):
         """
@@ -780,10 +764,10 @@ class TelegramBotManager(LocaleMixin):
         """
         return self.updater.bot.send_animation(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_photo(self, *args, **kwargs):
         """
@@ -806,6 +790,7 @@ class TelegramBotManager(LocaleMixin):
 
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_chat_action(self, *args, **kwargs):
         message_thread_id = kwargs.pop('message_thread_id', None)
@@ -813,44 +798,44 @@ class TelegramBotManager(LocaleMixin):
             kwargs['api_kwargs'] = { "message_thread_id":  message_thread_id}
         return self.updater.bot.send_chat_action(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_reply_markup(self, *args, **kwargs):
         return self.updater.bot.edit_message_reply_markup(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_location(self, *args, **kwargs):
         return self.updater.bot.send_location(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_venue(self, *args, **kwargs):
         return self.updater.bot.send_venue(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_sticker(self, *args, **kwargs):
         return self.updater.bot.send_sticker(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def forward_message(self, *args, **kwargs):
         return self.updater.bot.forward_message(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def copy_message(self, *args, **kwargs):
         return self.updater.bot.copy_message(*args, **kwargs)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -425,7 +425,7 @@ class TelegramBotManager(LocaleMixin):
                            f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {right_idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         else:
-            self.logger.info(f"Rate limit not reached for chat {chat_id}. "
+            self.logger.debug(f"Rate limit not reached for chat {chat_id}. "
                            f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {right_idx}/{self.GLOBAL_LIMIT}, Scan count: {scan_count}")
 
         return sleep_time, chat_count, global_count

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -473,7 +473,7 @@ class TelegramBotManager(LocaleMixin):
             Task ID for tracking
         """
         execute_time = time.time() + delay_time
-        task_id = f"{chat_id}_{execute_time}_{id(function)}"
+        task_id = f"{chat_id}_{execute_time:.9f}_{id(function)}"
 
         task = DelayedTask(
             execute_time=execute_time,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -138,7 +138,7 @@ class TelegramBotManager(LocaleMixin):
                     if not (chat_id and hasattr(self, '_chat_timestamps') and hasattr(self, '_global_timestamps')):
                         return ""
 
-                    current_time = time.time()
+                    current_time = time.time_ns()
                     chat_timestamps = list(self._chat_timestamps.get(chat_id, []))
                     global_timestamps = self._global_timestamps
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -334,14 +334,26 @@ class TelegramBotManager(LocaleMixin):
 
             # global rate limit
             if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 2:
-                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - self._global_timestamps[-self.GLOBAL_LIMIT + 2]))
+                # Get the timestamp that is (GLOBAL_LIMIT - 2) positions from the end
+                # This represents when we can safely send the next message
+                safe_index = len(self._global_timestamps) - (self.GLOBAL_LIMIT - 2)
+                if safe_index >= 0 and safe_index < len(self._global_timestamps):
+                    reference_timestamp = self._global_timestamps[safe_index]
+                    next_available_time = reference_timestamp + self.GLOBAL_WINDOW
+                    sleep_time = max(sleep_time, next_available_time - current_time)
 
             # chat-specific rate limit
             chat_timestamps = self._chat_timestamps[chat_id]
             if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
-                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[-self.CHAT_LIMIT + 2]))
+                # Get the timestamp that is (CHAT_LIMIT - 2) positions from the end
+                safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
+                if safe_index >= 0 and safe_index < len(chat_timestamps):
+                    reference_timestamp = chat_timestamps[safe_index]
+                    next_available_time = reference_timestamp + self.CHAT_WINDOW
+                    sleep_time = max(sleep_time, next_available_time - current_time)
+
             # Record the actual time this request will be processed
-            actual_time = current_time + sleep_time
+            actual_time = current_time + max(sleep_time, 0)
             self._global_timestamps.append(actual_time)
             self._chat_timestamps[chat_id].append(actual_time)
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -332,13 +332,13 @@ class TelegramBotManager(LocaleMixin):
             self._cleanup_old_timestamps()
 
             # global rate limit
-            if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 1:
-                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - self._global_timestamps[0]))
+            if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 2:
+                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - self._global_timestamps[0]) + 1)
 
             # chat-specific rate limit
             chat_timestamps = self._chat_timestamps[chat_id]
-            if len(chat_timestamps) >= self.CHAT_LIMIT - 1:
-                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[0]))
+            if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
+                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[0]) + 1)
             # Record the actual time this request will be processed
             actual_time = current_time + sleep_time
             self._global_timestamps.append(actual_time)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -87,6 +87,11 @@ class TelegramBotManager(LocaleMixin):
                 elif 'chat_id' in kwargs:
                     chat_id = kwargs['chat_id']
 
+                # if _delayed_worker_stop is set, we should not schedule new tasks
+                if self._delayed_worker_stop:
+                    self.logger.warning(f"Delayed worker is stopped. Not scheduling new tasks for chat {chat_id}.")
+                    return None
+
                 # Calculate rate limiting delay
                 if chat_id:
                     delay_time, chat_count, global_count = self._calculate_rate_limit_delay(chat_id)  # pylint: disable=protected-access

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -233,9 +233,10 @@ class TelegramBotManager(LocaleMixin):
 
                 file = args[1] if len(args) >= 2 else kwargs.get('file', None)
                 chat = args[0] if len(args) >= 1 else kwargs.get('chat_id', None)
+                message_thread_id = kwargs.get('message_thread_id', None)
 
                 if file:
-                    is_empty = self._detect_empty_file(file, chat, text, prefix, suffix)
+                    is_empty = self._detect_empty_file(file, chat, text, prefix, suffix, message_thread_id)
 
                     if is_empty:
                         return is_empty
@@ -1090,7 +1091,7 @@ class TelegramBotManager(LocaleMixin):
             # Don't raise exceptions in __del__
             pass
 
-    def _detect_empty_file(self, file, chat, caption, prefix, suffix):
+    def _detect_empty_file(self, file, chat, caption, prefix, suffix, message_thread_id=None):
         empty = True
         if isinstance(file, str):
             empty = os.stat(file).st_size == 0
@@ -1109,5 +1110,7 @@ class TelegramBotManager(LocaleMixin):
         elif isinstance(file, InputFile):
             empty = not bool(len(file.input_file_content))
         if empty:
-            return self.send_message(chat, prefix=self._("Empty attachment detected.") + prefix,
-                                     text=caption, suffix=suffix)
+            kwargs = {'prefix': self._("Empty attachment detected.") + prefix, 'text': caption, 'suffix': suffix}
+            if message_thread_id is not None:
+                kwargs['message_thread_id'] = message_thread_id
+            return self.send_message(chat, **kwargs)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -328,10 +328,10 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             tuple: (delay_time, chat_count, global_count) - delay in seconds, current queue counts
         """
-        current_time = time.time()
         sleep_time = 0.0
 
         with self._rate_limit_lock:
+            current_time = time.time()
             self._cleanup_old_timestamps()
 
             # --------------------------------------------------

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -268,6 +268,22 @@ class TelegramBotManager(LocaleMixin):
             return caption_affix
 
         @classmethod
+        def skip_on_rate_limit(cls, fn: Callable):
+            """Skip execution silently if messages are queued. For non-essential calls like typing indicators."""
+            @wraps(fn)
+            def skip_wrapper(self: 'TelegramBotManager', *args, **kwargs):
+                with self._delayed_queue_lock:
+                    if self._delayed_queue:
+                        return None
+
+                try:
+                    return fn(self, *args, **kwargs)
+                except telegram.error.RetryAfter:
+                    return None
+
+            return skip_wrapper
+
+        @classmethod
         def retry_on_chat_migration(cls, fn: Callable):
             @wraps(fn)
             def retry_on_chat_migration_wrap(self: 'TelegramBotManager', *args, **kwargs):
@@ -874,8 +890,8 @@ class TelegramBotManager(LocaleMixin):
         except telegram.error.BadRequest:
             return self.updater.bot.send_document(*args, **kwargs)
 
+    @Decorators.skip_on_rate_limit
     @Decorators.retry_on_timeout
-    @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_chat_action(self, *args, **kwargs):
         message_thread_id = kwargs.pop('message_thread_id', None)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -11,6 +11,8 @@ import time
 from collections import defaultdict, deque
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Tuple
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 from unittest.mock import Mock
 
 import telegram.constants
@@ -1110,7 +1112,8 @@ class TelegramBotManager(LocaleMixin):
     def _detect_empty_file(self, file, chat, caption, prefix, suffix, message_thread_id=None):
         empty = True
         if isinstance(file, str):
-            empty = os.stat(file).st_size == 0
+            stat_path = url2pathname(urlparse(file).path) if file.startswith('file://') else file
+            empty = os.stat(stat_path).st_size == 0
         elif hasattr(file, "seekable"):
             try:
                 if hasattr(file, 'closed') and file.closed:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -790,7 +790,6 @@ class TelegramBotManager(LocaleMixin):
 
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
-    @Decorators.rate_limit_decorator
     @Decorators.retry_on_chat_migration
     def send_chat_action(self, *args, **kwargs):
         message_thread_id = kwargs.pop('message_thread_id', None)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections import defaultdict, deque
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple
+from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Tuple
 from unittest.mock import Mock
 
 import telegram.constants
@@ -154,7 +154,17 @@ class TelegramBotManager(LocaleMixin):
 
                         retry_after = e.retry_after
                         cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
-                        time.sleep(retry_after)
+
+                        # Use interruptible sleep for rate limit waits
+                        if hasattr(self, '_delayed_worker_stop'):
+                            # Sleep in small chunks to allow for interruption during shutdown
+                            remaining = retry_after
+                            while remaining > 0 and not self._delayed_worker_stop.is_set():
+                                sleep_chunk = min(1.0, remaining)
+                                time.sleep(sleep_chunk)
+                                remaining -= sleep_chunk
+                        else:
+                            time.sleep(retry_after)
                     except telegram.error.TelegramError as e:
                         if "Too Many Requests" in str(e) or "429" in str(e) or "Flood" in str(e):
                             timestamp_info = get_timestamp_info()
@@ -167,7 +177,17 @@ class TelegramBotManager(LocaleMixin):
                             if chat_id and hasattr(self, '_chat_timestamps'):
                                 for timestamp in self._chat_timestamps[chat_id]:
                                     timestamp += delay
-                            time.sleep(delay)
+
+                            # Use interruptible sleep for rate limit waits
+                            if hasattr(self, '_delayed_worker_stop'):
+                                # Sleep in small chunks to allow for interruption during shutdown
+                                remaining = delay
+                                while remaining > 0 and not self._delayed_worker_stop.is_set():
+                                    sleep_chunk = min(1.0, remaining)
+                                    time.sleep(sleep_chunk)
+                                    remaining -= sleep_chunk
+                            else:
+                                time.sleep(delay)
                         else:
                             raise
 
@@ -305,7 +325,7 @@ class TelegramBotManager(LocaleMixin):
         self.logger.debug("Rate limiter initialized...")
 
         # Initialize delayed message queue system
-        self._delayed_queue: list[tuple[float, int, DelayedTask]] = []
+        self._delayed_queue: List[Tuple[float, int, DelayedTask]] = []
         self._delayed_queue_lock = threading.Lock()
         self._task_counter = 0  # Counter for tie-breaking in heapq
         self._delayed_worker_stop = threading.Event()
@@ -485,6 +505,10 @@ class TelegramBotManager(LocaleMixin):
 
                 # Execute ready tasks outside of lock
                 for task in tasks_to_execute:
+                    # Check if we should stop before executing each task
+                    if self._delayed_worker_stop.is_set():
+                        break
+
                     try:
                         self.logger.debug(f"Executing delayed task {task.task_id} for chat {task.chat_id}")
                         result = task.function(*task.args, **task.kwargs)
@@ -497,12 +521,14 @@ class TelegramBotManager(LocaleMixin):
                     except Exception as e:
                         self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
 
-                # Sleep for a short time to avoid busy waiting
-                time.sleep(0.1)
+                # Use event wait with timeout instead of sleep for faster shutdown response
+                if not self._delayed_worker_stop.wait(timeout=0.1):
+                    continue
 
             except Exception as e:
                 self.logger.exception(f"Error in delayed message worker: {e}")
-                time.sleep(1)  # Sleep longer on error to avoid spam
+                # Use event wait with timeout for error cases too
+                self._delayed_worker_stop.wait(timeout=1)
 
         self.logger.debug("Delayed message worker stopped")
 
@@ -543,10 +569,19 @@ class TelegramBotManager(LocaleMixin):
 
     def stop_delayed_worker(self):
         """Stop the delayed message worker thread."""
+        self.logger.debug("Stopping delayed message worker...")
+
         if hasattr(self, '_delayed_worker_stop'):
             self._delayed_worker_stop.set()
+
         if hasattr(self, '_delayed_worker_thread') and self._delayed_worker_thread.is_alive():
+            self.logger.debug("Waiting for delayed message worker to stop...")
             self._delayed_worker_thread.join(timeout=5)
+
+            if self._delayed_worker_thread.is_alive():
+                self.logger.warning("Delayed message worker did not stop gracefully within timeout")
+            else:
+                self.logger.debug("Delayed message worker stopped successfully")
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -1012,10 +1047,36 @@ class TelegramBotManager(LocaleMixin):
 
     def graceful_stop(self):
         """Gracefully stop the bot"""
+        self.logger.info("Starting graceful shutdown...")
+
+        # Log pending tasks count before stopping
+        pending_count = 0
+        if hasattr(self, '_delayed_queue'):
+            with self._delayed_queue_lock:
+                pending_count = len(self._delayed_queue)
+
+        if pending_count > 0:
+            self.logger.info(f"Found {pending_count} pending delayed tasks")
+
         # Stop the delayed message worker first
         self.stop_delayed_worker()
+
         # Then stop the updater
+        self.logger.debug("Stopping Telegram updater...")
         self.updater.stop()
+        self.logger.info("Graceful shutdown completed")
+
+    def __del__(self):
+        """Ensure cleanup on object destruction"""
+        try:
+            if hasattr(self, '_delayed_worker_stop') and hasattr(self, '_delayed_worker_thread'):
+                if not self._delayed_worker_stop.is_set():
+                    self._delayed_worker_stop.set()
+                if self._delayed_worker_thread.is_alive():
+                    self._delayed_worker_thread.join(timeout=1)
+        except Exception:
+            # Don't raise exceptions in __del__
+            pass
 
     def _detect_empty_file(self, file, chat, caption, prefix, suffix):
         empty = True

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -9,8 +9,9 @@ import os
 import threading
 import time
 from collections import defaultdict, deque
+from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 from unittest.mock import Mock
@@ -18,10 +19,12 @@ from unittest.mock import Mock
 import telegram.constants
 import telegram.error
 from retrying import retry
-from telegram import File, ForumTopic, InputFile, Update, User
+from telegram import File, ForumTopic, InlineKeyboardMarkup, InputFile, Update, User
 from telegram import Message as TelegramMessage
 from telegram.ext import CallbackContext, Dispatcher, Filters, MessageHandler, Updater
 
+from .auxiliary_bot import AuxiliaryBot
+from .bot_pool import BotPool
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
 from .msg_type import get_msg_type
@@ -41,6 +44,17 @@ if TYPE_CHECKING:
     from . import TelegramChannel
 
 MAX_CALLBACK_QUERY_ANSWER_LENGTH = 200
+
+
+def _has_callback_keyboard(reply_markup) -> bool:
+    """Check if a reply_markup contains InlineKeyboardButtons with callback_data."""
+    if not isinstance(reply_markup, InlineKeyboardMarkup):
+        return False
+    for row in reply_markup.inline_keyboard:
+        for button in row:
+            if button.callback_data and button.callback_data != "void":
+                return True
+    return False
 
 
 class TelegramBotManager(LocaleMixin):
@@ -79,12 +93,18 @@ class TelegramBotManager(LocaleMixin):
 
         @classmethod
         def rate_limit_decorator(cls, fn: Callable):
-            """Apply rate limiting to API calls."""
+            """Apply rate limiting to API calls with two-mode routing for multi-bot pool."""
             @wraps(fn)
             def rate_limit_wrapper(self: 'TelegramBotManager', *args, **kwargs):
+                # Bypass: caller already reserved a slot and set _using_bot
+                if kwargs.pop('_bypass_rate_limit', False):
+                    return fn(self, *args, **kwargs)
+
+                # Pop the _sender_bot_id kwarg (used for forced routing on edits/deletes)
+                sender_bot_id = kwargs.pop('_sender_bot_id', None)
+
                 # Extract chat_id from arguments
                 chat_id = None
-
                 if args:
                     chat_id = args[0]
                 elif 'chat_id' in kwargs:
@@ -95,8 +115,49 @@ class TelegramBotManager(LocaleMixin):
                     self.logger.warning(f"Delayed worker is stopped. Not scheduling new tasks for chat {chat_id}.")
                     return None
 
-                # Calculate rate limiting delay
+                # MODE 1: Forced routing (edits/deletes must go to the specific bot that sent the original)
+                if sender_bot_id and self.bot_pool:
+                    aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
+                    if aux_bot and not aux_bot.disabled:
+                        try:
+                            with self._using_bot(aux_bot.bot):
+                                result = fn(self, *args, **kwargs)
+                            if result and hasattr(result, '__dict__'):
+                                result._sender_bot_id = str(sender_bot_id)
+                            return result
+                        except telegram.error.Unauthorized:
+                            aux_bot.mark_disabled("Unauthorized during forced-route API call")
+                            self._notify_admin_disabled_bot(aux_bot)
+                    # Fallback: sender bot unavailable, try main bot
+                    return fn(self, *args, **kwargs)
+
+                # MODE 2: Pool routing (new sends pick best available bot)
+                # Only attempt aux bots when the main bot would impose a delay.
+                if chat_id and self.bot_pool:
+                    # Skip pool for messages with callback keyboards (EC-4)
+                    has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
+                    if not has_callback:
+                        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+                        slot = self.bot_pool.acquire_send_slot(chat_id, max_delay=main_delay) if main_delay > 0 else None
+                        if slot is not None:
+                            aux_bot, aux_delay = slot
+                            try:
+                                if aux_delay > 0:
+                                    time.sleep(aux_delay)
+                                with self._using_bot(aux_bot.bot):
+                                    result = fn(self, *args, **kwargs)
+                                if result and hasattr(result, '__dict__'):
+                                    result._sender_bot_id = str(aux_bot.bot_id)
+                                self._record_aux_use(chat_id)
+                                return result
+                            except telegram.error.Unauthorized:
+                                aux_bot.mark_disabled("Unauthorized during pool-route API call")
+                                self._notify_admin_disabled_bot(aux_bot)
+                                # Fallback: continue to main bot path below
+
+                # Default: main bot with rate limit check and delayed queue
                 if chat_id:
+                    # Calculate rate limiting delay
                     delay_time, chat_count, global_count = self._calculate_rate_limit_delay(chat_id)  # pylint: disable=protected-access
 
                     if delay_time > 0:
@@ -263,7 +324,7 @@ class TelegramBotManager(LocaleMixin):
                     msg = fn(self, *args, **kwargs)
                     chat_id = kwargs.get("chat_id", args[0] if len(args) > 0 else "")
                     filename = "%s_%s.txt" % (chat_id, msg.message_id)
-                    self.updater.bot.send_document(chat_id, full_message,
+                    self._active_bot.send_document(chat_id, full_message,
                                                    filename=filename,
                                                    reply_to_message_id=msg.message_id,
                                                    caption=self._("Caption is truncated due to its length. "
@@ -277,12 +338,21 @@ class TelegramBotManager(LocaleMixin):
 
         @classmethod
         def skip_on_rate_limit(cls, fn: Callable):
-            """Skip execution silently if messages are queued. For non-essential calls like typing indicators."""
+            """Skip execution silently if messages are queued or pool is in
+            high-volume mode for the target chat.
+            For non-essential calls like typing indicators."""
+            AUX_USE_RECENCY = 5.0  # seconds
+
             @wraps(fn)
             def skip_wrapper(self: 'TelegramBotManager', *args, **kwargs):
                 with self._delayed_queue_lock:
                     if self._delayed_queue:
                         return None
+
+                # Suppress when aux bots were recently used for this chat
+                chat_id = args[0] if args else kwargs.get('chat_id')
+                if chat_id and self._aux_recent_use.get(chat_id, 0) > time.time() - AUX_USE_RECENCY:
+                    return None
 
                 try:
                     return fn(self, *args, **kwargs)
@@ -353,7 +423,16 @@ class TelegramBotManager(LocaleMixin):
         self.CHAT_WINDOW = 60.0
 
         self._cleanup_tls = threading.local()  # Thread-local for pending cleanup files
+        self._tls = threading.local()  # Thread-local for bot override (_active_bot)
+        self._aux_recent_use: dict[int, float] = {}  # chat_id -> timestamp of last aux bot use
         self.logger.debug("Rate limiter initialized...")
+
+        # Initialize auxiliary bot pool
+        self.bot_pool: Optional[BotPool] = None
+        aux_configs = config.get('auxiliary_bots', [])
+        if aux_configs:
+            self._init_bot_pool(aux_configs, config, channel)
+        self.logger.debug("Bot pool initialization complete...")
 
         # Initialize delayed message queue system
         self._delayed_queue: List[Tuple[float, int, DelayedTask]] = []
@@ -379,6 +458,121 @@ class TelegramBotManager(LocaleMixin):
         self.Decorators.enable_retry = channel.flag('retry_on_error')
         self.logger.debug("Base dispatchers added...")
 
+    def _init_bot_pool(self, aux_configs: list, config: dict, channel: 'TelegramChannel'):
+        """Initialize the auxiliary bot pool from config."""
+        req_kwargs = {'read_timeout': 15}
+        conf_req_kwargs = config.get('request_kwargs')
+        if isinstance(conf_req_kwargs, collections.abc.Mapping):
+            req_kwargs.update(conf_req_kwargs)
+
+        main_token = config['token']
+        seen_tokens = {main_token}
+        aux_bots: list = []
+
+        for entry in aux_configs:
+            if not isinstance(entry, dict) or not isinstance(entry.get('token'), str):
+                self.logger.warning("Invalid auxiliary_bots entry (missing token string), skipping: %s", entry)
+                continue
+            token = entry['token']
+            if token in seen_tokens:
+                self.logger.warning("Duplicate bot token in auxiliary_bots, skipping")
+                continue
+            seen_tokens.add(token)
+
+            aux_bot = AuxiliaryBot(
+                token=token,
+                request_kwargs=req_kwargs,
+                base_url=channel.flag('api_base_url') or None,
+                base_file_url=channel.flag('api_base_file_url') or None,
+                global_limit=self.GLOBAL_LIMIT,
+                global_window=self.GLOBAL_WINDOW,
+                chat_limit=self.CHAT_LIMIT,
+                chat_window=self.CHAT_WINDOW,
+            )
+            if aux_bot.initialize():
+                aux_bots.append(aux_bot)
+            else:
+                self.logger.error("Skipping auxiliary bot with invalid token")
+
+        if aux_bots:
+            self.bot_pool = BotPool(aux_bots, self)
+            self.logger.info("Initialized bot pool with %d auxiliary bot(s)", len(aux_bots))
+
+    @property
+    def _active_bot(self):
+        """Return the bot to use for the current send operation.
+        Thread-safe: each thread has its own override slot."""
+        return getattr(self._tls, 'override_bot', None) or self.updater.bot
+
+    @contextmanager
+    def _using_bot(self, bot):
+        """Context manager to temporarily route sends through a different bot."""
+        old = getattr(self._tls, 'override_bot', None)
+        self._tls.override_bot = bot
+        try:
+            yield
+        finally:
+            self._tls.override_bot = old
+
+    def _record_aux_use(self, chat_id: int):
+        """Record that an aux bot was used for a chat (for typing suppression)."""
+        self._aux_recent_use[chat_id] = time.time()
+
+    def _notify_admin_disabled_bot(self, aux_bot: AuxiliaryBot):
+        """Send one-shot notification to admin that an aux bot was disabled."""
+        def _notify():
+            try:
+                admin_id = self.admins[0]
+                self.updater.bot.send_message(
+                    admin_id,
+                    f"⚠️ Auxiliary bot @{aux_bot.username} (id={aux_bot.bot_id}) has been "
+                    f"disabled: {aux_bot._disable_reason}. Please check the token in config."
+                )
+            except Exception as e:
+                self.logger.warning("Failed to notify admin about disabled aux bot: %s", e)
+
+        threading.Thread(target=_notify, daemon=True, name="AuxBotDisabledNotify").start()
+
+    def send_blocking_migration(self, chat_id: int, send_callable: Callable,
+                                timeout: float = 60.0):
+        """Block until any bot (main or aux) has a free slot, then send through it.
+
+        The callable receives a single ``_bypass_rate_limit=True`` kwarg that
+        the caller must forward to the decorated send method so the decorator
+        skips its own routing/reservation.
+
+        Returns whatever the send_callable returns.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+
+            # Try aux bots first if they can beat the main bot
+            if self.bot_pool:
+                slot = self.bot_pool.acquire_send_slot(chat_id, max_delay=max(main_delay, 0.01))
+                if slot is not None:
+                    aux_bot, aux_delay = slot
+                    if aux_delay > 0:
+                        time.sleep(aux_delay)
+                    try:
+                        with self._using_bot(aux_bot.bot):
+                            return send_callable(_bypass_rate_limit=True)
+                    except telegram.error.Unauthorized:
+                        aux_bot.mark_disabled("Unauthorized during migration send")
+                        self._notify_admin_disabled_bot(aux_bot)
+
+            # Try main bot
+            if main_delay == 0.0:
+                self._calculate_rate_limit_delay(chat_id)  # reserve
+                return send_callable(_bypass_rate_limit=True)
+
+            time.sleep(0.2)
+
+        # Timeout fallback: reserve on main and send anyway
+        self.logger.warning("send_blocking_migration timed out for chat %d, sending on main bot", chat_id)
+        self._calculate_rate_limit_delay(chat_id)
+        return send_callable(_bypass_rate_limit=True)
+
     def _cleanup_old_timestamps(self):
         """Remove timestamps older than the time window."""
         current_time = time.time()
@@ -391,13 +585,15 @@ class TelegramBotManager(LocaleMixin):
             while timestamps and timestamps[0] <= current_time - self.CHAT_WINDOW:
                 timestamps.popleft()
 
-    def _calculate_rate_limit_delay(self, chat_id: int):
+    def _calculate_rate_limit_delay(self, chat_id: int, peek_only: bool = False):
         """
         Calculate rate limiting delay using sliding window algorithm.
-        This method is stateful and updates the timestamp queues.
 
         Args:
             chat_id: Telegram chat ID
+            peek_only: If True, compute delay without reserving a slot
+                (no insort/append). Used to check main-bot availability
+                before committing to a pool decision.
 
         Returns:
             tuple: (delay_time, chat_count, global_count) - delay in seconds, current queue counts
@@ -427,20 +623,20 @@ class TelegramBotManager(LocaleMixin):
             scan_count = 0
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
-                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
                 right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
                     break
-                # Shift to just after the oldest entry in the current window
                 candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
                 scan_count += 1
 
             sleep_time = max(0.0, candidate_time - current_time)
 
-            # Record the scheduled time in both queues
-            bisect.insort(self._global_timestamps, candidate_time)
-            chat_timestamps.append(candidate_time)
+            if not peek_only:
+                # Record the scheduled time in both queues
+                bisect.insort(self._global_timestamps, candidate_time)
+                chat_timestamps.append(candidate_time)
 
             chat_count = len(chat_timestamps)
             global_count = len(self._global_timestamps)
@@ -543,7 +739,28 @@ class TelegramBotManager(LocaleMixin):
 
                     try:
                         self.logger.debug(f"Executing delayed task {task.task_id} for chat {task.chat_id}")
-                        result = task.function(*task.args, **task.kwargs)
+
+                        # Re-check pool: if an aux bot has become available, route through it
+                        result = None
+                        routed_to_aux = False
+                        if self.bot_pool and task.chat_id:
+                            slot = self.bot_pool.acquire_send_slot(task.chat_id, max_delay=0.01)
+                            if slot is not None:
+                                aux_bot, _ = slot
+                                try:
+                                    with self._using_bot(aux_bot.bot):
+                                        result = task.function(*task.args, **task.kwargs)
+                                    if result and hasattr(result, '__dict__'):
+                                        result._sender_bot_id = str(aux_bot.bot_id)
+                                    self._record_aux_use(task.chat_id)
+                                    routed_to_aux = True
+                                    self.logger.debug(f"Delayed task {task.task_id} routed to aux bot @{aux_bot.username}")
+                                except telegram.error.Unauthorized:
+                                    aux_bot.mark_disabled("Unauthorized during delayed task")
+                                    self._notify_admin_disabled_bot(aux_bot)
+
+                        if not routed_to_aux:
+                            result = task.function(*task.args, **task.kwargs)
                         self.logger.debug(f"Delayed task {task.task_id} completed successfully")
 
                         # Handle database update for delayed execution
@@ -601,8 +818,12 @@ class TelegramBotManager(LocaleMixin):
                 etm_msg.type_telegram = get_msg_type(real_tg_msg)
                 etm_msg.put_telegram_file(real_tg_msg)
 
+                # Capture sender_bot_id from the real message (annotated by rate_limit_decorator)
+                sender_bot_id = getattr(real_tg_msg, '_sender_bot_id', None)
+
                 # Update database with real message
-                self.channel.db.add_or_update_message_log(etm_msg, real_tg_msg, old_msg_id)
+                self.channel.db.add_or_update_message_log(
+                    etm_msg, real_tg_msg, old_msg_id, sender_bot_id=sender_bot_id)
                 self.logger.debug(f"Updated database with real message for delayed task {task_id}")
             else:
                 self.logger.warning(f"No pending database update found for task {task_id}")
@@ -673,10 +894,10 @@ class TelegramBotManager(LocaleMixin):
                 full_message.truncate()
             else:
                 filename += ".txt"
-            self.updater.bot.send_document(args[0], full_message, filename=filename,
-                                           reply_to_message_id=msg.message_id,
-                                           caption=self._("Message is truncated due to its length. "
-                                                          "Full message is sent as attachment."))
+            self._active_bot.send_document(args[0], full_message, filename=filename,
+                                          reply_to_message_id=msg.message_id,
+                                          caption=self._("Message is truncated due to its length. "
+                                                         "Full message is sent as attachment."))
             return msg
         else:
             kwargs['text'] = prefix + text + suffix
@@ -716,11 +937,11 @@ class TelegramBotManager(LocaleMixin):
                 filename += ".html"
             else:
                 filename += ".txt"
-            self.updater.bot.send_document(kwargs['chat_id'], full_message,
-                                           filename=filename,
-                                           reply_to_message_id=msg.message_id,
-                                           caption=self._("Message is truncated due to its length. "
-                                                          "Full message is sent as attachment."))
+            self._active_bot.send_document(kwargs['chat_id'], full_message,
+                                          filename=filename,
+                                          reply_to_message_id=msg.message_id,
+                                          caption=self._("Message is truncated due to its length. "
+                                                         "Full message is sent as attachment."))
             return msg
         else:
             kwargs['text'] = prefix + text + suffix
@@ -734,11 +955,11 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message: The message sent
         """
         try:
-            return self.updater.bot.send_message(*args, **kwargs)
+            return self._active_bot.send_message(*args, **kwargs)
         except telegram.error.BadRequest as e:
             if e.message.lower().startswith("can't parse entities") and 'parse_mode' in kwargs:
                 kwargs.pop("parse_mode")
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             else:
                 raise e
 
@@ -750,17 +971,17 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message: The message sent
         """
         try:
-            return self.updater.bot.edit_message_text(*args, **kwargs)
+            return self._active_bot.edit_message_text(*args, **kwargs)
         except telegram.error.BadRequest as e:
             if e.message == "Message can't be edited":
                 kwargs['reply_to_message_id'] = kwargs.pop('message_id')
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             elif e.message == "message to edit not found":
                 kwargs.pop('message_id')
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             elif e.message.lower().startswith("can't parse entities") and 'parse_mode' in kwargs:
                 kwargs.pop("parse_mode")
-                return self.updater.bot.edit_message_text(*args, **kwargs)
+                return self._active_bot.edit_message_text(*args, **kwargs)
             else:
                 raise e
 
@@ -786,9 +1007,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_audio(*args, **kwargs)
+            return self._active_bot.send_audio(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -812,9 +1033,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_voice(*args, **kwargs)
+            return self._active_bot.send_voice(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -838,9 +1059,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_video(*args, **kwargs)
+            return self._active_bot.send_video(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -861,7 +1082,7 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        return self.updater.bot.send_document(*args, **kwargs)
+        return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -882,7 +1103,7 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        return self.updater.bot.send_animation(*args, **kwargs)
+        return self._active_bot.send_animation(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -904,9 +1125,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_photo(*args, **kwargs)
+            return self._active_bot.send_photo(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.skip_on_rate_limit
     @Decorators.retry_on_timeout
@@ -922,42 +1143,42 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def edit_message_reply_markup(self, *args, **kwargs):
-        return self.updater.bot.edit_message_reply_markup(*args, **kwargs)
+        return self._active_bot.edit_message_reply_markup(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_location(self, *args, **kwargs):
-        return self.updater.bot.send_location(*args, **kwargs)
+        return self._active_bot.send_location(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_venue(self, *args, **kwargs):
-        return self.updater.bot.send_venue(*args, **kwargs)
+        return self._active_bot.send_venue(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_sticker(self, *args, **kwargs):
-        return self.updater.bot.send_sticker(*args, **kwargs)
+        return self._active_bot.send_sticker(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def forward_message(self, *args, **kwargs):
-        return self.updater.bot.forward_message(*args, **kwargs)
+        return self._active_bot.forward_message(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def copy_message(self, *args, **kwargs):
-        return self.updater.bot.copy_message(*args, **kwargs)
+        return self._active_bot.copy_message(*args, **kwargs)
 
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
@@ -979,12 +1200,12 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.caption_affix_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_caption(self, *args, **kwargs):
-        return self.updater.bot.edit_message_caption(*args, **kwargs)
+        return self._active_bot.edit_message_caption(*args, **kwargs)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
     def edit_message_media(self, *args, **kwargs):
-        return self.updater.bot.edit_message_media(*args, **kwargs)
+        return self._active_bot.edit_message_media(*args, **kwargs)
 
     def reply_error(self, update, errmsg):
         """
@@ -999,12 +1220,22 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
     def get_file(self, file_id: str) -> File:
-        return self.updater.bot.get_file(file_id)
+        return self._active_bot.get_file(file_id)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
-    def delete_message(self, chat_id, message_id):
-        return self.updater.bot.delete_message(chat_id, message_id)
+    def delete_message(self, chat_id, message_id, _sender_bot_id=None):
+        if _sender_bot_id and self.bot_pool:
+            aux_bot = self.bot_pool.get_bot_by_id(_sender_bot_id)
+            if aux_bot and not aux_bot.disabled:
+                try:
+                    return aux_bot.bot.delete_message(chat_id, message_id)
+                except telegram.error.Unauthorized:
+                    aux_bot.mark_disabled("Unauthorized during delete_message")
+                    self._notify_admin_disabled_bot(aux_bot)
+                except telegram.error.BadRequest:
+                    pass  # Fall through to main bot
+        return self._active_bot.delete_message(chat_id, message_id)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
@@ -1107,6 +1338,10 @@ class TelegramBotManager(LocaleMixin):
 
         # Stop the delayed message worker first
         self.stop_delayed_worker()
+
+        # Shut down auxiliary bot pool
+        if self.bot_pool:
+            self.bot_pool.shutdown()
 
         # Then stop the updater
         self.logger.debug("Stopping Telegram updater...")

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -1,23 +1,25 @@
 # coding=utf-8
+import bisect
 import collections
+import heapq
 import html
 import io
 import logging
 import os
-import time
 import threading
+import time
 from collections import defaultdict, deque
 from functools import wraps
-from typing import List, TYPE_CHECKING, Callable, NamedTuple, Deque
+from turtle import right
+from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple
 from unittest.mock import Mock
-import heapq
-import bisect
 
 import telegram.constants
 import telegram.error
 from retrying import retry
-from telegram import Update, InputFile, User, File, ForumTopic, Message as TelegramMessage
-from telegram.ext import CallbackContext, Filters, MessageHandler, Updater, Dispatcher
+from telegram import File, ForumTopic, InputFile, Update, User
+from telegram import Message as TelegramMessage
+from telegram.ext import CallbackContext, Dispatcher, Filters, MessageHandler, Updater
 
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
@@ -349,14 +351,17 @@ class TelegramBotManager(LocaleMixin):
             # --------------------------------------------------
             # Global limit – find the first slot that fits
             # --------------------------------------------------
+            scan_count = 0
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
                 idx = bisect.bisect_left(self._global_timestamps, left_bound)
-                in_window = len(self._global_timestamps) - idx
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
                     break
                 # Shift to just after the oldest entry in the current window
                 candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+                scan_count += 1
 
             sleep_time = max(0.0, candidate_time - current_time)
 
@@ -370,16 +375,11 @@ class TelegramBotManager(LocaleMixin):
         # Log rate limiting status but don't sleep
         if sleep_time > 0:
             self.logger.info(f"Rate limit reached, need to delay {sleep_time:.2f}s for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
-            if chat_count % 100 == 0:
-                self.logger.warning(f"Chat {chat_id} is heavily queued. "
-                                   f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
-            if chat_count % 1000 == 0:
-                self.logger.error(f"Chat {chat_id} is heavily queued. "
-                                   f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{idx}, Scan count: {scan_count}")
+
         else:
-            self.logger.debug(f"Rate limit not reached for chat {chat_id}. "
-                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{self.GLOBAL_LIMIT}")
+            self.logger.info(f"Rate limit not reached for chat {chat_id}. "
+                           f"Chat: {chat_count}/{self.CHAT_LIMIT}, Global: {global_count}/{idx}, Scan count: {scan_count}")
 
         return sleep_time, chat_count, global_count
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -88,7 +88,7 @@ class TelegramBotManager(LocaleMixin):
                     chat_id = kwargs['chat_id']
 
                 # if _delayed_worker_stop is set, we should not schedule new tasks
-                if self._delayed_worker_stop:
+                if self._delayed_worker_stop.is_set():
                     self.logger.warning(f"Delayed worker is stopped. Not scheduling new tasks for chat {chat_id}.")
                     return None
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -279,6 +279,7 @@ class TelegramBotManager(LocaleMixin):
         # Initialize delayed message queue system
         self._delayed_queue = []
         self._delayed_queue_lock = threading.Lock()
+        self._task_counter = 0  # Counter for tie-breaking in heapq
         self._delayed_worker_stop = threading.Event()
         self._pending_delayed_logs = {}  # Store pending database updates: task_id -> (etm_msg, old_msg_id)
         self._pending_logs_lock = threading.Lock()
@@ -418,7 +419,8 @@ class TelegramBotManager(LocaleMixin):
         )
 
         with self._delayed_queue_lock:
-            heapq.heappush(self._delayed_queue, (execute_time, task))
+            heapq.heappush(self._delayed_queue, (execute_time, self._task_counter, task))
+            self._task_counter += 1
 
         self.logger.debug(f"Scheduled delayed task {task_id} for chat {chat_id} in {delay_time:.2f}s")
         return task_id
@@ -437,7 +439,7 @@ class TelegramBotManager(LocaleMixin):
                 # Check for tasks ready to execute
                 with self._delayed_queue_lock:
                     while self._delayed_queue and self._delayed_queue[0][0] <= current_time:
-                        execute_time, task = heapq.heappop(self._delayed_queue)
+                        _, _, task = heapq.heappop(self._delayed_queue)
                         tasks_to_execute.append(task)
 
                 # Execute ready tasks outside of lock

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -1098,10 +1098,17 @@ class TelegramBotManager(LocaleMixin):
         if isinstance(file, str):
             empty = os.stat(file).st_size == 0
         elif hasattr(file, "seekable"):
-            if file.seekable():
-                file.seek(0, 2)
-                empty = file.tell() == 0
-                file.seek(0, 0)
+            try:
+                if hasattr(file, 'closed') and file.closed:
+                    empty = True
+                elif file.seekable():
+                    file.seek(0, 2)
+                    empty = file.tell() == 0
+                    file.seek(0, 0)
+                else:
+                    empty = True
+            except (ValueError, OSError):
+                empty = True
         elif isinstance(file, InputFile):
             empty = not bool(len(file.input_file_content))
         if empty:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -10,7 +10,6 @@ import threading
 import time
 from collections import defaultdict, deque
 from functools import wraps
-from turtle import right
 from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple
 from unittest.mock import Mock
 
@@ -355,7 +354,7 @@ class TelegramBotManager(LocaleMixin):
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
                 idx = bisect.bisect_left(self._global_timestamps, left_bound)
-                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                right_idx = bisect.bisect_right(self._global_timestamps, self._global_timestamps[idx] + self.GLOBAL_WINDOW)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
                     break

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -334,12 +334,14 @@ class TelegramBotManager(LocaleMixin):
 
             # global rate limit
             if len(self._global_timestamps) >= self.GLOBAL_LIMIT - 2:
-                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - self._global_timestamps[0]) + 1)
+                latestglobal_time = max(self._global_timestamps)
+                sleep_time = max(sleep_time, self.GLOBAL_WINDOW - (current_time - latestglobal_time) + 1)
 
             # chat-specific rate limit
             chat_timestamps = self._chat_timestamps[chat_id]
             if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
-                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - chat_timestamps[0]) + 1)
+                latest_chat_time = max(chat_timestamps)
+                sleep_time = max(sleep_time, self.CHAT_WINDOW - (current_time - latest_chat_time) + 1)
             # Record the actual time this request will be processed
             actual_time = current_time + sleep_time
             self._global_timestamps.append(actual_time)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -9,16 +9,18 @@ import threading
 from collections import defaultdict, deque
 from functools import wraps
 from typing import List, TYPE_CHECKING, Callable, NamedTuple
+from unittest.mock import Mock
 import heapq
 
 import telegram.constants
 import telegram.error
 from retrying import retry
-from telegram import Update, InputFile, User, File, ForumTopic
+from telegram import Update, InputFile, User, File, ForumTopic, Message as TelegramMessage
 from telegram.ext import CallbackContext, Filters, MessageHandler, Updater, Dispatcher
 
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
+from .msg_type import get_msg_type
 
 
 class DelayedTask(NamedTuple):
@@ -373,9 +375,6 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             A mock message object indicating delayed execution
         """
-        # Import here to avoid circular imports
-        from telegram import Message as TelegramMessage
-        from unittest.mock import Mock
 
         # Create a mock message object that represents a delayed message
         mock_msg = Mock(spec=TelegramMessage)
@@ -491,17 +490,12 @@ class TelegramBotManager(LocaleMixin):
                 etm_msg, old_msg_id = self._pending_delayed_logs.pop(task_id)
 
                 # Update the ETM message with real Telegram data
-                from .msg_type import get_msg_type
                 etm_msg.type_telegram = get_msg_type(real_tg_msg)
                 etm_msg.put_telegram_file(real_tg_msg)
 
                 # Update database with real message
-                from . import TelegramChannel
-                if hasattr(self, 'channel') and isinstance(self.channel, TelegramChannel):
-                    self.channel.db.add_or_update_message_log(etm_msg, real_tg_msg, old_msg_id)
-                    self.logger.debug(f"Updated database with real message for delayed task {task_id}")
-                else:
-                    self.logger.warning(f"Cannot update database - channel not available for task {task_id}")
+                self.channel.db.add_or_update_message_log(etm_msg, real_tg_msg, old_msg_id)
+                self.logger.debug(f"Updated database with real message for delayed task {task_id}")
             else:
                 self.logger.warning(f"No pending database update found for task {task_id}")
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -472,8 +472,8 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             Task ID for tracking
         """
-        execute_time = time.time() + delay_time
-        task_id = f"{chat_id}_{execute_time:.9f}_{id(function)}"
+        execute_time = time.time_ns() + delay_time * 1_000_000_000
+        task_id = f"{chat_id}_{execute_time}_{id(function)}"
 
         task = DelayedTask(
             execute_time=execute_time,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -473,7 +473,7 @@ class TelegramBotManager(LocaleMixin):
             Task ID for tracking
         """
         execute_time = time.time() + delay_time
-        task_id = f"{chat_id}_{time.time_ns() + delay_time * 1_000_000_000}_{id(function)}"
+        task_id = f"{chat_id}_{str(time.time_ns() + delay_time * 1_000_000_000)}_{id(function)}"
 
         task = DelayedTask(
             execute_time=execute_time,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -116,7 +116,7 @@ class TelegramBotManager(LocaleMixin):
             @wraps(fn)
             def rate_limit_error_handler(self: 'TelegramBotManager', *args, **kwargs):
                 max_retries = 3
-                base_delay = 30.0
+                base_delay = 60
 
                 for attempt in range(max_retries + 1):
                     try:
@@ -130,7 +130,7 @@ class TelegramBotManager(LocaleMixin):
                         cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries}")
                         time.sleep(retry_after)
                     except telegram.error.TelegramError as e:
-                        if "Too Many Requests" in str(e) or "429" in str(e):
+                        if "Too Many Requests" in str(e) or "429" in str(e) or "Flood" in str(e):
                             if attempt >= max_retries:
                                 cls.logger.error(f"Max retries exceeded for rate limit error: {e}")
                                 raise

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -875,7 +875,6 @@ class TelegramBotManager(LocaleMixin):
         args = args[:1]
         if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
             full_message = io.BytesIO((prefix + text + suffix).encode('utf-8'))
-            full_message.seek(0)
             truncated = prefix + text[:100] + "\n...\n" + text[-100:] + suffix
             msg = self._bot_send_message_fallback(args[0], text=truncated, **kwargs)
             filename = "%s_%s" % (args[0], msg.message_id)
@@ -889,9 +888,9 @@ class TelegramBotManager(LocaleMixin):
                     "<html><head><meta charset='utf-8'></head>"
                     "<body><pre style='white-space:pre-wrap'>" + (prefix + text + suffix) + "</pre></body></html>"
                 )
-                full_message.write(full_message_html.encode('utf-8'))
-                full_message.seek(0)
-                full_message.truncate()
+                # Replace the attachment payload with HTML-wrapped content.
+                # (Previous logic did seek(0) then truncate(), which empties the buffer.)
+                full_message = io.BytesIO(full_message_html.encode('utf-8'))
             else:
                 filename += ".txt"
             self._active_bot.send_document(args[0], full_message, filename=filename,

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -1,0 +1,237 @@
+# coding=utf-8
+
+import logging
+import threading
+import time
+from typing import Optional, List, Dict, Tuple, TYPE_CHECKING
+
+from .auxiliary_bot import AuxiliaryBot
+
+if TYPE_CHECKING:
+    from .bot_manager import TelegramBotManager
+
+logger = logging.getLogger(__name__)
+
+
+class BotPool:
+    """Manages auxiliary bot instances and routes sends to the best available bot.
+
+    Key responsibilities:
+    - Atomic slot acquisition across all bots
+    - O(1) bot lookup by Telegram user ID
+    - Throttled user notifications when aux bots need to be added to groups
+    - Background membership probes
+    """
+
+    def __init__(self, aux_bots: List[AuxiliaryBot], bot_manager: 'TelegramBotManager'):
+        self._bots: List[AuxiliaryBot] = aux_bots
+        self._bot_by_id: Dict[int, AuxiliaryBot] = {b.bot_id: b for b in aux_bots}
+        self._bot_manager = bot_manager
+        self._pool_lock = threading.Lock()
+
+        # One notification per chat per process lifetime
+        self._notified_chats: set = set()
+        self._notification_lock = threading.Lock()
+
+        logger.info("BotPool initialized with %d auxiliary bot(s): %s",
+                     len(aux_bots), [f"@{b.username}" for b in aux_bots])
+
+    @property
+    def bots(self) -> List[AuxiliaryBot]:
+        return self._bots
+
+    def get_bot_by_id(self, bot_id) -> Optional[AuxiliaryBot]:
+        """O(1) lookup by Telegram user ID. Returns None if not found."""
+        try:
+            return self._bot_by_id.get(int(bot_id))
+        except (TypeError, ValueError):
+            return None
+
+    def acquire_send_slot(self, chat_id: int, max_delay: float = float('inf')
+                          ) -> Optional[Tuple[AuxiliaryBot, float]]:
+        """Atomically find the best available auxiliary bot for a chat.
+
+        Iterates aux bots confirmed as members of the chat, picks the one
+        with the lowest delay, then reserves a slot.
+
+        For bots whose membership is unknown (first encounter / cold start),
+        a synchronous probe is performed so they can participate immediately.
+
+        Args:
+            chat_id: Target Telegram chat.
+            max_delay: Upper bound on acceptable delay. Bots whose delay
+                       >= max_delay are skipped. Pass the main bot's delay
+                       so aux bots are only chosen when they're actually faster.
+
+        Returns:
+            (AuxiliaryBot, delay) if a suitable aux bot was found,
+            None if no aux bot beats max_delay or none are members.
+        """
+        with self._pool_lock:
+            best_bot: Optional[AuxiliaryBot] = None
+            best_delay = float('inf')
+            confirmed_non_member_bots: List[AuxiliaryBot] = []
+            unknown_bots: List[AuxiliaryBot] = []
+
+            for aux_bot in self._bots:
+                if aux_bot.disabled:
+                    continue
+
+                status = aux_bot.check_membership_tri(chat_id)
+                if status is None:
+                    unknown_bots.append(aux_bot)
+                    continue
+                if status is False:
+                    confirmed_non_member_bots.append(aux_bot)
+                    continue
+
+                delay = aux_bot.peek_delay(chat_id)
+                if delay < best_delay:
+                    best_bot = aux_bot
+                    best_delay = delay
+                    if delay == 0.0:
+                        break
+
+            # Cold start: synchronously resolve unknown bots so they can help now
+            if best_bot is None and unknown_bots:
+                for aux_bot in unknown_bots:
+                    if aux_bot.check_membership_sync(chat_id, timeout=3.0):
+                        delay = aux_bot.peek_delay(chat_id)
+                        if delay < best_delay:
+                            best_bot = aux_bot
+                            best_delay = delay
+                            if delay == 0.0:
+                                break
+                    else:
+                        confirmed_non_member_bots.append(aux_bot)
+
+            if best_bot is not None and best_delay < max_delay:
+                best_bot.reserve_slot(chat_id)
+                return (best_bot, best_delay)
+
+            if confirmed_non_member_bots:
+                self._maybe_notify_admin(chat_id, confirmed_non_member_bots)
+
+            return None
+
+    def send_blocking(self, chat_id: int, timeout: float = 60.0) -> Optional[AuxiliaryBot]:
+        """Block until any bot in the pool has a free slot for the given chat.
+        Used by history migration for higher throughput.
+
+        Returns the AuxiliaryBot to use, or None on timeout.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._pool_lock:
+                for aux_bot in self._bots:
+                    if aux_bot.disabled:
+                        continue
+                    if not aux_bot.check_membership(chat_id):
+                        continue
+                    delay = aux_bot.peek_delay(chat_id)
+                    if delay == 0.0:
+                        aux_bot.reserve_slot(chat_id)
+                        return aux_bot
+            time.sleep(0.2)
+        return None
+
+    def on_bots_joined_chat(self, bot_ids: list, chat_id: int):
+        """Update membership cache when aux bots are added to a group."""
+        for bot_id in bot_ids:
+            aux_bot = self.get_bot_by_id(bot_id)
+            if aux_bot:
+                aux_bot.update_membership(chat_id, True)
+                logger.info("Auxiliary bot @%s added to chat %d, membership cache updated",
+                            aux_bot.username, chat_id)
+
+    def on_bot_left_chat(self, bot_id: int, chat_id: int):
+        """Update membership cache when an aux bot is removed from a group."""
+        aux_bot = self.get_bot_by_id(bot_id)
+        if aux_bot:
+            aux_bot.update_membership(chat_id, False)
+            logger.info("Auxiliary bot @%s removed from chat %d, membership cache updated",
+                        aux_bot.username, chat_id)
+
+    def _maybe_notify_admin(self, chat_id: int, bots_not_in_chat: List[AuxiliaryBot]):
+        """Send at most one notification per chat per process lifetime."""
+        with self._notification_lock:
+            if chat_id in self._notified_chats:
+                return
+            self._notified_chats.add(chat_id)
+
+        thread = threading.Thread(
+            target=self._send_admin_notification,
+            args=(chat_id, bots_not_in_chat),
+            daemon=True,
+            name=f"BotPoolNotify-{chat_id}"
+        )
+        thread.start()
+
+    def _send_admin_notification(self, chat_id: int, bots: List[AuxiliaryBot]):
+        """Send a message to the first admin about adding aux bots to a group."""
+        try:
+            admin_id = self._bot_manager.admins[0]
+            bot_links = ", ".join(
+                f'<code>@{b.username}</code>'
+                for b in bots if b.username
+            )
+            if not bot_links:
+                return
+
+            str_id = str(chat_id)
+            if str_id.startswith("-100"):
+                chat_url = f"https://t.me/c/{str_id[4:]}"
+            else:
+                chat_url = f"tg://openmessage?chat_id={chat_id}"
+
+            text = (
+                f'📊 Message rate is high in <a href="{chat_url}">chat {chat_id}</a>. '
+                f"To reduce delay, please add {bot_links} to the group."
+            )
+
+            self._bot_manager.updater.bot.send_message(
+                admin_id, text, parse_mode="HTML"
+            )
+        except Exception as e:
+            logger.warning("Failed to send auxiliary bot notification to admin: %s", e)
+
+    def get_pool_stats(self) -> Dict:
+        """Return per-bot status for monitoring/debugging."""
+        stats = {
+            'total_bots': len(self._bots),
+            'active_bots': sum(1 for b in self._bots if not b.disabled),
+            'bots': []
+        }
+        for bot in self._bots:
+            bot_stats = {
+                'username': bot.username,
+                'bot_id': bot.bot_id,
+                'disabled': bot.disabled,
+                'membership_cache_size': len(bot._membership_cache),
+            }
+            stats['bots'].append(bot_stats)
+        return stats
+
+    def shutdown(self):
+        """Clean up resources during shutdown.
+        Waits for pending membership probes to finish (with timeout)."""
+        logger.info("BotPool shutting down, %d auxiliary bot(s)", len(self._bots))
+
+        deadline = time.time() + 5.0
+        for aux_bot in self._bots:
+            while time.time() < deadline:
+                if not aux_bot.has_pending_probes():
+                    break
+                time.sleep(0.1)
+            else:
+                if aux_bot.has_pending_probes():
+                    logger.warning("Bot @%s still has pending membership probes at shutdown",
+                                   aux_bot.username)
+
+        logger.info("BotPool shutdown complete")
+
+    def __bool__(self):
+        return len(self._bots) > 0
+
+    def __len__(self):
+        return len(self._bots)

--- a/efb_telegram_master/chat.py
+++ b/efb_telegram_master/chat.py
@@ -425,6 +425,8 @@ def copy_member(source: ChatMember, dest: ETMChatMember):
 
 
 def unpickle(data: bytes, db: 'DatabaseManager') -> ETMChatType:
+    if isinstance(data, memoryview):
+        data = bytes(data)
     obj = pickle.loads(data)
     obj.db = db
     return obj

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -601,14 +601,14 @@ class ChatBindingManager(LocaleMixin):
             if not thread_id:
                 msg.reply_text(
                     self._(
-                    "Failed to create topic for {name} in the group.\n"
-                    "Please make sure the bot has the right.\n"
-                    "You can send /init_topics to create again."
+                        "Failed to create topic for {name} in the group.\n"
+                        "Please make sure the bot has the right.\n"
+                        "You can send /init_topics to create again."
                     ).format(name=chat_display_name),
                     reply_to_message_id=msg.message_id)
             else:
                 try:
-                    self._update_single_topic_info(tg_chat_to_link, thread_id, chat_uid)
+                    self._update_single_topic_info(TelegramChatID(tg_chat_to_link.id), thread_id, chat_uid)
                 except Exception as e:
                     self.logger.warning("Auto update group info failed for %s: %s", chat_display_name, e)
 

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -622,7 +622,7 @@ class ChatBindingManager(LocaleMixin):
 
         # migrate history
         if is_relink:
-            self.send_history_link(chat_uid, tg_chat_to_link.id, thread_id)
+            self.send_history_link(chat_uid, tg_chat_to_link.id, int(msg.message_id), thread_id)
         else:
             try:
                 self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)
@@ -642,39 +642,39 @@ class ChatBindingManager(LocaleMixin):
                     pass  # Ignore if we can't send the notice
 
     def send_history_link(self, slave_chat_id: EFBChannelChatIDStr,
-                           tg_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
+                           tg_chat_id: int, original_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
         """Send a message with a link to the chat history."""
         try:
-            # We only need one message to get the original chat_id
-            recent_messages = self.db.get_recent_messages(slave_chat_id, limit=1)
+            recent_messages = self.db.get_recent_messages(slave_chat_id, limit=5)
             if not recent_messages:
                 return
 
-            msg_log = recent_messages[0]
-            original_chat_id, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
+            msg_log = None
+            for message in recent_messages:
+                if message and message.master_msg_id and not message.text.startswith('/'):
+                    msg_log = message
+                    break
+
+            if not msg_log:
+                return
+
+            _, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
 
             original_chat_id_int = int(original_chat_id)
 
-            try:
-
-                if str(original_chat_id_int).startswith("-100"):
-                    # Supergroup: remove '-100' prefix and use /c/{short_id}/{msg_id}
-                    short_id = str(original_chat_id_int)[4:]
-                    link = f"https://t.me/c/{short_id}/{original_msg_id}"
-                elif str(original_chat_id_int).startswith("-"):
-                    # Regular group: use group link format
-                    link = f"https://t.me/{abs(original_chat_id_int)}/{original_msg_id}"
-                else:
-                    # Channel or user: fallback to /c/{id}/{msg_id}
-                    link = f"https://t.me/c/{original_chat_id_int}/{original_msg_id}"
-            except Exception:
-                link = None
-
-            if link:
-                text = self._("This chat was previously linked. History messages are not migrated. "
-                              "You can view previous messages here: {link}").format(link=link)
+            if str(original_chat_id_int).startswith("-100"):
+                # Supergroup: remove '-100' prefix and use /c/{short_id}/{msg_id}
+                short_id = str(original_chat_id_int)[4:]
+                link = f"https://t.me/c/{short_id}/{original_msg_id}"
+            elif str(original_chat_id_int).startswith("-"):
+                # Regular group: use group link format
+                link = f"https://t.me/{abs(original_chat_id_int)}/{original_msg_id}"
             else:
-                text = self._("This chat was previously linked. History messages are not migrated.")
+                # Channel or user: fallback to /c/{id}/{msg_id}
+                link = f"https://t.me/c/{original_chat_id_int}/{original_msg_id}"
+
+            text = self._("This chat was previously linked. History messages are not migrated. "
+                            "You can view previous messages here: {link}").format(link=link)
 
             kwargs = {
                 'chat_id': tg_chat_id,

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -622,7 +622,7 @@ class ChatBindingManager(LocaleMixin):
 
         # migrate history
         if is_relink:
-            self.send_history_link(chat_uid, tg_chat_to_link.id, int(msg.message_id), thread_id)
+            self.send_history_link(chat_uid, tg_chat_to_link.id, int(msg.chat.id), thread_id)
         else:
             try:
                 self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -567,6 +567,7 @@ class ChatBindingManager(LocaleMixin):
         except KeyError:
             return update.message.reply_text(self._("Session expired or unknown parameter. (SE02)"))
         chat: ETMChatType = data.chats[0]
+        is_relink = chat.linked
         chat_display_name = chat.full_name
         slave_channel, slave_chat_uid = chat.module_id, chat.uid
         chat_uid = utils.chat_id_to_str(slave_channel, slave_chat_uid)
@@ -620,22 +621,72 @@ class ChatBindingManager(LocaleMixin):
         self.msg_storage.pop(storage_key, None)
 
         # migrate history
-        try:
-            self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)
-        except Exception as e:
-            self.logger.warning("History migration failed for %s: %s", chat_display_name, e)
-            # Send a notice to user about failed migration
+        if is_relink:
+            self.send_history_link(chat_uid, tg_chat_to_link.id, thread_id)
+        else:
             try:
-                notice_kwargs = {
-                    'chat_id': tg_chat_to_link.id,
-                    'text': self._("⚠️ 历史消息迁移失败，但聊天绑定成功"),
-                    'disable_notification': True
-                }
-                if thread_id:
-                    notice_kwargs['message_thread_id'] = thread_id
-                self.bot.send_message(**notice_kwargs)
+                self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)
+            except Exception as e:
+                self.logger.warning("History migration failed for %s: %s", chat_display_name, e)
+                # Send a notice to user about failed migration
+                try:
+                    notice_kwargs = {
+                        'chat_id': tg_chat_to_link.id,
+                        'text': self._("⚠️ 历史消息迁移失败，但聊天绑定成功"),
+                        'disable_notification': True
+                    }
+                    if thread_id:
+                        notice_kwargs['message_thread_id'] = thread_id
+                    self.bot.send_message(**notice_kwargs)
+                except Exception:
+                    pass  # Ignore if we can't send the notice
+
+    def send_history_link(self, slave_chat_id: EFBChannelChatIDStr,
+                           tg_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
+        """Send a message with a link to the chat history."""
+        try:
+            # We only need one message to get the original chat_id
+            recent_messages = self.db.get_recent_messages(slave_chat_id, limit=1)
+            if not recent_messages:
+                return
+
+            msg_log = recent_messages[0]
+            original_chat_id, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
+
+            original_chat_id_int = int(original_chat_id)
+
+            try:
+
+                if str(original_chat_id_int).startswith("-100"):
+                    # Supergroup: remove '-100' prefix and use /c/{short_id}/{msg_id}
+                    short_id = str(original_chat_id_int)[4:]
+                    link = f"https://t.me/c/{short_id}/{original_msg_id}"
+                elif str(original_chat_id_int).startswith("-"):
+                    # Regular group: use group link format
+                    link = f"https://t.me/{abs(original_chat_id_int)}/{original_msg_id}"
+                else:
+                    # Channel or user: fallback to /c/{id}/{msg_id}
+                    link = f"https://t.me/c/{original_chat_id_int}/{original_msg_id}"
             except Exception:
-                pass  # Ignore if we can't send the notice
+                link = None
+
+            if link:
+                text = self._("This chat was previously linked. History messages are not migrated. "
+                              "You can view previous messages here: {link}").format(link=link)
+            else:
+                text = self._("This chat was previously linked. History messages are not migrated.")
+
+            kwargs = {
+                'chat_id': tg_chat_id,
+                'text': text,
+                'disable_notification': True
+            }
+            if thread_id:
+                kwargs['message_thread_id'] = thread_id
+            self.bot.send_message(**kwargs)
+
+        except Exception as e:
+            self.logger.warning("Failed to send history link for %s: %s", slave_chat_id, e)
 
     def unlink_all(self, update: Update, context: CallbackContext):
         """
@@ -1020,9 +1071,9 @@ class ChatBindingManager(LocaleMixin):
     def _get_chat_info_and_picture(self, chat: ETMChatType, channel: Channel) -> Tuple[Optional[str], Optional[IO], Optional[IO]]:
         """
         Get chat description and picture with proper processing.
-        
+
         Returns:
-            Tuple[Optional[str], Optional[IO], Optional[IO]]: 
+            Tuple[Optional[str], Optional[IO], Optional[IO]]:
             (description, original_picture, resized_picture)
         """
         picture: Optional[IO] = None
@@ -1067,7 +1118,7 @@ class ChatBindingManager(LocaleMixin):
         """
         Update forum group info for multiple linked chats.
         Send a message with avatar and description in each topic and pin it.
-        
+
         Returns:
             Tuple[bool, str, int]: (success, message, updated_count)
         """
@@ -1094,7 +1145,7 @@ class ChatBindingManager(LocaleMixin):
                     updated_count += 1
             except Exception as e:
                 self.logger.warning(f"Failed to update topic {thread_id}: {e}")
-            
+
             time.sleep(30) # seems pinning message has a special rate limit but I didn't find the official documentation
 
         if updated_count > 0:
@@ -1294,12 +1345,12 @@ class ChatBindingManager(LocaleMixin):
     def migrate_chat_history(self, slave_chat_id: EFBChannelChatIDStr,
                            tg_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
         """Migrate historical messages to the newly linked chat.
-        
+
         This method now runs in a background thread to avoid blocking the bot.
-        
+
         Args:
             slave_chat_id: The slave chat identifier
-            tg_chat_id: The Telegram chat ID to migrate messages to  
+            tg_chat_id: The Telegram chat ID to migrate messages to
             thread_id: Optional thread ID for forum groups
         """
         # Run migration in background thread to avoid blocking the bot
@@ -1314,10 +1365,10 @@ class ChatBindingManager(LocaleMixin):
     def _migrate_chat_history_background(self, slave_chat_id: EFBChannelChatIDStr,
                                        tg_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
         """Background method that performs the actual migration work.
-        
+
         Args:
             slave_chat_id: The slave chat identifier
-            tg_chat_id: The Telegram chat ID to migrate messages to  
+            tg_chat_id: The Telegram chat ID to migrate messages to
             thread_id: Optional thread ID for forum groups
         """
         try:
@@ -1335,7 +1386,7 @@ class ChatBindingManager(LocaleMixin):
             for i, msg_log in enumerate(recent_messages):
                 # Check if message text is empty or doesn't exist
                 message_text = msg_log.text or ""
-                
+
                 # If text is empty or this is a media message, handle accordingly
                 if not message_text.strip() or (msg_log.media_type and msg_log.media_type != 'Text'):
                     # Send current text batch if it exists
@@ -1347,7 +1398,7 @@ class ChatBindingManager(LocaleMixin):
                             threading.Event().wait(4.0)
                         except Exception as e:
                             self.logger.warning("Failed to send text batch: %s", e)
-                    
+
                     # Forward the media message or empty text message
                     try:
                         self._forward_media_message(msg_log, tg_chat_id, thread_id)
@@ -1370,7 +1421,7 @@ class ChatBindingManager(LocaleMixin):
                     # Format message with author and timestamp
                     formatted_msg = f"*{author_name}* `{timestamp}`\n{message_text}\n\n"
                     expected_msg_length = len(formatted_msg)
-                    
+
                     # Check if adding this message would exceed the limit
                     if current_length + expected_msg_length > 4096 - 20:
                         # Send current batch if it exists
@@ -1381,7 +1432,7 @@ class ChatBindingManager(LocaleMixin):
                                 threading.Event().wait(4.0)
                             except Exception as e:
                                 self.logger.warning("Failed to send text batch: %s", e)
-                        
+
                         # Start new batch with current message
                         current_text_batch = [formatted_msg]
                         current_length = len(formatted_msg)
@@ -1403,10 +1454,10 @@ class ChatBindingManager(LocaleMixin):
     def _send_text_batch_background(self, text_batch: List[str], tg_chat_id: int,
                                    thread_id: Optional[TelegramTopicID] = None):
         """Send a batch of formatted text messages.
-        
+
         Args:
             text_batch: List of formatted text strings ready to send
-            tg_chat_id: The Telegram chat ID to send messages to  
+            tg_chat_id: The Telegram chat ID to send messages to
             thread_id: Optional thread ID for forum groups
         """
         if not text_batch:

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -622,7 +622,7 @@ class ChatBindingManager(LocaleMixin):
 
         # migrate history
         if is_relink:
-            self.send_history_link(chat_uid, tg_chat_to_link.id, int(storage_key[0]), int(storage_key[1]), thread_id)
+            self.send_history_link(chat_uid, tg_chat_to_link.id, storage_key, thread_id)
         else:
             try:
                 self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)
@@ -642,10 +642,11 @@ class ChatBindingManager(LocaleMixin):
                     pass  # Ignore if we can't send the notice
 
     def send_history_link(self, slave_chat_id: EFBChannelChatIDStr,
-                           tg_chat_id: int, original_chat_id: int, original_msg_id: int, thread_id: Optional[TelegramTopicID] = None):
+                           tg_chat_id: int, storage_key: Tuple[int, int], thread_id: Optional[TelegramTopicID] = None):
         """Send a message with a link to the chat history."""
         try:
-            original_chat_id_int = int(original_chat_id)
+            original_chat_id_int = int(storage_key[0])
+            original_msg_id = int(storage_key[1])
 
             if str(original_chat_id_int).startswith("-100"):
                 # Supergroup: remove '-100' prefix and use /c/{short_id}/{msg_id}

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -622,7 +622,7 @@ class ChatBindingManager(LocaleMixin):
 
         # migrate history
         if is_relink:
-            self.send_history_link(chat_uid, tg_chat_to_link.id, int(msg.chat.id), thread_id)
+            self.send_history_link(chat_uid, tg_chat_to_link.id, int(storage_key[0]), thread_id)
         else:
             try:
                 self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -622,7 +622,7 @@ class ChatBindingManager(LocaleMixin):
 
         # migrate history
         if is_relink:
-            self.send_history_link(chat_uid, tg_chat_to_link.id, int(storage_key[0]), thread_id)
+            self.send_history_link(chat_uid, tg_chat_to_link.id, int(storage_key[0]), int(storage_key[1]), thread_id)
         else:
             try:
                 self.migrate_chat_history(chat_uid, tg_chat_to_link.id, thread_id)
@@ -642,24 +642,9 @@ class ChatBindingManager(LocaleMixin):
                     pass  # Ignore if we can't send the notice
 
     def send_history_link(self, slave_chat_id: EFBChannelChatIDStr,
-                           tg_chat_id: int, original_chat_id: int, thread_id: Optional[TelegramTopicID] = None):
+                           tg_chat_id: int, original_chat_id: int, original_msg_id: int, thread_id: Optional[TelegramTopicID] = None):
         """Send a message with a link to the chat history."""
         try:
-            recent_messages = self.db.get_recent_messages(slave_chat_id, limit=5)
-            if not recent_messages:
-                return
-
-            msg_log = None
-            for message in recent_messages:
-                if message and message.master_msg_id and not message.text.startswith('/'):
-                    msg_log = message
-                    break
-
-            if not msg_log:
-                return
-
-            _, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
-
             original_chat_id_int = int(original_chat_id)
 
             if str(original_chat_id_int).startswith("-100"):

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -157,6 +157,8 @@ class ChatBindingManager(LocaleMixin):
         self.bot.dispatcher.add_handler(
             MessageHandler(Filters.status_update.migrate, self.chat_migration))
         self.bot.dispatcher.add_handler(
+            MessageHandler(Filters.status_update.new_chat_members, self.chat_joined))
+        self.bot.dispatcher.add_handler(
             MessageHandler(Filters.status_update.left_chat_member, self.chat_left))
 
     def pre_link_check(self, message: Message):
@@ -1205,6 +1207,18 @@ class ChatBindingManager(LocaleMixin):
             if pic_resized and getattr(pic_resized, 'close', None):
                 pic_resized.close()
 
+    def chat_joined(self, update: Update, context: CallbackContext):
+        """Triggered when new members join a chat. Updates aux bot membership cache."""
+        assert isinstance(update, Update)
+        assert update.effective_message
+
+        message = update.effective_message
+        if not message.new_chat_members or not self.bot.bot_pool:
+            return
+
+        joined_ids = [m.id for m in message.new_chat_members]
+        self.bot.bot_pool.on_bots_joined_chat(joined_ids, message.chat.id)
+
     def chat_left(self, update: Update, context: CallbackContext):
         """Triggered by any message update with either
         ``left_chat_member``.
@@ -1213,9 +1227,20 @@ class ChatBindingManager(LocaleMixin):
         assert update.effective_message
 
         message = update.effective_message
-        if message.left_chat_member is not None and message.left_chat_member.id == self.bot.me.id:
+        if message.left_chat_member is None:
+            return
+
+        left_member_id = message.left_chat_member.id
+
+        # Check if main bot was removed
+        if left_member_id == self.bot.me.id:
             chat_id = ChatID(str(message.chat.id))
             self.db.remove_chat_assoc(master_uid=utils.chat_id_to_str(self.channel.channel_id, chat_id))
+            return
+
+        # Check if an auxiliary bot was removed
+        if self.bot.bot_pool:
+            self.bot.bot_pool.on_bot_left_chat(left_member_id, message.chat.id)
 
     def update_thread_info(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
@@ -1378,19 +1403,15 @@ class ChatBindingManager(LocaleMixin):
                     # Send current text batch if it exists
                     if current_text_batch:
                         try:
-                            self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
+                            self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                             current_text_batch = []
                             current_length = 0
-                            threading.Event().wait(4.0)
                         except Exception as e:
                             self.logger.warning("Failed to send text batch: %s", e)
 
                     # Forward the media message or empty text message
                     try:
-                        self._forward_media_message(msg_log, tg_chat_id, thread_id)
-                        # Add delay after forwarding media
-                        if i < len(recent_messages) - 1:
-                            threading.Event().wait(4.0)
+                        self._migration_forward_media(msg_log, tg_chat_id, thread_id)
                     except Exception as e:
                         self.logger.warning("Failed to forward message %s: %s", msg_log.master_msg_id, e)
                 else:
@@ -1413,9 +1434,7 @@ class ChatBindingManager(LocaleMixin):
                         # Send current batch if it exists
                         if current_text_batch:
                             try:
-                                self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
-                                # Add delay after sending text batch
-                                threading.Event().wait(4.0)
+                                self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                             except Exception as e:
                                 self.logger.warning("Failed to send text batch: %s", e)
 
@@ -1430,15 +1449,15 @@ class ChatBindingManager(LocaleMixin):
             # Send remaining text batch if exists
             if current_text_batch:
                 try:
-                    self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
+                    self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                 except Exception as e:
                     self.logger.warning("Failed to send final text batch: %s", e)
 
         except Exception as e:
             self.logger.error("Error during history migration for %s: %s", slave_chat_id, e)
 
-    def _send_text_batch_background(self, text_batch: List[str], tg_chat_id: int,
-                                   thread_id: Optional[TelegramTopicID] = None):
+    def _migration_send_text(self, tg_chat_id: int, text_batch: List[str],
+                             thread_id: Optional[TelegramTopicID] = None):
         """Send a batch of formatted text messages.
 
         Args:
@@ -1450,47 +1469,56 @@ class ChatBindingManager(LocaleMixin):
             return
 
         combined_text = "".join(text_batch)
-
-        kwargs = {
+        kwargs: dict = {
             'chat_id': tg_chat_id,
             'text': combined_text,
             'parse_mode': 'Markdown',
             'disable_notification': True
         }
-
         if thread_id:
             kwargs['message_thread_id'] = thread_id
 
-        try:
-            self.bot.send_message(**kwargs)
-        except Exception as e:
-            self.logger.warning("Failed to send with Markdown, trying plain text: %s", e)
-            kwargs['parse_mode'] = None
-            kwargs['text'] = combined_text.replace('*', '').replace('`', '')
-            self.bot.send_message(**kwargs)
+        def _do_send(**extra):
+            kw = {**kwargs, **extra}
+            try:
+                self.bot.send_message(**kw)
+            except Exception:
+                kw['parse_mode'] = None
+                kw['text'] = combined_text.replace('*', '').replace('`', '')
+                self.bot.send_message(**kw)
 
-    def _forward_media_message(self, msg_log: MsgLog, tg_chat_id: int,
-                             thread_id: Optional[TelegramTopicID] = None):
-        """Forward(Actually copy for better user experience) a media message to the target chat."""
-        # Parse the original message ID
+        if self.bot.bot_pool:
+            self.bot.send_blocking_migration(tg_chat_id, _do_send, timeout=30.0)
+        else:
+            _do_send(_bypass_rate_limit=False)
+
+    def _migration_forward_media(self, msg_log, tg_chat_id: int,
+                                  thread_id: Optional[TelegramTopicID] = None):
+        """Wait for a slot, then forward a media message through the best available bot."""
         try:
+            # Parse the original message ID
             original_chat_id, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
-
-            # Use copy_message to copy the media
-            kwargs = {
-                'chat_id': tg_chat_id,
-                'from_chat_id': original_chat_id,
-                'message_id': original_msg_id,
-                'disable_notification': True
-            }
-
-            if thread_id:
-                kwargs['message_thread_id'] = thread_id
-
-            self.bot.copy_message(**kwargs)
-
         except Exception as e:
-            self.logger.warning("Failed to forward media message %s: %s", msg_log.master_msg_id, e)
+            self.logger.warning("Failed to parse message ID %s: %s", msg_log.master_msg_id, e)
+            return
+
+        # Use copy_message to copy the media
+        kwargs: dict = {
+            'chat_id': tg_chat_id,
+            'from_chat_id': original_chat_id,
+            'message_id': original_msg_id,
+            'disable_notification': True
+        }
+        if thread_id:
+            kwargs['message_thread_id'] = thread_id
+
+        def _do_copy(**extra):
+            self.bot.copy_message(**{**kwargs, **extra})
+
+        if self.bot.bot_pool:
+            self.bot.send_blocking_migration(tg_chat_id, _do_copy, timeout=30.0)
+        else:
+            _do_copy(_bypass_rate_limit=False)
 
     @staticmethod
     def truncate_ellipsis(text: str, length: int) -> str:

--- a/efb_telegram_master/chat_object_cache.py
+++ b/efb_telegram_master/chat_object_cache.py
@@ -37,7 +37,7 @@ class ChatObjectCacheManager:
                 self.logger.debug("Loading chats from '%s'...", channel_id)
                 chats = module.get_chats()
             except Exception:
-                self.logger.exception("Error occurred while getting chats from %. "
+                self.logger.exception("Error occurred while getting chats from %s. "
                                       "ETM will report no chat from this channel until further noticed.", channel_id)
                 continue
             self.logger.debug("Found %s chats from '%s'.", len(chats), channel_id)

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -102,6 +102,8 @@ class MsgLog(BaseModel):
     """
     sent_to = TextField()
     """Module ID of the message sent to."""
+    sender_bot_id = TextField(null=True)
+    """Telegram bot user ID that sent this message. NULL means the main bot."""
     time = DateTimeField(default=datetime.datetime.now, null=True)
     """Time of the message sent."""
 
@@ -121,6 +123,7 @@ class MsgLog(BaseModel):
             mime=self.mime or None,
             file_id=self.file_id or None,
         )
+        msg.sender_bot_id = self.sender_bot_id
         with suppress(NameError):
             to_module = coordinator.get_module_by_id(self.sent_to)
             if isinstance(to_module, Channel):
@@ -315,6 +318,8 @@ class DatabaseManager:
             self._migrate(2)
         elif "file_unique_id" not in msg_log_columns:
             self._migrate(3)
+        elif "sender_bot_id" not in msg_log_columns:
+            self._migrate(4)
 
     def _migrate(self, i: int):
         """
@@ -352,6 +357,11 @@ class DatabaseManager:
             # 2019NOV18
             migrate(
                 migrator.add_column("msglog", "file_unique_id", MsgLog.file_unique_id)
+            )
+        if i <= 4:
+            # Migration 4: Add column for sender bot ID (multi-bot pool support)
+            migrate(
+                migrator.add_column("msglog", "sender_bot_id", MsgLog.sender_bot_id)
             )
 
     def add_chat_assoc(self, master_uid: EFBChannelChatIDStr,
@@ -597,7 +607,8 @@ class DatabaseManager:
     def add_or_update_message_log(self,
                                   msg: ETMMsg,
                                   master_message: Message,
-                                  old_message_id: Optional[OldMsgID] = None):
+                                  old_message_id: Optional[OldMsgID] = None,
+                                  sender_bot_id: Optional[str] = None):
         """Add or update a message into the database."""
         master_msg_id = message_id_to_str(TelegramChatID(master_message.chat_id), TelegramMessageID(master_message.message_id))
         master_msg_id_alt = None
@@ -632,6 +643,7 @@ class DatabaseManager:
         row.file_id = msg.file_id
         row.file_unique_id = msg.file_unique_id
         row.mime = msg.mime
+        row.sender_bot_id = sender_bot_id or getattr(msg, 'sender_bot_id', None)
         pickle_data = self.pickle_misc_msg(msg)
         if pickle_data:
             row.pickle = pickle_data

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -8,9 +8,10 @@ from contextlib import suppress
 from functools import partial
 from typing import List, Optional, Tuple, Dict, Collection, TYPE_CHECKING
 
-from peewee import Model, TextField, DateTimeField, CharField, DoesNotExist, fn, BlobField
-from playhouse.sqliteq import SqliteQueueDatabase
-from playhouse.migrate import SqliteMigrator, migrate
+from pathlib import Path
+
+from peewee import Model, TextField, DateTimeField, CharField, DoesNotExist, fn, BlobField, DatabaseProxy
+from playhouse.migrate import migrate
 from telegram import Message
 from typing_extensions import TypedDict
 
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
     from . import TelegramChannel
     from .chat import ETMChatMember, ETMChatType
 
-database = SqliteQueueDatabase(None, autostart=False)
+database = DatabaseProxy()
 
 PickledDict = TypedDict('PickledDict', {
     "target": EFBChannelChatIDStr,
@@ -132,7 +133,8 @@ class MsgLog(BaseModel):
         # - ``substitutions``: ``Dict[Tuple[int, int], SlaveChatID]``
         # - ``reactions``: ``Dict[str, Collection[SlaveChatID]]``
         if self.pickle:
-            misc_data: PickledDict = pickle.loads(self.pickle)
+            pickle_data = bytes(self.pickle) if isinstance(self.pickle, memoryview) else self.pickle
+            misc_data: PickledDict = pickle.loads(pickle_data)
 
             if 'target' in misc_data and recur:
                 target_row = self.get_or_none(MsgLog.master_msg_id == misc_data['target'])
@@ -181,31 +183,64 @@ class DatabaseManager:
 
     def __init__(self, channel: 'TelegramChannel'):
         base_path = utils.get_data_path(channel.channel_id)
+        self._base_path = base_path
 
         self.logger.debug("Loading database...")
-        database.init(str(base_path / 'tgdata.db'))
-        database.start()
+        db_config = channel.config.get('database', {})
+        db_type = db_config.get('type', 'sqlite')
+
+        if db_type == 'postgresql':
+            from playhouse.pool import PooledPostgresqlExtDatabase
+            from playhouse.migrate import PostgresqlMigrator
+            actual_db = PooledPostgresqlExtDatabase(
+                db_config.get('database', 'efb_telegram'),
+                host=db_config.get('host', 'localhost'),
+                port=db_config.get('port', 5432),
+                user=db_config.get('user', 'postgres'),
+                password=db_config.get('password', ''),
+                max_connections=db_config.get('max_connections', 8),
+                stale_timeout=db_config.get('stale_timeout', 300),
+            )
+            self._migrator_cls = PostgresqlMigrator
+            self._is_sqlite = False
+        else:
+            from playhouse.sqliteq import SqliteQueueDatabase
+            from playhouse.migrate import SqliteMigrator
+            actual_db = SqliteQueueDatabase(
+                str(base_path / 'tgdata.db'),
+                autostart=False,
+            )
+            self._migrator_cls = SqliteMigrator
+            self._is_sqlite = True
+            actual_db.start()
+
+        database.initialize(actual_db)
         database.connect()
         self.logger.debug("Database loaded.")
 
         self.logger.debug("Checking database migration...")
-        if not ChatAssoc.table_exists() or not TopicAssoc.table_exists():
-            self._create()
+        if not self._is_sqlite:
+            # PostgreSQL backend
+            if not ChatAssoc.table_exists():
+                sqlite_path = Path(base_path / 'tgdata.db')
+                if sqlite_path.exists():
+                    self._migrate_from_sqlite(sqlite_path)
+                else:
+                    self._create()
+            else:
+                self._check_and_run_migrations()
         else:
-            msg_log_columns = {i.name for i in database.get_columns("msglog")}
-            slave_chat_info_columns = {i.name for i in database.get_columns("slavechatinfo")}
-            if "file_id" not in msg_log_columns:
-                self._migrate(0)
-            elif "pickle" not in msg_log_columns:
-                self._migrate(1)
-            elif "slave_chat_group_id" not in slave_chat_info_columns:
-                self._migrate(2)
-            elif "file_unique_id" not in msg_log_columns:
-                self._migrate(3)
+            # SQLite backend: original logic
+            if not ChatAssoc.table_exists() or not TopicAssoc.table_exists():
+                self._create()
+            else:
+                self._check_and_run_migrations()
         self.logger.debug("Database migration finished...")
 
     def stop_worker(self):
-        database.stop()
+        if self._is_sqlite:
+            database.obj.stop()
+        database.close()
 
     @staticmethod
     def _create():
@@ -214,15 +249,81 @@ class DatabaseManager:
         """
         database.create_tables([ChatAssoc, MsgLog, SlaveChatInfo, TopicAssoc])
 
-    @staticmethod
-    def _migrate(i: int):
+    def _migrate_from_sqlite(self, sqlite_path: Path):
+        """Migrate data from existing SQLite database to PostgreSQL on first use."""
+        from playhouse.sqliteq import SqliteQueueDatabase
+        from peewee import chunked
+
+        self.logger.info("Detected existing SQLite database. Migrating to PostgreSQL...")
+
+        sqlite_db = SqliteQueueDatabase(str(sqlite_path), autostart=False)
+        sqlite_db.start()
+        sqlite_db.connect()
+
+        models = [ChatAssoc, TopicAssoc, SlaveChatInfo, MsgLog]
+        with sqlite_db.bind_ctx(models):
+            chat_assocs = list(ChatAssoc.select(
+                ChatAssoc.master_uid, ChatAssoc.slave_uid
+            ).dicts())
+            topic_assocs = list(TopicAssoc.select(
+                TopicAssoc.topic_chat_id, TopicAssoc.message_thread_id, TopicAssoc.slave_uid
+            ).dicts())
+            slave_chat_infos = list(SlaveChatInfo.select(
+                SlaveChatInfo.slave_channel_id, SlaveChatInfo.slave_channel_emoji,
+                SlaveChatInfo.slave_chat_uid, SlaveChatInfo.slave_chat_group_id,
+                SlaveChatInfo.slave_chat_name, SlaveChatInfo.slave_chat_alias,
+                SlaveChatInfo.slave_chat_type, SlaveChatInfo.pickle
+            ).dicts())
+            msg_logs = list(MsgLog.select().dicts())
+
+        sqlite_db.stop()
+        sqlite_db.close()
+
+        self._create()
+
+        with database.atomic():
+            for batch in chunked(chat_assocs, 500):
+                ChatAssoc.insert_many(batch).execute()
+            for batch in chunked(topic_assocs, 500):
+                TopicAssoc.insert_many(batch).execute()
+            for batch in chunked(slave_chat_infos, 500):
+                SlaveChatInfo.insert_many(batch).execute()
+            for batch in chunked(msg_logs, 500):
+                MsgLog.insert_many(batch).execute()
+
+        migrated_path = sqlite_path.with_suffix('.db.migrated')
+        sqlite_path.rename(migrated_path)
+
+        self.logger.info(
+            "Migration complete. %d chat assocs, %d topic assocs, "
+            "%d chat infos, %d messages migrated. "
+            "Original SQLite file renamed to %s",
+            len(chat_assocs), len(topic_assocs),
+            len(slave_chat_infos), len(msg_logs),
+            migrated_path
+        )
+
+    def _check_and_run_migrations(self):
+        """Check schema and run pending migrations."""
+        msg_log_columns = {i.name for i in database.get_columns("msglog")}
+        slave_chat_info_columns = {i.name for i in database.get_columns("slavechatinfo")}
+        if "file_id" not in msg_log_columns:
+            self._migrate(0)
+        elif "pickle" not in msg_log_columns:
+            self._migrate(1)
+        elif "slave_chat_group_id" not in slave_chat_info_columns:
+            self._migrate(2)
+        elif "file_unique_id" not in msg_log_columns:
+            self._migrate(3)
+
+    def _migrate(self, i: int):
         """
         Run migrations.
 
         Args:
             i: Migration ID
         """
-        migrator = SqliteMigrator(database)
+        migrator = self._migrator_cls(database.obj)
 
         if i <= 0:
             # Migration 0: Add media file ID and editable message ID

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -115,8 +115,23 @@ class MasterMessageProcessor(LocaleMixin):
     def stop_worker(self):
         if not self.message_worker_thread.is_alive():
             return
+        # Drain any pending messages to allow quick shutdown
+        drained_count = 0
+        while not self.message_queue.empty():
+            try:
+                self.message_queue.get_nowait()
+                self.message_queue.task_done()
+                drained_count += 1
+            except Exception:
+                break
+        if drained_count > 0:
+            self.logger.info("Drained %d pending messages from queue during shutdown", drained_count)
+        # Signal worker to stop
         self.message_queue.put(None)
-        self.message_worker_thread.join()
+        # Use timeout to avoid hanging indefinitely
+        self.message_worker_thread.join(timeout=5.0)
+        if self.message_worker_thread.is_alive():
+            self.logger.warning("Message worker thread did not stop within timeout, continuing anyway")
 
     def enqueue_message(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)

--- a/efb_telegram_master/message.py
+++ b/efb_telegram_master/message.py
@@ -32,6 +32,8 @@ class ETMMsg(Message):
     """File ID from Telegram Bot API"""
     file_unique_id: Optional[str] = None
     """Unique file ID from Telegram Bot API"""
+    sender_bot_id: Optional[str] = None
+    """Telegram bot user ID that sent this message. None means the main bot."""
     type_telegram: TGMsgType
     """Type of message in Telegram Bot API"""
     chat: ETMChatType
@@ -60,13 +62,33 @@ class ETMMsg(Message):
     def _load_file(self):
         if self.file_id:
             # noinspection PyUnresolvedReferences
-            bot = coordinator.master.bot_manager
+            bot_manager = coordinator.master.bot_manager
+
+            # Route get_file through the correct bot based on sender_bot_id
+            file_bot = None
+            if self.sender_bot_id:
+                bot_pool = getattr(bot_manager, 'bot_pool', None)
+                if bot_pool:
+                    aux_bot = bot_pool.get_bot_by_id(self.sender_bot_id)
+                    if aux_bot and not aux_bot.disabled:
+                        file_bot = aux_bot.bot
 
             try:
-                file_meta = bot.get_file(self.file_id)
+                if file_bot:
+                    file_meta = file_bot.get_file(self.file_id)
+                else:
+                    file_meta = bot_manager.get_file(self.file_id)
             except BadRequest as e:
-                logger.exception("Bad request while trying to get file metadata: %s", e)
-                return
+                if file_bot:
+                    logger.warning("Failed to get file from aux bot, trying main bot: %s", e)
+                    try:
+                        file_meta = bot_manager.get_file(self.file_id)
+                    except BadRequest as e2:
+                        logger.exception("Bad request from main bot too: %s", e2)
+                        return
+                else:
+                    logger.exception("Bad request while trying to get file metadata: %s", e)
+                    return
             if not self.mime:
                 ext = os.path.splitext(file_meta.file_path)[1]
                 mime = mimetypes.guess_type(file_meta.file_path, strict=False)[0]

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -621,8 +621,8 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 assert msg.file and msg.path
                 file = self.process_file_obj(msg.file, msg.path)
-                file_: Union[IO[bytes], bytes] = open(file, 'rb') if isinstance(file, str) else file
-                return self.bot.send_animation(tg_dest, InputFile(file_, filename=msg.filename),
+                anim_file: Union[IO[bytes], str] = file if isinstance(file, str) else InputFile(file, filename=msg.filename)
+                return self.bot.send_animation(tg_dest, anim_file,
                                                prefix=msg_template, suffix=reactions,
                                                caption=text, parse_mode="HTML",
                                                reply_to_message_id=target_msg_id,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -51,6 +51,7 @@ class SlaveMessageProcessor(LocaleMixin):
         self.channel: 'TelegramChannel' = channel
         self.bot: 'TelegramBotManager' = self.channel.bot_manager
         self.logger: logging.Logger = logging.getLogger(__name__)
+        self._tls = threading.local()  # Thread-local storage for per-send cleanup tracking
         self.flag: utils.ExperimentalFlagsManager = self.channel.flag
         self.db: 'DatabaseManager' = channel.db
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
@@ -571,6 +572,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     def slave_message_animation(self, msg: Message, tg_dest: TelegramChatID,
                                 thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -632,6 +634,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file is not None:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     def slave_message_sticker(self, msg: Message, tg_dest: TelegramChatID,
                               thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -714,6 +717,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file and not msg.file.closed:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     @staticmethod
     def build_chat_info_inline_keyboard(msg: Message, msg_template: str, reactions: str,
@@ -807,6 +811,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file is not None:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     def slave_message_voice(self, msg: Message, tg_dest: TelegramChatID,
                             thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -875,6 +880,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file is not None:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     def slave_message_location(self, msg: Message, tg_dest: TelegramChatID,
                                thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -965,6 +971,7 @@ class SlaveMessageProcessor(LocaleMixin):
         finally:
             if msg.file is not None:
                 msg.file.close()
+            self._cleanup_pending_local_api_files()
 
     def slave_message_unsupported(self, msg: Message, tg_dest: TelegramChatID,
                                   thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -1236,6 +1243,22 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.debug("Copied file from %s to shared temp dir: %s (original filename: %s)",
                                       path, dest_path, filename or "N/A")
 
+                    # Track copied file for cleanup after send completes
+                    if not hasattr(self._tls, 'pending_cleanup'):
+                        self._tls.pending_cleanup = []
+                    self._tls.pending_cleanup.append(dest_path)
+
             return abs_path.as_uri()
         return file
+
+    def _cleanup_pending_local_api_files(self):
+        """Delete temp files copied to shared dir for local Bot API sends in this thread."""
+        pending = getattr(self._tls, 'pending_cleanup', [])
+        for path in pending:
+            try:
+                os.unlink(path)
+                self.logger.debug("Cleaned up local API temp file: %s", path)
+            except OSError as e:
+                self.logger.warning("Failed to clean up local API temp file %s: %s", path, e)
+        self._tls.pending_cleanup = []
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1078,12 +1078,12 @@ class SlaveMessageProcessor(LocaleMixin):
         old_msg.edit = True # Mark as edit so dispatch knows it's an update
         old_msg.edit_media = False # Ensure media is not considered edited
 
-        msg_template, _ = self.get_slave_msg_dest(old_msg)
+        msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(old_msg)
         effective_msg = old_msg_db.master_msg_id_alt or old_msg_db.master_msg_id
         chat_id, msg_id = utils.message_id_str_to_id(effective_msg)
 
         # Go through the ordinary update process
-        self.dispatch_message(old_msg, msg_template, old_msg_id=(chat_id, msg_id), tg_dest=chat_id)
+        self.dispatch_message(old_msg, msg_template, old_msg_id=(chat_id, msg_id), tg_dest, thread_id)
 
     def generate_message_template(self, msg: Message, singly_linked: bool) -> str:
         msg_prefix = ""  # For group member name

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -515,7 +515,7 @@ class SlaveMessageProcessor(LocaleMixin):
                     if edit_media:
                         assert msg.path
                         media: InputMedia
-                        file = self.process_file_obj(msg.file, msg.path)
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
                         if send_as_file:
                             media = InputMediaDocument(file)
                         else:
@@ -539,7 +539,7 @@ class SlaveMessageProcessor(LocaleMixin):
             # Sending new message (either initially or as fallback from edit)
             if send_as_file:
                 assert msg.path
-                file = self.process_file_obj(msg.file, msg.path)
+                file = self.process_file_obj(msg.file, msg.path, msg.filename)
                 return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
                                               caption=text, parse_mode="HTML", filename=msg.filename,
                                               reply_to_message_id=target_msg_id,
@@ -549,7 +549,7 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 try:
                     assert msg.path
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     return self.bot.send_photo(tg_dest, file, prefix=msg_template, suffix=reactions,
                                                caption=text, parse_mode="HTML",
                                                reply_to_message_id=target_msg_id,
@@ -561,7 +561,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                       msg.uid, e)
                     assert msg.path
                     msg.file.seek(0) # Rewind file pointer
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
                                                   caption=text, parse_mode="HTML", filename=msg.filename,
                                                   reply_to_message_id=target_msg_id,
@@ -609,7 +609,7 @@ class SlaveMessageProcessor(LocaleMixin):
             if old_msg_id:
                 if edit_media:
                     assert msg.file and msg.path
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
                                                 reply_markup=reply_markup)
                     if not text:
@@ -620,7 +620,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                      caption=text, parse_mode="HTML")
             else:
                 assert msg.file and msg.path
-                file = self.process_file_obj(msg.file, msg.path)
+                file = self.process_file_obj(msg.file, msg.path, msg.filename)
                 anim_file: Union[IO[bytes], str] = file if isinstance(file, str) else InputFile(file, filename=msg.filename)
                 return self.bot.send_animation(tg_dest, anim_file,
                                                prefix=msg_template, suffix=reactions,
@@ -693,7 +693,7 @@ class SlaveMessageProcessor(LocaleMixin):
                     webp_img = tempfile.NamedTemporaryFile(suffix='.webp', dir=utils.ExperimentalFlagsManager.get_temp_dir(self.channel))
                     pic_img.convert("RGBA").save(webp_img, 'webp')
                     webp_img.seek(0)
-                    file = self.process_file_obj(webp_img, webp_img.name)
+                    file = self.process_file_obj(webp_img, webp_img.name, msg.filename)
                     return self.bot.send_sticker(tg_dest, file, reply_markup=sticker_reply_markup,
                                                  message_thread_id=thread_id,
                                                  reply_to_message_id=target_msg_id,
@@ -701,7 +701,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 except IOError:
                     self.logger.warning("[%s] Failed to convert image to webp sticker, sending as document.", msg.uid)
                     assert msg.file and msg.path
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
                                                   message_thread_id=thread_id,
                                                   caption=msg.text, filename=msg.filename,
@@ -787,7 +787,7 @@ class SlaveMessageProcessor(LocaleMixin):
             if old_msg_id:
                 if edit_media:
                     assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
                     if not text:
                         return res
@@ -796,7 +796,7 @@ class SlaveMessageProcessor(LocaleMixin):
             assert msg.file is not None and msg.path is not None
             self.logger.debug("[%s] Uploading file %s (%s) as %s", msg.uid,
                               msg.file.name, msg.mime, file_name)
-            file = self.process_file_obj(msg.file, msg.path)
+            file = self.process_file_obj(msg.file, msg.path, file_name)
             return self.bot.send_document(tg_dest, file,
                                           prefix=msg_template, suffix=reactions,
                                           caption=text, parse_mode="HTML", filename=file_name,
@@ -856,7 +856,7 @@ class SlaveMessageProcessor(LocaleMixin):
                         pydub.AudioSegment.from_file(msg.file).export(f.name, format="ogg", codec="libopus",
                                                                       parameters=['-vbr', 'on'])
                         # process_file_obj might return URI or file object. send_voice expects content or path.
-                        processed_path = self.process_file_obj(f, f.name) # Get path/URI
+                        processed_path = self.process_file_obj(f, f.name, msg.filename) # Get path/URI
                         # Send using the path/URI
                         tg_msg = self.bot.send_voice(tg_dest, processed_path, prefix=msg_template, suffix=reactions,
                                                      caption=text, parse_mode="HTML",
@@ -947,7 +947,7 @@ class SlaveMessageProcessor(LocaleMixin):
             if old_msg_id:
                 if edit_media:
                     assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path)
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
                     res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
                                                 reply_markup=reply_markup)
                     if not text:
@@ -955,7 +955,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
                                                      prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
             assert msg.file is not None and msg.path is not None
-            file = self.process_file_obj(msg.file, msg.path)
+            file = self.process_file_obj(msg.file, msg.path, msg.filename)
             return self.bot.send_video(tg_dest, file, prefix=msg_template, suffix=reactions,
                                        caption=text, parse_mode="HTML",
                                        reply_to_message_id=target_msg_id,
@@ -1148,7 +1148,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 size=size_str, max_size=max_size_str)
         return None
 
-    def process_file_obj(self, file: IO[bytes], path: Union[str, Path]) -> Union[IO[bytes], str]:
+    def process_file_obj(self, file: IO[bytes], path: Union[str, Path], filename: Optional[str] = None) -> Union[IO[bytes], str]:
         """Process file object for sending to Telegram.
 
         When using local TDLIB API, files need to be accessible by the Docker container.
@@ -1158,6 +1158,7 @@ class SlaveMessageProcessor(LocaleMixin):
         Args:
             file: The file object
             path: Path to the file
+            filename: Optional original filename to preserve when copying
 
         Returns:
             file:// URI if using local TDLIB API, otherwise the file object
@@ -1178,9 +1179,18 @@ class SlaveMessageProcessor(LocaleMixin):
                     import shutil
                     import tempfile as tmp
 
-                    # Determine extension; guess from magic bytes if path has none
-                    suffix = abs_path.suffix
+                    # Determine extension from filename or guess from magic bytes
+                    suffix = ''
+                    if filename:
+                        # Extract extension from original filename
+                        suffix = Path(filename).suffix
+
                     if not suffix:
+                        # Fall back to guessing from file path
+                        suffix = abs_path.suffix
+
+                    if not suffix:
+                        # Last resort: guess from magic bytes
                         file.seek(0)
                         head = file.read(16)
                         file.seek(0)
@@ -1196,8 +1206,23 @@ class SlaveMessageProcessor(LocaleMixin):
                             suffix = '.mp4'
                         elif head[:4] == b'OggS':
                             suffix = '.ogg'
-                    with tmp.NamedTemporaryFile(suffix=suffix, dir=temp_dir, delete=False) as dest:
-                        dest_path = dest.name
+                        elif head[:4] == b'%PDF':
+                            suffix = '.pdf'
+
+                    # Use original filename if provided, otherwise generate temp name
+                    if filename:
+                        # Sanitize filename to avoid path traversal
+                        safe_filename = os.path.basename(filename)
+                        dest_path = os.path.join(temp_dir, safe_filename)
+                        # If file already exists, add a unique suffix
+                        if os.path.exists(dest_path):
+                            import uuid
+                            name_parts = os.path.splitext(safe_filename)
+                            safe_filename = f"{name_parts[0]}_{uuid.uuid4().hex[:8]}{name_parts[1]}"
+                            dest_path = os.path.join(temp_dir, safe_filename)
+                    else:
+                        with tmp.NamedTemporaryFile(suffix=suffix, dir=temp_dir, delete=False) as dest:
+                            dest_path = dest.name
 
                     # Copy file content
                     file.seek(0)
@@ -1208,7 +1233,8 @@ class SlaveMessageProcessor(LocaleMixin):
                     os.chmod(dest_path, 0o644)
 
                     abs_path = Path(dest_path)
-                    self.logger.debug("Copied file from %s to shared temp dir: %s", path, dest_path)
+                    self.logger.debug("Copied file from %s to shared temp dir: %s (original filename: %s)",
+                                      path, dest_path, filename or "N/A")
 
             return abs_path.as_uri()
         return file

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -237,6 +237,12 @@ class SlaveMessageProcessor(LocaleMixin):
                 commands, coordinator.get_module_by_id(msg.author.module_id), msg_template, msg.text
             ))
 
+        # Check if message sending failed (tg_msg is None)
+        if tg_msg is None:
+            self.logger.warning("[%s] Message sending returned None, skipping database logging. "
+                               "This may happen during shutdown or when Telegram API is unavailable.", xid)
+            return
+
         # Check if this is a delayed execution (mock message)
         if hasattr(tg_msg, '_delayed_execution_pending') and tg_msg._delayed_execution_pending:
             # This is a delayed execution - defer database logging

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -690,7 +690,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
                 try:
                     pic_img: Image = Image.open(msg.file)
-                    webp_img = tempfile.NamedTemporaryFile(suffix='.webp')
+                    webp_img = tempfile.NamedTemporaryFile(suffix='.webp', dir=utils.ExperimentalFlagsManager.get_temp_dir(self.channel))
                     pic_img.convert("RGBA").save(webp_img, 'webp')
                     webp_img.seek(0)
                     file = self.process_file_obj(webp_img, webp_img.name)
@@ -851,7 +851,7 @@ class SlaveMessageProcessor(LocaleMixin):
             # Sending new message (initial or fallback)
             if not old_msg_id: # Ensure we are in the 'send new' path
                 assert msg.file is not None
-                with tempfile.NamedTemporaryFile(suffix=".ogg") as f: # Ensure correct suffix for pydub
+                with tempfile.NamedTemporaryFile(suffix=".ogg", dir=utils.ExperimentalFlagsManager.get_temp_dir(self.channel)) as f: # Ensure correct suffix for pydub
                     try:
                         pydub.AudioSegment.from_file(msg.file).export(f.name, format="ogg", codec="libopus",
                                                                       parameters=['-vbr', 'on'])
@@ -1149,6 +1149,51 @@ class SlaveMessageProcessor(LocaleMixin):
         return None
 
     def process_file_obj(self, file: IO[bytes], path: Union[str, Path]) -> Union[IO[bytes], str]:
+        """Process file object for sending to Telegram.
+
+        When using local TDLIB API, files need to be accessible by the Docker container.
+        If local_tdlib_temp_dir is configured and the file is outside that directory,
+        the file will be copied to the shared directory first.
+
+        Args:
+            file: The file object
+            path: Path to the file
+
+        Returns:
+            file:// URI if using local TDLIB API, otherwise the file object
+        """
         if self.channel.flag("local_tdlib_api"):
-            return Path(path).absolute().as_uri()
+            abs_path = Path(path).absolute()
+            temp_dir = utils.ExperimentalFlagsManager.get_temp_dir(self.channel)
+
+            # If we have a shared temp dir configured, check if file needs to be copied
+            if temp_dir:
+                temp_dir_path = Path(temp_dir)
+                # Check if the file is already in the shared directory
+                try:
+                    abs_path.relative_to(temp_dir_path)
+                    # File is already in shared dir, use it directly
+                except ValueError:
+                    # File is outside shared dir, need to copy it
+                    import shutil
+                    import tempfile as tmp
+
+                    # Create a temp file in the shared directory with same extension
+                    suffix = abs_path.suffix or ''
+                    with tmp.NamedTemporaryFile(suffix=suffix, dir=temp_dir, delete=False) as dest:
+                        dest_path = dest.name
+
+                    # Copy file content
+                    file.seek(0)
+                    with open(dest_path, 'wb') as dest:
+                        shutil.copyfileobj(file, dest)
+
+                    # Set permissions to 644 so Docker container can read
+                    os.chmod(dest_path, 0o644)
+
+                    abs_path = Path(dest_path)
+                    self.logger.debug("Copied file from %s to shared temp dir: %s", path, dest_path)
+
+            return abs_path.as_uri()
         return file
+

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -55,6 +55,18 @@ class SlaveMessageProcessor(LocaleMixin):
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
 
+    def _get_edit_context(self, msg: Message):
+        """Get a context manager for routing edits through the correct bot.
+        Returns the bot_manager's _using_bot context manager if sender_bot_id is set,
+        otherwise returns a no-op context manager."""
+        from contextlib import nullcontext
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+        if _sender_bot_id and self.bot.bot_pool:
+            aux_bot = self.bot.bot_pool.get_bot_by_id(_sender_bot_id)
+            if aux_bot and not aux_bot.disabled:
+                return self.bot._using_bot(aux_bot.bot)
+        return nullcontext()
+
     def is_silent(self, msg: Message) -> Optional[bool]:
         """Determine if a message shall be sent silently.
         Returns None if the message shall not be sent at all.
@@ -104,10 +116,12 @@ class SlaveMessageProcessor(LocaleMixin):
 
             # When editing message
             old_msg_id: Optional[OldMsgID] = None
+            _edit_sender_bot_id: Optional[str] = None
             if msg.edit:
                 old_msg = self.db.get_msg_log(slave_msg_id=msg.uid,
                                               slave_origin_uid=utils.chat_id_to_str(chat=msg.chat))
                 if old_msg:
+                    _edit_sender_bot_id = old_msg.sender_bot_id
 
                     if old_msg.master_msg_id_alt:
                         old_msg_id = utils.message_id_str_to_id(old_msg.master_msg_id_alt)
@@ -117,6 +131,11 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.info('[%s] Was supposed to edit this message, '
                                      'but it does not exist in database. Sending new message instead.',
                                      msg.uid)
+
+            # Store sender_bot_id for routing edits to the correct bot
+            if _edit_sender_bot_id:
+                msg.vendor_specific = msg.vendor_specific or {}
+                msg.vendor_specific['_sender_bot_id'] = _edit_sender_bot_id
 
             self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
         except Exception as e:
@@ -264,7 +283,12 @@ class SlaveMessageProcessor(LocaleMixin):
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
             etm_msg.type_telegram = get_msg_type(tg_msg)
             etm_msg.put_telegram_file(tg_msg)
-            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id)
+
+            # Capture sender_bot_id annotated by rate_limit_decorator
+            sender_bot_id = getattr(tg_msg, '_sender_bot_id', None)
+
+            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id,
+                                              sender_bot_id=sender_bot_id)
             # self.logger.debug("[%s] Message inserted/updated to the database.", xid)
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:
@@ -376,6 +400,8 @@ class SlaveMessageProcessor(LocaleMixin):
 
         text = self.html_substitutions(msg)
 
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+
         if not old_msg_id:
             tg_msg = self.bot.send_message(tg_dest,
                                            text=text, prefix=msg_template, suffix=reactions,
@@ -386,11 +412,14 @@ class SlaveMessageProcessor(LocaleMixin):
                                            disable_notification=silent)
         else:
             # Cannot change reply_to_message_id when editing a message
-            tg_msg = self.bot.edit_message_text(chat_id=old_msg_id[0],
-                                                message_id=old_msg_id[1],
-                                                text=text, prefix=msg_template, suffix=reactions,
-                                                parse_mode='HTML',
-                                                reply_markup=reply_markup)
+            edit_kwargs = dict(chat_id=old_msg_id[0],
+                               message_id=old_msg_id[1],
+                               text=text, prefix=msg_template, suffix=reactions,
+                               parse_mode='HTML',
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            tg_msg = self.bot.edit_message_text(**edit_kwargs)
 
         self.logger.debug("[%s] Processed and sent as text message", msg.uid)
         return tg_msg
@@ -417,9 +446,13 @@ class SlaveMessageProcessor(LocaleMixin):
         if msg.text:
             text += "\n\n" + self.html_substitutions(msg)
         if old_msg_id:
-            return self.bot.edit_message_text(text=text, chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                              prefix=msg_template, suffix=reactions, parse_mode='HTML',
-                                              reply_markup=reply_markup)
+            _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+            edit_kwargs = dict(text=text, chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                               prefix=msg_template, suffix=reactions, parse_mode='HTML',
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            return self.bot.edit_message_text(**edit_kwargs)
         else:
             return self.bot.send_message(chat_id=tg_dest,
                                          text=text,
@@ -511,21 +544,22 @@ class SlaveMessageProcessor(LocaleMixin):
 
             if old_msg_id:
                 try:
-                    if edit_media:
-                        assert msg.path
-                        media: InputMedia
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                        if send_as_file:
-                            media = InputMediaDocument(file)
-                        else:
-                            media = InputMediaPhoto(file)
-                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
-                                                    reply_markup=reply_markup)
-                        if not text:
-                            return res
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                         reply_markup=reply_markup,
-                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                    with self._get_edit_context(msg):
+                        if edit_media:
+                            assert msg.path
+                            media: InputMedia
+                            file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                            if send_as_file:
+                                media = InputMediaDocument(file)
+                            else:
+                                media = InputMediaPhoto(file)
+                            res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
+                                                        reply_markup=reply_markup)
+                            if not text:
+                                return res
+                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                             reply_markup=reply_markup,
+                                                             prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
                 except telegram.error.BadRequest as e:
                     self.logger.warning("[%s] Failed to edit media/caption (BadRequest: %s). Sending new message instead.", msg.uid, e)
                     # Send as a reply if cannot edit previous message.
@@ -607,17 +641,18 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file and msg.path
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
-                                                reply_markup=reply_markup)
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                     prefix=msg_template, suffix=reactions,
-                                                     reply_markup=reply_markup,
-                                                     caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file and msg.path
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
+                                                    reply_markup=reply_markup)
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         prefix=msg_template, suffix=reactions,
+                                                         reply_markup=reply_markup,
+                                                         caption=text, parse_mode="HTML")
             else:
                 assert msg.file and msg.path
                 file = self.process_file_obj(msg.file, msg.path, msg.filename)
@@ -655,14 +690,18 @@ class SlaveMessageProcessor(LocaleMixin):
             if msg.edit_media and old_msg_id is not None:
                  if old_msg_id[0] == str(tg_dest):
                     target_msg_id = old_msg_id[1] # Set reply target to the message being "edited"
-                 old_msg_id = None # Force sending a new message
+                 old_msg_id = None  # Force sending new message below
 
             # If not editing media, but have old_msg_id, try editing reply_markup (e.g., for reactions)
             if old_msg_id and not msg.edit_media:
                 try:
+                    _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+                    edit_kwargs = dict(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                       reply_markup=sticker_reply_markup)
+                    if _sender_bot_id:
+                        edit_kwargs['_sender_bot_id'] = _sender_bot_id
                     # Editing reply markup doesn't involve thread_id
-                    return self.bot.edit_message_reply_markup(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                              reply_markup=sticker_reply_markup)
+                    return self.bot.edit_message_reply_markup(**edit_kwargs)
                 except TelegramError:
                     return self.bot.send_message(chat_id=old_msg_id[0], reply_to_message_id=old_msg_id[1],
                                                  prefix=msg_template, text=msg.text, suffix=reactions,
@@ -787,14 +826,15 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file is not None and msg.path is not None
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
             assert msg.file is not None and msg.path is not None
             self.logger.debug("[%s] Uploading file %s (%s) as %s", msg.uid,
                               msg.file.name, msg.mime, file_name)
@@ -846,11 +886,12 @@ class SlaveMessageProcessor(LocaleMixin):
                     msg_template += " " + self._("[Edited]")
                     if str(tg_dest) == old_msg_id[0]:
                         target_msg_id = target_msg_id or old_msg_id[1]
-                    old_msg_id = None # Force sending new message below
+                    old_msg_id = None
                 else:
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                         reply_markup=reply_markup, prefix=msg_template,
-                                                         suffix=reactions, caption=text, parse_mode="HTML")
+                    with self._get_edit_context(msg):
+                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                             reply_markup=reply_markup, prefix=msg_template,
+                                                             suffix=reactions, caption=text, parse_mode="HTML")
             # Sending new message (initial or fallback)
             if not old_msg_id: # Ensure we are in the 'send new' path
                 assert msg.file is not None
@@ -949,15 +990,16 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
-                                                reply_markup=reply_markup)
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file is not None and msg.path is not None
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
+                                                    reply_markup=reply_markup)
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
             assert msg.file is not None and msg.path is not None
             file = self.process_file_obj(msg.file, msg.path, msg.filename)
             return self.bot.send_video(tg_dest, file, prefix=msg_template, suffix=reactions,
@@ -985,21 +1027,26 @@ class SlaveMessageProcessor(LocaleMixin):
         else:
             text = ""
 
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+
         if not old_msg_id:
             tg_msg = self.bot.send_message(tg_dest,
                                            text=text, parse_mode="HTML",
                                            prefix=msg_template + " " + self._("(unsupported)"),
                                            suffix=reactions,
-                                           reply_to_message_id=target_msg_id, message_thread_id=thread_id, reply_markup=reply_markup,
+                                           reply_to_message_id=target_msg_id, message_thread_id=thread_id,                                            reply_markup=reply_markup,
                                            disable_notification=silent)
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
-            tg_msg = self.bot.edit_message_text(chat_id=old_msg_id[0],
-                                                message_id=old_msg_id[1],
-                                                text=text, parse_mode="HTML",
-                                                prefix=msg_template + " " + self._("(unsupported) [Edited]"), # Mark as edited
-                                                suffix=reactions,
-                                                reply_markup=reply_markup)
+            edit_kwargs = dict(chat_id=old_msg_id[0],
+                               message_id=old_msg_id[1],
+                               text=text, parse_mode="HTML",
+                               prefix=msg_template + " " + self._("(unsupported) [Edited]"),  # Mark as edited
+                               suffix=reactions,
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            tg_msg = self.bot.edit_message_text(**edit_kwargs)
 
         self.logger.debug("[%s] Processed and sent as text message", msg.uid)
         return tg_msg
@@ -1048,7 +1095,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                   *old_msg_id)
                 try:
                     if not self.channel.flag('prevent_message_removal'):
-                        self.bot.delete_message(*old_msg_id)
+                        self.bot.delete_message(*old_msg_id,
+                                                _sender_bot_id=old_msg.sender_bot_id)
                         return
                 except TelegramError as e:
                     self.logger.warning("Failed to delete message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
@@ -1056,7 +1104,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.bot.send_message(chat_id=old_msg_id[0],
                                       text=self._("Message is removed in remote chat."),
                                       reply_to_message_id=old_msg_id[1],
-                                      disable_notification=True) # Probably silent notification
+                                      disable_notification=True)  # Probably silent notification
             else:
                 self.logger.info('Was supposed to delete a message, '
                                  'but it does not exist in database: %s', status)
@@ -1086,8 +1134,13 @@ class SlaveMessageProcessor(LocaleMixin):
 
         old_msg: ETMMsg = old_msg_db.build_etm_msg(chat_manager=self.chat_manager)
         old_msg.reactions = status.reactions
-        old_msg.edit = True # Mark as edit so dispatch knows it's an update
-        old_msg.edit_media = False # Ensure media is not considered edited
+        old_msg.edit = True  # Mark as edit so dispatch knows it's an update
+        old_msg.edit_media = False  # Ensure media is not considered edited
+
+        # Thread sender_bot_id for routing edits to the correct bot
+        if old_msg_db.sender_bot_id:
+            old_msg.vendor_specific = old_msg.vendor_specific or {}
+            old_msg.vendor_specific['_sender_bot_id'] = old_msg_db.sender_bot_id
 
         msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(old_msg)
         if tg_dest is None:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -5,7 +5,6 @@ import itertools
 import logging
 import os
 import tempfile
-import threading
 import traceback
 import urllib.parse
 from collections import defaultdict
@@ -51,7 +50,6 @@ class SlaveMessageProcessor(LocaleMixin):
         self.channel: 'TelegramChannel' = channel
         self.bot: 'TelegramBotManager' = self.channel.bot_manager
         self.logger: logging.Logger = logging.getLogger(__name__)
-        self._tls = threading.local()  # Thread-local storage for per-send cleanup tracking
         self.flag: utils.ExperimentalFlagsManager = self.channel.flag
         self.db: 'DatabaseManager' = channel.db
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
@@ -1244,21 +1242,25 @@ class SlaveMessageProcessor(LocaleMixin):
                                       path, dest_path, filename or "N/A")
 
                     # Track copied file for cleanup after send completes
-                    if not hasattr(self._tls, 'pending_cleanup'):
-                        self._tls.pending_cleanup = []
-                    self._tls.pending_cleanup.append(dest_path)
+                    # Store on bot_manager's thread-local so delayed task scheduling can pick them up
+                    tls = self.bot._cleanup_tls
+                    if not hasattr(tls, 'pending_cleanup'):
+                        tls.pending_cleanup = []
+                    tls.pending_cleanup.append(dest_path)
 
             return abs_path.as_uri()
         return file
 
     def _cleanup_pending_local_api_files(self):
-        """Delete temp files copied to shared dir for local Bot API sends in this thread."""
-        pending = getattr(self._tls, 'pending_cleanup', [])
+        """Delete temp files copied to shared dir for local Bot API sends in this thread.
+        Only cleans up files that were NOT already claimed by a delayed task."""
+        tls = self.bot._cleanup_tls
+        pending = getattr(tls, 'pending_cleanup', [])
         for path in pending:
             try:
                 os.unlink(path)
                 self.logger.debug("Cleaned up local API temp file: %s", path)
             except OSError as e:
                 self.logger.warning("Failed to clean up local API temp file %s: %s", path, e)
-        self._tls.pending_cleanup = []
+        tls.pending_cleanup = []
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1178,8 +1178,24 @@ class SlaveMessageProcessor(LocaleMixin):
                     import shutil
                     import tempfile as tmp
 
-                    # Create a temp file in the shared directory with same extension
-                    suffix = abs_path.suffix or ''
+                    # Determine extension; guess from magic bytes if path has none
+                    suffix = abs_path.suffix
+                    if not suffix:
+                        file.seek(0)
+                        head = file.read(16)
+                        file.seek(0)
+                        if head[:4] == b'RIFF' and head[8:12] == b'WEBP':
+                            suffix = '.webp'
+                        elif head[:8] == b'\x89PNG\r\n\x1a\n':
+                            suffix = '.png'
+                        elif head[:2] == b'\xff\xd8':
+                            suffix = '.jpg'
+                        elif head[:6] in (b'GIF87a', b'GIF89a'):
+                            suffix = '.gif'
+                        elif head[4:8] == b'ftyp':
+                            suffix = '.mp4'
+                        elif head[:4] == b'OggS':
+                            suffix = '.ogg'
                     with tmp.NamedTemporaryFile(suffix=suffix, dir=temp_dir, delete=False) as dest:
                         dest_path = dest.name
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -237,14 +237,30 @@ class SlaveMessageProcessor(LocaleMixin):
                 commands, coordinator.get_module_by_id(msg.author.module_id), msg_template, msg.text
             ))
 
-        self.logger.debug("[%s] Message is sent to the user with telegram message id %s.%s.",
-                          xid, tg_msg.chat.id, tg_msg.message_id)
+        # Check if this is a delayed execution (mock message)
+        if hasattr(tg_msg, '_delayed_execution_pending') and tg_msg._delayed_execution_pending:
+            # This is a delayed execution - defer database logging
+            self.logger.debug("[%s] Message execution is delayed (task_id: %s), deferring database logging.",
+                             xid, getattr(tg_msg, 'task_id', 'unknown'))
 
-        etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
-        etm_msg.type_telegram = get_msg_type(tg_msg)
-        etm_msg.put_telegram_file(tg_msg)
-        self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id)
-        # self.logger.debug("[%s] Message inserted/updated to the database.", xid)
+            # Prepare ETM message for later database update
+            etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
+
+            # Register the delayed database update
+            if hasattr(tg_msg, 'task_id'):
+                self.bot.register_delayed_database_update(tg_msg.task_id, etm_msg, old_msg_id)
+            else:
+                self.logger.warning("[%s] Delayed message missing task_id, cannot register database update", xid)
+        else:
+            # Normal execution - log to database immediately
+            self.logger.debug("[%s] Message is sent to the user with telegram message id %s.%s.",
+                              xid, tg_msg.chat.id, tg_msg.message_id)
+
+            etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
+            etm_msg.type_telegram = get_msg_type(tg_msg)
+            etm_msg.put_telegram_file(tg_msg)
+            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id)
+            # self.logger.debug("[%s] Message inserted/updated to the database.", xid)
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:
         """Get the Telegram destination of a message with its header.

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1079,11 +1079,16 @@ class SlaveMessageProcessor(LocaleMixin):
         old_msg.edit_media = False # Ensure media is not considered edited
 
         msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(old_msg)
+        if tg_dest is None:
+            self.logger.error('Cannot update reactions for message %s from %s: destination not found.',
+                              status.msg_id, status.chat)
+            return
+
         effective_msg = old_msg_db.master_msg_id_alt or old_msg_db.master_msg_id
         chat_id, msg_id = utils.message_id_str_to_id(effective_msg)
 
         # Go through the ordinary update process
-        self.dispatch_message(old_msg, msg_template, old_msg_id=(chat_id, msg_id), tg_dest, thread_id)
+        self.dispatch_message(old_msg, msg_template, (chat_id, msg_id), tg_dest, thread_id)
 
     def generate_message_template(self, msg: Message, singly_linked: bool) -> str:
         msg_prefix = ""  # For group member name

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -59,6 +59,27 @@ class ExperimentalFlagsManager(LocaleMixin):
         "topic_group": None,
     }
 
+    @staticmethod
+    def get_temp_dir(channel: 'TelegramChannel') -> Optional[str]:
+        """Get the temp directory for creating temporary files.
+
+        When using local TDLIB API with Docker, temp files need to be created
+        in a directory that is shared between the host and the container.
+
+        Extracts the directory path from api_base_file_url if configured.
+        For example: file:///var/lib/telegram-bot-api -> /var/lib/telegram-bot-api
+
+        Returns:
+            The temp directory path if local_tdlib_api and api_base_file_url are configured,
+            otherwise None (use system default).
+        """
+        if channel.flag("local_tdlib_api") and channel.flag("api_base_file_url"):
+            from urllib.parse import urlparse
+            parsed = urlparse(channel.flag("api_base_file_url"))
+            if parsed.scheme == "file" and parsed.path:
+                return parsed.path
+        return None
+
     def __init__(self, channel: 'TelegramChannel'):
         self.channel = channel
         self.config: Dict[str, Any] = ExperimentalFlagsManager.DEFAULT_VALUES.copy()

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ setup(
             "lottie",
             "cairosvg",  # required by ``lottie`` to export GIF
         ],
+        "postgresql": [
+            "psycopg2-binary",
+        ],
     },
     entry_points={
         "ehforwarderbot.master": "blueset.telegram = efb_telegram_master:TelegramChannel",


### PR DESCRIPTION
This pull request introduces major new infrastructure for supporting auxiliary (send-only) Telegram bots, including robust rate limiting, group membership tracking, and a pool manager to orchestrate their usage. It also includes some minor bug fixes and handler improvements.

The most important changes are:

**Auxiliary Bot Infrastructure:**

* Added a new `AuxiliaryBot` class (`auxiliary_bot.py`) that wraps `telegram.Bot` to provide per-bot rate limiting, group membership caching with background probes, and safe enable/disable logic. This allows the system to use multiple bots for sending messages without exceeding Telegram limits.
* Introduced a `BotPool` class (`bot_pool.py`) to manage multiple `AuxiliaryBot` instances, handle atomic slot acquisition, maintain O(1) lookup by bot ID, and notify admins when bots need to be added to groups.
* Updated the configuration loader (`__init__.py`) to validate the new `auxiliary_bots` config section, ensuring tokens are unique and well-formed.

**Chat Binding and Migration:**

* Improved chat binding logic to distinguish between relinking and new linking, and to invoke the appropriate history migration or linking method. [[1]](diffhunk://#diff-2e4c171a93b9ede16c82985dadad614a9175b27908395dcebaffc5a097847b20R572) [[2]](diffhunk://#diff-2e4c171a93b9ede16c82985dadad614a9175b27908395dcebaffc5a097847b20R626-R628)
* Fixed a bug in auto-updating group info by ensuring the correct chat ID type is passed.

**Handlers and Serialization:**

* Registered a new handler for `new_chat_members` events to support auxiliary bot membership tracking.
* Fixed a bug in `unpickle()` to handle `memoryview` objects, improving compatibility with some database backends.