### PR TITLE
Muilty bot send

### DIFF
--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -195,6 +195,22 @@ class TelegramChannel(MasterChannel):
                     raise ValueError(self._('Admin ID is expected to be an int, but {data} is found.')
                                      .format(data=data['admins'][i]))
 
+            # Validate auxiliary_bots config
+            aux_bots = data.get('auxiliary_bots', [])
+            if aux_bots:
+                if not isinstance(aux_bots, list):
+                    raise ValueError(self._('auxiliary_bots must be a list.'))
+                main_token = data['token']
+                seen_tokens = {main_token}
+                for idx, entry in enumerate(aux_bots):
+                    if not isinstance(entry, dict) or not isinstance(entry.get('token'), str):
+                        raise ValueError(
+                            self._('auxiliary_bots[{idx}] must have a "token" string.').format(idx=idx))
+                    if entry['token'] in seen_tokens:
+                        raise ValueError(
+                            self._('Duplicate token found in auxiliary_bots[{idx}].').format(idx=idx))
+                    seen_tokens.add(entry['token'])
+
             self.config = data.copy()
 
     def info(self, update: Update, context: CallbackContext):

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -161,6 +161,7 @@ class AuxiliaryBot:
         return the stale value while refreshing in the background. This avoids
         false "not a member" results when all bots' caches expire simultaneously.
         """
+        need_probe = False
         with self._membership_lock:
             entry = self._membership_cache.get(chat_id)
             if entry is not None:
@@ -169,9 +170,13 @@ class AuxiliaryBot:
                 age = time.time() - timestamp
                 if age < ttl:
                     return is_member
-                # Stale but exists: return stale value, refresh in background
-                self._start_membership_probe(chat_id)
-                return is_member
+                # Stale but exists: flag for background refresh, return stale value
+                need_probe = True
+                stale_value = is_member
+
+        if need_probe:
+            self._start_membership_probe(chat_id)
+            return stale_value
 
         # True cache miss (never seen): trigger background probe
         self._start_membership_probe(chat_id)

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Tuple, TYPE_CHECKING
 
 import telegram
 import telegram.error
+from telegram.utils.request import Request
 
 if TYPE_CHECKING:
     pass
@@ -40,7 +41,8 @@ class AuxiliaryBot:
         if base_file_url:
             kwargs['base_file_url'] = base_file_url
         if request_kwargs:
-            kwargs['request_kwargs'] = request_kwargs
+            # Match telegram.ext.Updater: pass a Request instance, not request_kwargs (PTB 13.11+).
+            kwargs['request'] = Request(**request_kwargs)
 
         self.bot: telegram.Bot = telegram.Bot(token=token, **kwargs)
 

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+
+import bisect
+import logging
+import threading
+import time
+from collections import defaultdict, deque
+from typing import Optional, Dict, Tuple, TYPE_CHECKING
+
+import telegram
+import telegram.error
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class AuxiliaryBot:
+    """Lightweight wrapper around telegram.Bot for send-only auxiliary bots.
+
+    Each instance has its own independent sliding-window rate limiter
+    and a non-blocking group membership cache with TTL-based refresh.
+    """
+
+    MEMBERSHIP_TTL_MEMBER = 1800.0      # 30 min for confirmed member
+    MEMBERSHIP_TTL_NOT_MEMBER = 300.0   # 5 min for non-member (re-check sooner)
+
+    def __init__(self, token: str, *,
+                 request_kwargs: Optional[dict] = None,
+                 base_url: Optional[str] = None,
+                 base_file_url: Optional[str] = None,
+                 global_limit: int = 30,
+                 global_window: float = 1.0,
+                 chat_limit: int = 20,
+                 chat_window: float = 60.0):
+        kwargs = {}
+        if base_url:
+            kwargs['base_url'] = base_url
+        if base_file_url:
+            kwargs['base_file_url'] = base_file_url
+        if request_kwargs:
+            kwargs['request_kwargs'] = request_kwargs
+
+        self.bot: telegram.Bot = telegram.Bot(token=token, **kwargs)
+
+        # Identity (populated by initialize())
+        self.bot_id: int = 0
+        self.username: str = ""
+        self.disabled: bool = False
+        self._disable_reason: str = ""
+
+        # Rate limiting (same structure as TelegramBotManager)
+        self._rate_limit_lock = threading.Lock()
+        self._global_timestamps: list = []
+        self._chat_timestamps: defaultdict = defaultdict(deque)
+        self.GLOBAL_LIMIT = global_limit
+        self.GLOBAL_WINDOW = global_window
+        self.CHAT_LIMIT = chat_limit
+        self.CHAT_WINDOW = chat_window
+
+        # Membership cache: chat_id -> (is_member, timestamp)
+        self._membership_cache: Dict[int, Tuple[bool, float]] = {}
+        self._membership_lock = threading.Lock()
+        self._pending_probes: set = set()
+
+    def initialize(self) -> bool:
+        """Call get_me() to validate token and cache identity.
+        Returns True on success, False on failure (bot is disabled).
+        """
+        try:
+            me = self.bot.get_me()
+            self.bot_id = me.id
+            self.username = me.username or ""
+            logger.info("Auxiliary bot initialized: @%s (id=%d)", self.username, self.bot_id)
+            return True
+        except telegram.error.Unauthorized as e:
+            self.disabled = True
+            self._disable_reason = str(e)
+            logger.error("Failed to initialize auxiliary bot: %s", e)
+            return False
+        except Exception as e:
+            self.disabled = True
+            self._disable_reason = str(e)
+            logger.error("Failed to initialize auxiliary bot: %s", e)
+            return False
+
+    def _cleanup_old_timestamps(self):
+        """Remove timestamps older than the time window (called under lock)."""
+        current_time = time.time()
+        while self._global_timestamps and self._global_timestamps[0] <= current_time - self.GLOBAL_WINDOW:
+            self._global_timestamps.pop(0)
+        for _chat_id, timestamps in self._chat_timestamps.items():
+            while timestamps and timestamps[0] <= current_time - self.CHAT_WINDOW:
+                timestamps.popleft()
+
+    def peek_delay(self, chat_id: int) -> float:
+        """Check rate limit delay without reserving a slot. Thread-safe."""
+        with self._rate_limit_lock:
+            current_time = time.time()
+            self._cleanup_old_timestamps()
+
+            # Chat-specific check
+            chat_delay = 0.0
+            chat_timestamps = self._chat_timestamps[chat_id]
+            if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
+                safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
+                reference_timestamp = chat_timestamps[safe_index]
+                chat_delay = max(0.0, (reference_timestamp + self.CHAT_WINDOW) - current_time)
+
+            candidate_time = current_time + chat_delay
+
+            # Global limit check
+            while True:
+                left_bound = candidate_time - self.GLOBAL_WINDOW
+                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                in_window = right_idx - idx
+                if in_window < self.GLOBAL_LIMIT - 2:
+                    break
+                candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+
+            return max(0.0, candidate_time - current_time)
+
+    def reserve_slot(self, chat_id: int) -> float:
+        """Reserve a send slot and return the delay. Thread-safe."""
+        with self._rate_limit_lock:
+            current_time = time.time()
+            self._cleanup_old_timestamps()
+
+            chat_delay = 0.0
+            chat_timestamps = self._chat_timestamps[chat_id]
+            if len(chat_timestamps) >= self.CHAT_LIMIT - 2:
+                safe_index = len(chat_timestamps) - (self.CHAT_LIMIT - 2)
+                reference_timestamp = chat_timestamps[safe_index]
+                chat_delay = max(0.0, (reference_timestamp + self.CHAT_WINDOW) - current_time)
+
+            candidate_time = current_time + chat_delay
+
+            while True:
+                left_bound = candidate_time - self.GLOBAL_WINDOW
+                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
+                in_window = right_idx - idx
+                if in_window < self.GLOBAL_LIMIT - 2:
+                    break
+                candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
+
+            delay = max(0.0, candidate_time - current_time)
+            bisect.insort(self._global_timestamps, candidate_time)
+            chat_timestamps.append(candidate_time)
+            return delay
+
+    def check_membership(self, chat_id: int) -> bool:
+        """Return cached membership status. On cache miss, trigger a
+        background probe and return False (non-blocking)."""
+        with self._membership_lock:
+            entry = self._membership_cache.get(chat_id)
+            if entry is not None:
+                is_member, timestamp = entry
+                ttl = self.MEMBERSHIP_TTL_MEMBER if is_member else self.MEMBERSHIP_TTL_NOT_MEMBER
+                if time.time() - timestamp < ttl:
+                    return is_member
+
+        # Cache miss or expired: trigger background probe
+        self._start_membership_probe(chat_id)
+        return False
+
+    def update_membership(self, chat_id: int, is_member: bool):
+        """Update the membership cache directly (e.g. from chat_left handler)."""
+        with self._membership_lock:
+            self._membership_cache[chat_id] = (is_member, time.time())
+
+    def _start_membership_probe(self, chat_id: int):
+        """Start a background thread to check membership via get_chat_member API."""
+        with self._membership_lock:
+            if chat_id in self._pending_probes:
+                return
+            self._pending_probes.add(chat_id)
+
+        thread = threading.Thread(
+            target=self._probe_membership,
+            args=(chat_id,),
+            daemon=True,
+            name=f"AuxBotMemberProbe-{self.bot_id}-{chat_id}"
+        )
+        thread.start()
+
+    def _probe_membership(self, chat_id: int):
+        """Background probe: call get_chat_member and update cache."""
+        try:
+            member = self.bot.get_chat_member(chat_id, self.bot_id)
+            is_member = member.status in ('member', 'administrator', 'creator', 'restricted')
+            self.update_membership(chat_id, is_member)
+            logger.debug("Membership probe for bot %d in chat %d: %s (status=%s)",
+                         self.bot_id, chat_id, is_member, member.status)
+        except telegram.error.Unauthorized:
+            self.disabled = True
+            self._disable_reason = "Unauthorized during membership probe"
+            logger.error("Auxiliary bot %d got Unauthorized during membership probe", self.bot_id)
+        except telegram.error.BadRequest as e:
+            self.update_membership(chat_id, False)
+            logger.debug("Membership probe for bot %d in chat %d failed: %s", self.bot_id, chat_id, e)
+        except Exception as e:
+            self.update_membership(chat_id, False)
+            logger.warning("Membership probe failed for bot %d in chat %d: %s", self.bot_id, chat_id, e)
+        finally:
+            with self._membership_lock:
+                self._pending_probes.discard(chat_id)
+
+    def has_pending_probes(self) -> bool:
+        """Check if there are any pending membership probes."""
+        with self._membership_lock:
+            return bool(self._pending_probes)
+
+    def mark_disabled(self, reason: str = ""):
+        """Mark this bot as permanently disabled for this session."""
+        self.disabled = True
+        self._disable_reason = reason
+        logger.error("Auxiliary bot @%s (id=%d) disabled: %s", self.username, self.bot_id, reason)
+
+    def __repr__(self):
+        return f"AuxiliaryBot(@{self.username}, id={self.bot_id}, disabled={self.disabled})"

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -112,10 +112,12 @@ class AuxiliaryBot:
 
             candidate_time = current_time + chat_delay
 
-            # Global limit check
+            # Global limit check — use bisect_right for left bound so the
+            # window is half-open (left_bound, candidate_time], preventing an
+            # infinite loop when timestamps cluster on the boundary.
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
-                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
                 right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
@@ -141,7 +143,7 @@ class AuxiliaryBot:
 
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
-                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
                 right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -155,16 +155,25 @@ class AuxiliaryBot:
 
     def check_membership(self, chat_id: int) -> bool:
         """Return cached membership status. On cache miss, trigger a
-        background probe and return False (non-blocking)."""
+        background probe and return False (non-blocking).
+
+        Uses stale-while-revalidate: if cached value exists but is expired,
+        return the stale value while refreshing in the background. This avoids
+        false "not a member" results when all bots' caches expire simultaneously.
+        """
         with self._membership_lock:
             entry = self._membership_cache.get(chat_id)
             if entry is not None:
                 is_member, timestamp = entry
                 ttl = self.MEMBERSHIP_TTL_MEMBER if is_member else self.MEMBERSHIP_TTL_NOT_MEMBER
-                if time.time() - timestamp < ttl:
+                age = time.time() - timestamp
+                if age < ttl:
                     return is_member
+                # Stale but exists: return stale value, refresh in background
+                self._start_membership_probe(chat_id)
+                return is_member
 
-        # Cache miss or expired: trigger background probe
+        # True cache miss (never seen): trigger background probe
         self._start_membership_probe(chat_id)
         return False
 

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -153,6 +153,11 @@ class AuxiliaryBot:
             chat_timestamps.append(candidate_time)
             return delay
 
+    # Tri-state membership results
+    MEMBERSHIP_MEMBER = True
+    MEMBERSHIP_NOT_MEMBER = False
+    MEMBERSHIP_UNKNOWN = None
+
     def check_membership(self, chat_id: int) -> bool:
         """Return cached membership status. On cache miss, trigger a
         background probe and return False (non-blocking).
@@ -161,6 +166,16 @@ class AuxiliaryBot:
         return the stale value while refreshing in the background. This avoids
         false "not a member" results when all bots' caches expire simultaneously.
         """
+        result = self.check_membership_tri(chat_id)
+        if result is None:
+            return False
+        return result
+
+    def check_membership_tri(self, chat_id: int):
+        """Tri-state membership check: True (member), False (confirmed not member),
+        None (unknown / probe in progress).
+        """
+        stale_value = None
         need_probe = False
         with self._membership_lock:
             entry = self._membership_cache.get(chat_id)
@@ -170,7 +185,6 @@ class AuxiliaryBot:
                 age = time.time() - timestamp
                 if age < ttl:
                     return is_member
-                # Stale but exists: flag for background refresh, return stale value
                 need_probe = True
                 stale_value = is_member
 
@@ -178,8 +192,35 @@ class AuxiliaryBot:
             self._start_membership_probe(chat_id)
             return stale_value
 
-        # True cache miss (never seen): trigger background probe
         self._start_membership_probe(chat_id)
+        return None
+
+    def check_membership_sync(self, chat_id: int, timeout: float = 5.0) -> bool:
+        """Blocking membership check. Waits for a pending probe to finish,
+        or runs one synchronously if no cache entry exists."""
+        with self._membership_lock:
+            entry = self._membership_cache.get(chat_id)
+            if entry is not None:
+                is_member, timestamp = entry
+                ttl = self.MEMBERSHIP_TTL_MEMBER if is_member else self.MEMBERSHIP_TTL_NOT_MEMBER
+                if time.time() - timestamp < ttl:
+                    return is_member
+
+        # Trigger probe if not already running
+        self._start_membership_probe(chat_id)
+
+        # Wait for the probe to finish
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._membership_lock:
+                if chat_id not in self._pending_probes:
+                    entry = self._membership_cache.get(chat_id)
+                    if entry is not None:
+                        return entry[0]
+                    return False
+            time.sleep(0.05)
+
+        logger.warning("Membership sync check timed out for bot %d in chat %d", self.bot_id, chat_id)
         return False
 
     def update_membership(self, chat_id: int, is_member: bool):

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -138,10 +138,12 @@ class TelegramBotManager(LocaleMixin):
                     has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
                     if not has_callback:
                         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
-                        slot = self.bot_pool.acquire_send_slot(chat_id) if main_delay > 0 else None
+                        slot = self.bot_pool.acquire_send_slot(chat_id, max_delay=main_delay) if main_delay > 0 else None
                         if slot is not None:
-                            aux_bot, delay = slot
+                            aux_bot, aux_delay = slot
                             try:
+                                if aux_delay > 0:
+                                    time.sleep(aux_delay)
                                 with self._using_bot(aux_bot.bot):
                                     result = fn(self, *args, **kwargs)
                                 if result and hasattr(result, '__dict__'):
@@ -543,21 +545,23 @@ class TelegramBotManager(LocaleMixin):
         """
         deadline = time.time() + timeout
         while time.time() < deadline:
-            # Try aux bots first (higher aggregate throughput)
+            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+
+            # Try aux bots first if they can beat the main bot
             if self.bot_pool:
-                slot = self.bot_pool.acquire_send_slot(chat_id)
+                slot = self.bot_pool.acquire_send_slot(chat_id, max_delay=max(main_delay, 0.01))
                 if slot is not None:
-                    aux_bot, _ = slot
+                    aux_bot, aux_delay = slot
+                    if aux_delay > 0:
+                        time.sleep(aux_delay)
                     try:
                         with self._using_bot(aux_bot.bot):
                             return send_callable(_bypass_rate_limit=True)
                     except telegram.error.Unauthorized:
                         aux_bot.mark_disabled("Unauthorized during migration send")
                         self._notify_admin_disabled_bot(aux_bot)
-                        # Fall through and retry with another bot
 
-            # Try main bot (peek only to avoid wasting a slot)
-            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+            # Try main bot
             if main_delay == 0.0:
                 self._calculate_rate_limit_delay(chat_id)  # reserve
                 return send_callable(_bypass_rate_limit=True)
@@ -741,7 +745,7 @@ class TelegramBotManager(LocaleMixin):
                         result = None
                         routed_to_aux = False
                         if self.bot_pool and task.chat_id:
-                            slot = self.bot_pool.acquire_send_slot(task.chat_id)
+                            slot = self.bot_pool.acquire_send_slot(task.chat_id, max_delay=0.01)
                             if slot is not None:
                                 aux_bot, _ = slot
                                 try:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -132,11 +132,13 @@ class TelegramBotManager(LocaleMixin):
                     return fn(self, *args, **kwargs)
 
                 # MODE 2: Pool routing (new sends pick best available bot)
+                # Only attempt aux bots when the main bot would impose a delay.
                 if chat_id and self.bot_pool:
                     # Skip pool for messages with callback keyboards (EC-4)
                     has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
                     if not has_callback:
-                        slot = self.bot_pool.acquire_send_slot(chat_id)
+                        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+                        slot = self.bot_pool.acquire_send_slot(chat_id) if main_delay > 0 else None
                         if slot is not None:
                             aux_bot, delay = slot
                             try:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -9,8 +9,9 @@ import os
 import threading
 import time
 from collections import defaultdict, deque
+from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, Callable, Deque, List, NamedTuple, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 from unittest.mock import Mock
@@ -18,10 +19,12 @@ from unittest.mock import Mock
 import telegram.constants
 import telegram.error
 from retrying import retry
-from telegram import File, ForumTopic, InputFile, Update, User
+from telegram import File, ForumTopic, InlineKeyboardMarkup, InputFile, Update, User
 from telegram import Message as TelegramMessage
 from telegram.ext import CallbackContext, Dispatcher, Filters, MessageHandler, Updater
 
+from .auxiliary_bot import AuxiliaryBot
+from .bot_pool import BotPool
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
 from .msg_type import get_msg_type
@@ -41,6 +44,17 @@ if TYPE_CHECKING:
     from . import TelegramChannel
 
 MAX_CALLBACK_QUERY_ANSWER_LENGTH = 200
+
+
+def _has_callback_keyboard(reply_markup) -> bool:
+    """Check if a reply_markup contains InlineKeyboardButtons with callback_data."""
+    if not isinstance(reply_markup, InlineKeyboardMarkup):
+        return False
+    for row in reply_markup.inline_keyboard:
+        for button in row:
+            if button.callback_data and button.callback_data != "void":
+                return True
+    return False
 
 
 class TelegramBotManager(LocaleMixin):
@@ -79,12 +93,18 @@ class TelegramBotManager(LocaleMixin):
 
         @classmethod
         def rate_limit_decorator(cls, fn: Callable):
-            """Apply rate limiting to API calls."""
+            """Apply rate limiting to API calls with two-mode routing for multi-bot pool."""
             @wraps(fn)
             def rate_limit_wrapper(self: 'TelegramBotManager', *args, **kwargs):
+                # Bypass: caller already reserved a slot and set _using_bot
+                if kwargs.pop('_bypass_rate_limit', False):
+                    return fn(self, *args, **kwargs)
+
+                # Pop the _sender_bot_id kwarg (used for forced routing on edits/deletes)
+                sender_bot_id = kwargs.pop('_sender_bot_id', None)
+
                 # Extract chat_id from arguments
                 chat_id = None
-
                 if args:
                     chat_id = args[0]
                 elif 'chat_id' in kwargs:
@@ -95,8 +115,45 @@ class TelegramBotManager(LocaleMixin):
                     self.logger.warning(f"Delayed worker is stopped. Not scheduling new tasks for chat {chat_id}.")
                     return None
 
-                # Calculate rate limiting delay
+                # MODE 1: Forced routing (edits/deletes must go to the specific bot that sent the original)
+                if sender_bot_id and self.bot_pool:
+                    aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
+                    if aux_bot and not aux_bot.disabled:
+                        try:
+                            with self._using_bot(aux_bot.bot):
+                                result = fn(self, *args, **kwargs)
+                            if result and hasattr(result, '__dict__'):
+                                result._sender_bot_id = str(sender_bot_id)
+                            return result
+                        except telegram.error.Unauthorized:
+                            aux_bot.mark_disabled("Unauthorized during forced-route API call")
+                            self._notify_admin_disabled_bot(aux_bot)
+                    # Fallback: sender bot unavailable, try main bot
+                    return fn(self, *args, **kwargs)
+
+                # MODE 2: Pool routing (new sends pick best available bot)
+                if chat_id and self.bot_pool:
+                    # Skip pool for messages with callback keyboards (EC-4)
+                    has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
+                    if not has_callback:
+                        slot = self.bot_pool.acquire_send_slot(chat_id)
+                        if slot is not None:
+                            aux_bot, delay = slot
+                            try:
+                                with self._using_bot(aux_bot.bot):
+                                    result = fn(self, *args, **kwargs)
+                                if result and hasattr(result, '__dict__'):
+                                    result._sender_bot_id = str(aux_bot.bot_id)
+                                self._record_aux_use(chat_id)
+                                return result
+                            except telegram.error.Unauthorized:
+                                aux_bot.mark_disabled("Unauthorized during pool-route API call")
+                                self._notify_admin_disabled_bot(aux_bot)
+                                # Fallback: continue to main bot path below
+
+                # Default: main bot with rate limit check and delayed queue
                 if chat_id:
+                    # Calculate rate limiting delay
                     delay_time, chat_count, global_count = self._calculate_rate_limit_delay(chat_id)  # pylint: disable=protected-access
 
                     if delay_time > 0:
@@ -263,7 +320,7 @@ class TelegramBotManager(LocaleMixin):
                     msg = fn(self, *args, **kwargs)
                     chat_id = kwargs.get("chat_id", args[0] if len(args) > 0 else "")
                     filename = "%s_%s.txt" % (chat_id, msg.message_id)
-                    self.updater.bot.send_document(chat_id, full_message,
+                    self._active_bot.send_document(chat_id, full_message,
                                                    filename=filename,
                                                    reply_to_message_id=msg.message_id,
                                                    caption=self._("Caption is truncated due to its length. "
@@ -277,12 +334,21 @@ class TelegramBotManager(LocaleMixin):
 
         @classmethod
         def skip_on_rate_limit(cls, fn: Callable):
-            """Skip execution silently if messages are queued. For non-essential calls like typing indicators."""
+            """Skip execution silently if messages are queued or pool is in
+            high-volume mode for the target chat.
+            For non-essential calls like typing indicators."""
+            AUX_USE_RECENCY = 5.0  # seconds
+
             @wraps(fn)
             def skip_wrapper(self: 'TelegramBotManager', *args, **kwargs):
                 with self._delayed_queue_lock:
                     if self._delayed_queue:
                         return None
+
+                # Suppress when aux bots were recently used for this chat
+                chat_id = args[0] if args else kwargs.get('chat_id')
+                if chat_id and self._aux_recent_use.get(chat_id, 0) > time.time() - AUX_USE_RECENCY:
+                    return None
 
                 try:
                     return fn(self, *args, **kwargs)
@@ -353,7 +419,16 @@ class TelegramBotManager(LocaleMixin):
         self.CHAT_WINDOW = 60.0
 
         self._cleanup_tls = threading.local()  # Thread-local for pending cleanup files
+        self._tls = threading.local()  # Thread-local for bot override (_active_bot)
+        self._aux_recent_use: dict[int, float] = {}  # chat_id -> timestamp of last aux bot use
         self.logger.debug("Rate limiter initialized...")
+
+        # Initialize auxiliary bot pool
+        self.bot_pool: Optional[BotPool] = None
+        aux_configs = config.get('auxiliary_bots', [])
+        if aux_configs:
+            self._init_bot_pool(aux_configs, config, channel)
+        self.logger.debug("Bot pool initialization complete...")
 
         # Initialize delayed message queue system
         self._delayed_queue: List[Tuple[float, int, DelayedTask]] = []
@@ -379,6 +454,119 @@ class TelegramBotManager(LocaleMixin):
         self.Decorators.enable_retry = channel.flag('retry_on_error')
         self.logger.debug("Base dispatchers added...")
 
+    def _init_bot_pool(self, aux_configs: list, config: dict, channel: 'TelegramChannel'):
+        """Initialize the auxiliary bot pool from config."""
+        req_kwargs = {'read_timeout': 15}
+        conf_req_kwargs = config.get('request_kwargs')
+        if isinstance(conf_req_kwargs, collections.abc.Mapping):
+            req_kwargs.update(conf_req_kwargs)
+
+        main_token = config['token']
+        seen_tokens = {main_token}
+        aux_bots: list = []
+
+        for entry in aux_configs:
+            if not isinstance(entry, dict) or not isinstance(entry.get('token'), str):
+                self.logger.warning("Invalid auxiliary_bots entry (missing token string), skipping: %s", entry)
+                continue
+            token = entry['token']
+            if token in seen_tokens:
+                self.logger.warning("Duplicate bot token in auxiliary_bots, skipping")
+                continue
+            seen_tokens.add(token)
+
+            aux_bot = AuxiliaryBot(
+                token=token,
+                request_kwargs=req_kwargs,
+                base_url=channel.flag('api_base_url') or None,
+                base_file_url=channel.flag('api_base_file_url') or None,
+                global_limit=self.GLOBAL_LIMIT,
+                global_window=self.GLOBAL_WINDOW,
+                chat_limit=self.CHAT_LIMIT,
+                chat_window=self.CHAT_WINDOW,
+            )
+            if aux_bot.initialize():
+                aux_bots.append(aux_bot)
+            else:
+                self.logger.error("Skipping auxiliary bot with invalid token")
+
+        if aux_bots:
+            self.bot_pool = BotPool(aux_bots, self)
+            self.logger.info("Initialized bot pool with %d auxiliary bot(s)", len(aux_bots))
+
+    @property
+    def _active_bot(self):
+        """Return the bot to use for the current send operation.
+        Thread-safe: each thread has its own override slot."""
+        return getattr(self._tls, 'override_bot', None) or self.updater.bot
+
+    @contextmanager
+    def _using_bot(self, bot):
+        """Context manager to temporarily route sends through a different bot."""
+        old = getattr(self._tls, 'override_bot', None)
+        self._tls.override_bot = bot
+        try:
+            yield
+        finally:
+            self._tls.override_bot = old
+
+    def _record_aux_use(self, chat_id: int):
+        """Record that an aux bot was used for a chat (for typing suppression)."""
+        self._aux_recent_use[chat_id] = time.time()
+
+    def _notify_admin_disabled_bot(self, aux_bot: AuxiliaryBot):
+        """Send one-shot notification to admin that an aux bot was disabled."""
+        def _notify():
+            try:
+                admin_id = self.admins[0]
+                self.updater.bot.send_message(
+                    admin_id,
+                    f"⚠️ Auxiliary bot @{aux_bot.username} (id={aux_bot.bot_id}) has been "
+                    f"disabled: {aux_bot._disable_reason}. Please check the token in config."
+                )
+            except Exception as e:
+                self.logger.warning("Failed to notify admin about disabled aux bot: %s", e)
+
+        threading.Thread(target=_notify, daemon=True, name="AuxBotDisabledNotify").start()
+
+    def send_blocking_migration(self, chat_id: int, send_callable: Callable,
+                                timeout: float = 60.0):
+        """Block until any bot (main or aux) has a free slot, then send through it.
+
+        The callable receives a single ``_bypass_rate_limit=True`` kwarg that
+        the caller must forward to the decorated send method so the decorator
+        skips its own routing/reservation.
+
+        Returns whatever the send_callable returns.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            # Try aux bots first (higher aggregate throughput)
+            if self.bot_pool:
+                slot = self.bot_pool.acquire_send_slot(chat_id)
+                if slot is not None:
+                    aux_bot, _ = slot
+                    try:
+                        with self._using_bot(aux_bot.bot):
+                            return send_callable(_bypass_rate_limit=True)
+                    except telegram.error.Unauthorized:
+                        aux_bot.mark_disabled("Unauthorized during migration send")
+                        self._notify_admin_disabled_bot(aux_bot)
+                        # Fall through and retry with another bot
+
+            # Try main bot (peek only to avoid wasting a slot)
+            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+            if main_delay == 0.0:
+                self._calculate_rate_limit_delay(chat_id)  # reserve
+                return send_callable(_bypass_rate_limit=True)
+
+            time.sleep(0.2)
+
+        # Timeout fallback: reserve on main and send anyway
+        self.logger.warning("send_blocking_migration timed out for chat %d, sending on main bot", chat_id)
+        self._calculate_rate_limit_delay(chat_id)
+        return send_callable(_bypass_rate_limit=True)
+
     def _cleanup_old_timestamps(self):
         """Remove timestamps older than the time window."""
         current_time = time.time()
@@ -391,13 +579,15 @@ class TelegramBotManager(LocaleMixin):
             while timestamps and timestamps[0] <= current_time - self.CHAT_WINDOW:
                 timestamps.popleft()
 
-    def _calculate_rate_limit_delay(self, chat_id: int):
+    def _calculate_rate_limit_delay(self, chat_id: int, peek_only: bool = False):
         """
         Calculate rate limiting delay using sliding window algorithm.
-        This method is stateful and updates the timestamp queues.
 
         Args:
             chat_id: Telegram chat ID
+            peek_only: If True, compute delay without reserving a slot
+                (no insort/append). Used to check main-bot availability
+                before committing to a pool decision.
 
         Returns:
             tuple: (delay_time, chat_count, global_count) - delay in seconds, current queue counts
@@ -438,9 +628,10 @@ class TelegramBotManager(LocaleMixin):
 
             sleep_time = max(0.0, candidate_time - current_time)
 
-            # Record the scheduled time in both queues
-            bisect.insort(self._global_timestamps, candidate_time)
-            chat_timestamps.append(candidate_time)
+            if not peek_only:
+                # Record the scheduled time in both queues
+                bisect.insort(self._global_timestamps, candidate_time)
+                chat_timestamps.append(candidate_time)
 
             chat_count = len(chat_timestamps)
             global_count = len(self._global_timestamps)
@@ -543,7 +734,28 @@ class TelegramBotManager(LocaleMixin):
 
                     try:
                         self.logger.debug(f"Executing delayed task {task.task_id} for chat {task.chat_id}")
-                        result = task.function(*task.args, **task.kwargs)
+
+                        # Re-check pool: if an aux bot has become available, route through it
+                        result = None
+                        routed_to_aux = False
+                        if self.bot_pool and task.chat_id:
+                            slot = self.bot_pool.acquire_send_slot(task.chat_id)
+                            if slot is not None:
+                                aux_bot, _ = slot
+                                try:
+                                    with self._using_bot(aux_bot.bot):
+                                        result = task.function(*task.args, **task.kwargs)
+                                    if result and hasattr(result, '__dict__'):
+                                        result._sender_bot_id = str(aux_bot.bot_id)
+                                    self._record_aux_use(task.chat_id)
+                                    routed_to_aux = True
+                                    self.logger.debug(f"Delayed task {task.task_id} routed to aux bot @{aux_bot.username}")
+                                except telegram.error.Unauthorized:
+                                    aux_bot.mark_disabled("Unauthorized during delayed task")
+                                    self._notify_admin_disabled_bot(aux_bot)
+
+                        if not routed_to_aux:
+                            result = task.function(*task.args, **task.kwargs)
                         self.logger.debug(f"Delayed task {task.task_id} completed successfully")
 
                         # Handle database update for delayed execution
@@ -601,8 +813,12 @@ class TelegramBotManager(LocaleMixin):
                 etm_msg.type_telegram = get_msg_type(real_tg_msg)
                 etm_msg.put_telegram_file(real_tg_msg)
 
+                # Capture sender_bot_id from the real message (annotated by rate_limit_decorator)
+                sender_bot_id = getattr(real_tg_msg, '_sender_bot_id', None)
+
                 # Update database with real message
-                self.channel.db.add_or_update_message_log(etm_msg, real_tg_msg, old_msg_id)
+                self.channel.db.add_or_update_message_log(
+                    etm_msg, real_tg_msg, old_msg_id, sender_bot_id=sender_bot_id)
                 self.logger.debug(f"Updated database with real message for delayed task {task_id}")
             else:
                 self.logger.warning(f"No pending database update found for task {task_id}")
@@ -673,10 +889,10 @@ class TelegramBotManager(LocaleMixin):
                 full_message.truncate()
             else:
                 filename += ".txt"
-            self.updater.bot.send_document(args[0], full_message, filename=filename,
-                                           reply_to_message_id=msg.message_id,
-                                           caption=self._("Message is truncated due to its length. "
-                                                          "Full message is sent as attachment."))
+            self._active_bot.send_document(args[0], full_message, filename=filename,
+                                          reply_to_message_id=msg.message_id,
+                                          caption=self._("Message is truncated due to its length. "
+                                                         "Full message is sent as attachment."))
             return msg
         else:
             kwargs['text'] = prefix + text + suffix
@@ -716,11 +932,11 @@ class TelegramBotManager(LocaleMixin):
                 filename += ".html"
             else:
                 filename += ".txt"
-            self.updater.bot.send_document(kwargs['chat_id'], full_message,
-                                           filename=filename,
-                                           reply_to_message_id=msg.message_id,
-                                           caption=self._("Message is truncated due to its length. "
-                                                          "Full message is sent as attachment."))
+            self._active_bot.send_document(kwargs['chat_id'], full_message,
+                                          filename=filename,
+                                          reply_to_message_id=msg.message_id,
+                                          caption=self._("Message is truncated due to its length. "
+                                                         "Full message is sent as attachment."))
             return msg
         else:
             kwargs['text'] = prefix + text + suffix
@@ -734,11 +950,11 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message: The message sent
         """
         try:
-            return self.updater.bot.send_message(*args, **kwargs)
+            return self._active_bot.send_message(*args, **kwargs)
         except telegram.error.BadRequest as e:
             if e.message.lower().startswith("can't parse entities") and 'parse_mode' in kwargs:
                 kwargs.pop("parse_mode")
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             else:
                 raise e
 
@@ -750,17 +966,17 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message: The message sent
         """
         try:
-            return self.updater.bot.edit_message_text(*args, **kwargs)
+            return self._active_bot.edit_message_text(*args, **kwargs)
         except telegram.error.BadRequest as e:
             if e.message == "Message can't be edited":
                 kwargs['reply_to_message_id'] = kwargs.pop('message_id')
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             elif e.message == "message to edit not found":
                 kwargs.pop('message_id')
-                return self.updater.bot.send_message(*args, **kwargs)
+                return self._active_bot.send_message(*args, **kwargs)
             elif e.message.lower().startswith("can't parse entities") and 'parse_mode' in kwargs:
                 kwargs.pop("parse_mode")
-                return self.updater.bot.edit_message_text(*args, **kwargs)
+                return self._active_bot.edit_message_text(*args, **kwargs)
             else:
                 raise e
 
@@ -786,9 +1002,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_audio(*args, **kwargs)
+            return self._active_bot.send_audio(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -812,9 +1028,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_voice(*args, **kwargs)
+            return self._active_bot.send_voice(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -838,9 +1054,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_video(*args, **kwargs)
+            return self._active_bot.send_video(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -861,7 +1077,7 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        return self.updater.bot.send_document(*args, **kwargs)
+        return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -882,7 +1098,7 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        return self.updater.bot.send_animation(*args, **kwargs)
+        return self._active_bot.send_animation(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
@@ -904,9 +1120,9 @@ class TelegramBotManager(LocaleMixin):
             telegram.Message
         """
         try:
-            return self.updater.bot.send_photo(*args, **kwargs)
+            return self._active_bot.send_photo(*args, **kwargs)
         except telegram.error.BadRequest:
-            return self.updater.bot.send_document(*args, **kwargs)
+            return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.skip_on_rate_limit
     @Decorators.retry_on_timeout
@@ -922,42 +1138,42 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def edit_message_reply_markup(self, *args, **kwargs):
-        return self.updater.bot.edit_message_reply_markup(*args, **kwargs)
+        return self._active_bot.edit_message_reply_markup(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_location(self, *args, **kwargs):
-        return self.updater.bot.send_location(*args, **kwargs)
+        return self._active_bot.send_location(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_venue(self, *args, **kwargs):
-        return self.updater.bot.send_venue(*args, **kwargs)
+        return self._active_bot.send_venue(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def send_sticker(self, *args, **kwargs):
-        return self.updater.bot.send_sticker(*args, **kwargs)
+        return self._active_bot.send_sticker(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def forward_message(self, *args, **kwargs):
-        return self.updater.bot.forward_message(*args, **kwargs)
+        return self._active_bot.forward_message(*args, **kwargs)
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def copy_message(self, *args, **kwargs):
-        return self.updater.bot.copy_message(*args, **kwargs)
+        return self._active_bot.copy_message(*args, **kwargs)
 
     @Decorators.retry_on_timeout
     @Decorators.handle_rate_limit_error
@@ -979,12 +1195,12 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.caption_affix_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_caption(self, *args, **kwargs):
-        return self.updater.bot.edit_message_caption(*args, **kwargs)
+        return self._active_bot.edit_message_caption(*args, **kwargs)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
     def edit_message_media(self, *args, **kwargs):
-        return self.updater.bot.edit_message_media(*args, **kwargs)
+        return self._active_bot.edit_message_media(*args, **kwargs)
 
     def reply_error(self, update, errmsg):
         """
@@ -999,12 +1215,22 @@ class TelegramBotManager(LocaleMixin):
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
     def get_file(self, file_id: str) -> File:
-        return self.updater.bot.get_file(file_id)
+        return self._active_bot.get_file(file_id)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
-    def delete_message(self, chat_id, message_id):
-        return self.updater.bot.delete_message(chat_id, message_id)
+    def delete_message(self, chat_id, message_id, _sender_bot_id=None):
+        if _sender_bot_id and self.bot_pool:
+            aux_bot = self.bot_pool.get_bot_by_id(_sender_bot_id)
+            if aux_bot and not aux_bot.disabled:
+                try:
+                    return aux_bot.bot.delete_message(chat_id, message_id)
+                except telegram.error.Unauthorized:
+                    aux_bot.mark_disabled("Unauthorized during delete_message")
+                    self._notify_admin_disabled_bot(aux_bot)
+                except telegram.error.BadRequest:
+                    pass  # Fall through to main bot
+        return self._active_bot.delete_message(chat_id, message_id)
 
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
@@ -1107,6 +1333,10 @@ class TelegramBotManager(LocaleMixin):
 
         # Stop the delayed message worker first
         self.stop_delayed_worker()
+
+        # Shut down auxiliary bot pool
+        if self.bot_pool:
+            self.bot_pool.shutdown()
 
         # Then stop the updater
         self.logger.debug("Stopping Telegram updater...")

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -623,12 +623,11 @@ class TelegramBotManager(LocaleMixin):
             scan_count = 0
             while True:
                 left_bound = candidate_time - self.GLOBAL_WINDOW
-                idx = bisect.bisect_left(self._global_timestamps, left_bound)
+                idx = bisect.bisect_right(self._global_timestamps, left_bound)
                 right_idx = bisect.bisect_right(self._global_timestamps, candidate_time)
                 in_window = right_idx - idx
                 if in_window < self.GLOBAL_LIMIT - 2:
                     break
-                # Shift to just after the oldest entry in the current window
                 candidate_time = self._global_timestamps[idx] + self.GLOBAL_WINDOW
                 scan_count += 1
 

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -172,7 +172,7 @@ class BotPool:
         try:
             admin_id = self._bot_manager.admins[0]
             bot_links = ", ".join(
-                f'<a href="https://t.me/{b.username}?startgroup=true">@{b.username}</a>'
+                f'<code>@{b.username}</code>'
                 for b in bots if b.username
             )
             if not bot_links:

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -23,16 +23,14 @@ class BotPool:
     - Background membership probes
     """
 
-    NOTIFICATION_COOLDOWN = 3600.0  # 1 hour per (bot_id, chat_id) pair
-
     def __init__(self, aux_bots: List[AuxiliaryBot], bot_manager: 'TelegramBotManager'):
         self._bots: List[AuxiliaryBot] = aux_bots
         self._bot_by_id: Dict[int, AuxiliaryBot] = {b.bot_id: b for b in aux_bots}
         self._bot_manager = bot_manager
         self._pool_lock = threading.Lock()
 
-        # Notification throttle: (bot_id, chat_id) -> last_notification_timestamp
-        self._notification_timestamps: Dict[Tuple[int, int], float] = {}
+        # One notification per chat per process lifetime
+        self._notified_chats: set = set()
         self._notification_lock = threading.Lock()
 
         logger.info("BotPool initialized with %d auxiliary bot(s): %s",
@@ -155,31 +153,15 @@ class BotPool:
                         aux_bot.username, chat_id)
 
     def _maybe_notify_admin(self, chat_id: int, bots_not_in_chat: List[AuxiliaryBot]):
-        """Send throttled notification to admin about aux bots not in a group."""
-        now = time.time()
-        bots_to_notify: List[AuxiliaryBot] = []
-
+        """Send at most one notification per chat per process lifetime."""
         with self._notification_lock:
-            # Purge stale entries older than cooldown + 60s margin
-            cutoff = now - self.NOTIFICATION_COOLDOWN - 60.0
-            stale_keys = [k for k, ts in self._notification_timestamps.items() if ts < cutoff]
-            for k in stale_keys:
-                del self._notification_timestamps[k]
+            if chat_id in self._notified_chats:
+                return
+            self._notified_chats.add(chat_id)
 
-            for aux_bot in bots_not_in_chat:
-                key = (aux_bot.bot_id, chat_id)
-                last_notified = self._notification_timestamps.get(key, 0.0)
-                if now - last_notified >= self.NOTIFICATION_COOLDOWN:
-                    self._notification_timestamps[key] = now
-                    bots_to_notify.append(aux_bot)
-
-        if not bots_to_notify:
-            return
-
-        # Send notification in background to avoid blocking
         thread = threading.Thread(
             target=self._send_admin_notification,
-            args=(chat_id, bots_to_notify),
+            args=(chat_id, bots_not_in_chat),
             daemon=True,
             name=f"BotPoolNotify-{chat_id}"
         )

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -49,15 +49,22 @@ class BotPool:
         except (TypeError, ValueError):
             return None
 
-    def acquire_send_slot(self, chat_id: int) -> Optional[Tuple[AuxiliaryBot, float]]:
+    def acquire_send_slot(self, chat_id: int, max_delay: float = float('inf')
+                          ) -> Optional[Tuple[AuxiliaryBot, float]]:
         """Atomically find the best available auxiliary bot for a chat.
 
-        Iterates aux bots confirmed as members of the chat, peeks their delay,
-        picks the one with delay=0 (or lowest delay), then reserves a slot.
+        Iterates aux bots confirmed as members of the chat, picks the one
+        with the lowest delay, then reserves a slot.
+
+        Args:
+            chat_id: Target Telegram chat.
+            max_delay: Upper bound on acceptable delay. Bots whose delay
+                       >= max_delay are skipped. Pass the main bot's delay
+                       so aux bots are only chosen when they're actually faster.
 
         Returns:
-            (AuxiliaryBot, delay) if an aux bot is available with delay=0,
-            None if all aux bots have delay > 0 or none are members.
+            (AuxiliaryBot, delay) if a suitable aux bot was found,
+            None if no aux bot beats max_delay or none are members.
         """
         with self._pool_lock:
             best_bot: Optional[AuxiliaryBot] = None
@@ -72,21 +79,16 @@ class BotPool:
                     continue
 
                 delay = aux_bot.peek_delay(chat_id)
-                if delay == 0.0:
-                    # Perfect candidate: no delay
-                    best_bot = aux_bot
-                    best_delay = 0.0
-                    break
-                elif delay < best_delay:
+                if delay < best_delay:
                     best_bot = aux_bot
                     best_delay = delay
+                    if delay == 0.0:
+                        break
 
-            if best_bot is not None and best_delay == 0.0:
+            if best_bot is not None and best_delay < max_delay:
                 best_bot.reserve_slot(chat_id)
-                return (best_bot, 0.0)
+                return (best_bot, best_delay)
 
-            # No aux bot available with zero delay;
-            # notify admin about bots not in the group
             if need_member_bots:
                 self._maybe_notify_admin(chat_id, need_member_bots)
 

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -113,6 +113,15 @@ class BotPool:
             time.sleep(0.2)
         return None
 
+    def on_bots_joined_chat(self, bot_ids: list, chat_id: int):
+        """Update membership cache when aux bots are added to a group."""
+        for bot_id in bot_ids:
+            aux_bot = self.get_bot_by_id(bot_id)
+            if aux_bot:
+                aux_bot.update_membership(chat_id, True)
+                logger.info("Auxiliary bot @%s added to chat %d, membership cache updated",
+                            aux_bot.username, chat_id)
+
     def on_bot_left_chat(self, bot_id: int, chat_id: int):
         """Update membership cache when an aux bot is removed from a group."""
         aux_bot = self.get_bot_by_id(bot_id)

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -154,11 +154,20 @@ class BotPool:
             if not bot_mentions:
                 return
 
+            str_id = str(chat_id)
+            if str_id.startswith("-100"):
+                chat_url = f"https://t.me/c/{str_id[4:]}"
+            else:
+                chat_url = f"tg://openmessage?chat_id={chat_id}"
+
             text = (
-                f"📊 Message rate is high in chat {chat_id}. "
+                f'📊 Message rate is high in <a href="{chat_url}">chat {chat_id}</a>. '
                 f"To reduce delay, please add {bot_mentions} to the group."
             )
-            self._bot_manager.updater.bot.send_message(admin_id, text)
+
+            self._bot_manager.updater.bot.send_message(
+                admin_id, text, parse_mode="HTML"
+            )
         except Exception as e:
             logger.warning("Failed to send auxiliary bot notification to admin: %s", e)
 

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -127,6 +127,12 @@ class BotPool:
         bots_to_notify: List[AuxiliaryBot] = []
 
         with self._notification_lock:
+            # Purge stale entries older than cooldown + 60s margin
+            cutoff = now - self.NOTIFICATION_COOLDOWN - 60.0
+            stale_keys = [k for k, ts in self._notification_timestamps.items() if ts < cutoff]
+            for k in stale_keys:
+                del self._notification_timestamps[k]
+
             for aux_bot in bots_not_in_chat:
                 key = (aux_bot.bot_id, chat_id)
                 last_notified = self._notification_timestamps.get(key, 0.0)

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -150,8 +150,11 @@ class BotPool:
         """Send a message to the first admin about adding aux bots to a group."""
         try:
             admin_id = self._bot_manager.admins[0]
-            bot_mentions = ", ".join(f"@{b.username}" for b in bots if b.username)
-            if not bot_mentions:
+            bot_links = ", ".join(
+                f'<a href="https://t.me/{b.username}?startgroup=true">@{b.username}</a>'
+                for b in bots if b.username
+            )
+            if not bot_links:
                 return
 
             str_id = str(chat_id)
@@ -162,7 +165,7 @@ class BotPool:
 
             text = (
                 f'📊 Message rate is high in <a href="{chat_url}">chat {chat_id}</a>. '
-                f"To reduce delay, please add {bot_mentions} to the group."
+                f"To reduce delay, please add {bot_links} to the group."
             )
 
             self._bot_manager.updater.bot.send_message(

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -56,6 +56,9 @@ class BotPool:
         Iterates aux bots confirmed as members of the chat, picks the one
         with the lowest delay, then reserves a slot.
 
+        For bots whose membership is unknown (first encounter / cold start),
+        a synchronous probe is performed so they can participate immediately.
+
         Args:
             chat_id: Target Telegram chat.
             max_delay: Upper bound on acceptable delay. Bots whose delay
@@ -69,13 +72,19 @@ class BotPool:
         with self._pool_lock:
             best_bot: Optional[AuxiliaryBot] = None
             best_delay = float('inf')
-            need_member_bots: List[AuxiliaryBot] = []
+            confirmed_non_member_bots: List[AuxiliaryBot] = []
+            unknown_bots: List[AuxiliaryBot] = []
 
             for aux_bot in self._bots:
                 if aux_bot.disabled:
                     continue
-                if not aux_bot.check_membership(chat_id):
-                    need_member_bots.append(aux_bot)
+
+                status = aux_bot.check_membership_tri(chat_id)
+                if status is None:
+                    unknown_bots.append(aux_bot)
+                    continue
+                if status is False:
+                    confirmed_non_member_bots.append(aux_bot)
                     continue
 
                 delay = aux_bot.peek_delay(chat_id)
@@ -85,12 +94,25 @@ class BotPool:
                     if delay == 0.0:
                         break
 
+            # Cold start: synchronously resolve unknown bots so they can help now
+            if best_bot is None and unknown_bots:
+                for aux_bot in unknown_bots:
+                    if aux_bot.check_membership_sync(chat_id, timeout=3.0):
+                        delay = aux_bot.peek_delay(chat_id)
+                        if delay < best_delay:
+                            best_bot = aux_bot
+                            best_delay = delay
+                            if delay == 0.0:
+                                break
+                    else:
+                        confirmed_non_member_bots.append(aux_bot)
+
             if best_bot is not None and best_delay < max_delay:
                 best_bot.reserve_slot(chat_id)
                 return (best_bot, best_delay)
 
-            if need_member_bots:
-                self._maybe_notify_admin(chat_id, need_member_bots)
+            if confirmed_non_member_bots:
+                self._maybe_notify_admin(chat_id, confirmed_non_member_bots)
 
             return None
 

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -1,0 +1,204 @@
+# coding=utf-8
+
+import logging
+import threading
+import time
+from typing import Optional, List, Dict, Tuple, TYPE_CHECKING
+
+from .auxiliary_bot import AuxiliaryBot
+
+if TYPE_CHECKING:
+    from .bot_manager import TelegramBotManager
+
+logger = logging.getLogger(__name__)
+
+
+class BotPool:
+    """Manages auxiliary bot instances and routes sends to the best available bot.
+
+    Key responsibilities:
+    - Atomic slot acquisition across all bots
+    - O(1) bot lookup by Telegram user ID
+    - Throttled user notifications when aux bots need to be added to groups
+    - Background membership probes
+    """
+
+    NOTIFICATION_COOLDOWN = 3600.0  # 1 hour per (bot_id, chat_id) pair
+
+    def __init__(self, aux_bots: List[AuxiliaryBot], bot_manager: 'TelegramBotManager'):
+        self._bots: List[AuxiliaryBot] = aux_bots
+        self._bot_by_id: Dict[int, AuxiliaryBot] = {b.bot_id: b for b in aux_bots}
+        self._bot_manager = bot_manager
+        self._pool_lock = threading.Lock()
+
+        # Notification throttle: (bot_id, chat_id) -> last_notification_timestamp
+        self._notification_timestamps: Dict[Tuple[int, int], float] = {}
+        self._notification_lock = threading.Lock()
+
+        logger.info("BotPool initialized with %d auxiliary bot(s): %s",
+                     len(aux_bots), [f"@{b.username}" for b in aux_bots])
+
+    @property
+    def bots(self) -> List[AuxiliaryBot]:
+        return self._bots
+
+    def get_bot_by_id(self, bot_id) -> Optional[AuxiliaryBot]:
+        """O(1) lookup by Telegram user ID. Returns None if not found."""
+        try:
+            return self._bot_by_id.get(int(bot_id))
+        except (TypeError, ValueError):
+            return None
+
+    def acquire_send_slot(self, chat_id: int) -> Optional[Tuple[AuxiliaryBot, float]]:
+        """Atomically find the best available auxiliary bot for a chat.
+
+        Iterates aux bots confirmed as members of the chat, peeks their delay,
+        picks the one with delay=0 (or lowest delay), then reserves a slot.
+
+        Returns:
+            (AuxiliaryBot, delay) if an aux bot is available with delay=0,
+            None if all aux bots have delay > 0 or none are members.
+        """
+        with self._pool_lock:
+            best_bot: Optional[AuxiliaryBot] = None
+            best_delay = float('inf')
+            need_member_bots: List[AuxiliaryBot] = []
+
+            for aux_bot in self._bots:
+                if aux_bot.disabled:
+                    continue
+                if not aux_bot.check_membership(chat_id):
+                    need_member_bots.append(aux_bot)
+                    continue
+
+                delay = aux_bot.peek_delay(chat_id)
+                if delay == 0.0:
+                    # Perfect candidate: no delay
+                    best_bot = aux_bot
+                    best_delay = 0.0
+                    break
+                elif delay < best_delay:
+                    best_bot = aux_bot
+                    best_delay = delay
+
+            if best_bot is not None and best_delay == 0.0:
+                best_bot.reserve_slot(chat_id)
+                return (best_bot, 0.0)
+
+            # No aux bot available with zero delay;
+            # notify admin about bots not in the group
+            if need_member_bots:
+                self._maybe_notify_admin(chat_id, need_member_bots)
+
+            return None
+
+    def send_blocking(self, chat_id: int, timeout: float = 60.0) -> Optional[AuxiliaryBot]:
+        """Block until any bot in the pool has a free slot for the given chat.
+        Used by history migration for higher throughput.
+
+        Returns the AuxiliaryBot to use, or None on timeout.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._pool_lock:
+                for aux_bot in self._bots:
+                    if aux_bot.disabled:
+                        continue
+                    if not aux_bot.check_membership(chat_id):
+                        continue
+                    delay = aux_bot.peek_delay(chat_id)
+                    if delay == 0.0:
+                        aux_bot.reserve_slot(chat_id)
+                        return aux_bot
+            time.sleep(0.2)
+        return None
+
+    def on_bot_left_chat(self, bot_id: int, chat_id: int):
+        """Update membership cache when an aux bot is removed from a group."""
+        aux_bot = self.get_bot_by_id(bot_id)
+        if aux_bot:
+            aux_bot.update_membership(chat_id, False)
+            logger.info("Auxiliary bot @%s removed from chat %d, membership cache updated",
+                        aux_bot.username, chat_id)
+
+    def _maybe_notify_admin(self, chat_id: int, bots_not_in_chat: List[AuxiliaryBot]):
+        """Send throttled notification to admin about aux bots not in a group."""
+        now = time.time()
+        bots_to_notify: List[AuxiliaryBot] = []
+
+        with self._notification_lock:
+            for aux_bot in bots_not_in_chat:
+                key = (aux_bot.bot_id, chat_id)
+                last_notified = self._notification_timestamps.get(key, 0.0)
+                if now - last_notified >= self.NOTIFICATION_COOLDOWN:
+                    self._notification_timestamps[key] = now
+                    bots_to_notify.append(aux_bot)
+
+        if not bots_to_notify:
+            return
+
+        # Send notification in background to avoid blocking
+        thread = threading.Thread(
+            target=self._send_admin_notification,
+            args=(chat_id, bots_to_notify),
+            daemon=True,
+            name=f"BotPoolNotify-{chat_id}"
+        )
+        thread.start()
+
+    def _send_admin_notification(self, chat_id: int, bots: List[AuxiliaryBot]):
+        """Send a message to the first admin about adding aux bots to a group."""
+        try:
+            admin_id = self._bot_manager.admins[0]
+            bot_mentions = ", ".join(f"@{b.username}" for b in bots if b.username)
+            if not bot_mentions:
+                return
+
+            text = (
+                f"📊 Message rate is high in chat {chat_id}. "
+                f"To reduce delay, please add {bot_mentions} to the group."
+            )
+            self._bot_manager.updater.bot.send_message(admin_id, text)
+        except Exception as e:
+            logger.warning("Failed to send auxiliary bot notification to admin: %s", e)
+
+    def get_pool_stats(self) -> Dict:
+        """Return per-bot status for monitoring/debugging."""
+        stats = {
+            'total_bots': len(self._bots),
+            'active_bots': sum(1 for b in self._bots if not b.disabled),
+            'bots': []
+        }
+        for bot in self._bots:
+            bot_stats = {
+                'username': bot.username,
+                'bot_id': bot.bot_id,
+                'disabled': bot.disabled,
+                'membership_cache_size': len(bot._membership_cache),
+            }
+            stats['bots'].append(bot_stats)
+        return stats
+
+    def shutdown(self):
+        """Clean up resources during shutdown.
+        Waits for pending membership probes to finish (with timeout)."""
+        logger.info("BotPool shutting down, %d auxiliary bot(s)", len(self._bots))
+
+        deadline = time.time() + 5.0
+        for aux_bot in self._bots:
+            while time.time() < deadline:
+                if not aux_bot.has_pending_probes():
+                    break
+                time.sleep(0.1)
+            else:
+                if aux_bot.has_pending_probes():
+                    logger.warning("Bot @%s still has pending membership probes at shutdown",
+                                   aux_bot.username)
+
+        logger.info("BotPool shutdown complete")
+
+    def __bool__(self):
+        return len(self._bots) > 0
+
+    def __len__(self):
+        return len(self._bots)

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -157,6 +157,8 @@ class ChatBindingManager(LocaleMixin):
         self.bot.dispatcher.add_handler(
             MessageHandler(Filters.status_update.migrate, self.chat_migration))
         self.bot.dispatcher.add_handler(
+            MessageHandler(Filters.status_update.new_chat_members, self.chat_joined))
+        self.bot.dispatcher.add_handler(
             MessageHandler(Filters.status_update.left_chat_member, self.chat_left))
 
     def pre_link_check(self, message: Message):
@@ -1204,6 +1206,18 @@ class ChatBindingManager(LocaleMixin):
                 picture.close()
             if pic_resized and getattr(pic_resized, 'close', None):
                 pic_resized.close()
+
+    def chat_joined(self, update: Update, context: CallbackContext):
+        """Triggered when new members join a chat. Updates aux bot membership cache."""
+        assert isinstance(update, Update)
+        assert update.effective_message
+
+        message = update.effective_message
+        if not message.new_chat_members or not self.bot.bot_pool:
+            return
+
+        joined_ids = [m.id for m in message.new_chat_members]
+        self.bot.bot_pool.on_bots_joined_chat(joined_ids, message.chat.id)
 
     def chat_left(self, update: Update, context: CallbackContext):
         """Triggered by any message update with either

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -1213,9 +1213,20 @@ class ChatBindingManager(LocaleMixin):
         assert update.effective_message
 
         message = update.effective_message
-        if message.left_chat_member is not None and message.left_chat_member.id == self.bot.me.id:
+        if message.left_chat_member is None:
+            return
+
+        left_member_id = message.left_chat_member.id
+
+        # Check if main bot was removed
+        if left_member_id == self.bot.me.id:
             chat_id = ChatID(str(message.chat.id))
             self.db.remove_chat_assoc(master_uid=utils.chat_id_to_str(self.channel.channel_id, chat_id))
+            return
+
+        # Check if an auxiliary bot was removed
+        if self.bot.bot_pool:
+            self.bot.bot_pool.on_bot_left_chat(left_member_id, message.chat.id)
 
     def update_thread_info(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
@@ -1378,19 +1389,15 @@ class ChatBindingManager(LocaleMixin):
                     # Send current text batch if it exists
                     if current_text_batch:
                         try:
-                            self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
+                            self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                             current_text_batch = []
                             current_length = 0
-                            threading.Event().wait(4.0)
                         except Exception as e:
                             self.logger.warning("Failed to send text batch: %s", e)
 
                     # Forward the media message or empty text message
                     try:
-                        self._forward_media_message(msg_log, tg_chat_id, thread_id)
-                        # Add delay after forwarding media
-                        if i < len(recent_messages) - 1:
-                            threading.Event().wait(4.0)
+                        self._migration_forward_media(msg_log, tg_chat_id, thread_id)
                     except Exception as e:
                         self.logger.warning("Failed to forward message %s: %s", msg_log.master_msg_id, e)
                 else:
@@ -1413,9 +1420,7 @@ class ChatBindingManager(LocaleMixin):
                         # Send current batch if it exists
                         if current_text_batch:
                             try:
-                                self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
-                                # Add delay after sending text batch
-                                threading.Event().wait(4.0)
+                                self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                             except Exception as e:
                                 self.logger.warning("Failed to send text batch: %s", e)
 
@@ -1430,15 +1435,15 @@ class ChatBindingManager(LocaleMixin):
             # Send remaining text batch if exists
             if current_text_batch:
                 try:
-                    self._send_text_batch_background(current_text_batch, tg_chat_id, thread_id)
+                    self._migration_send_text(tg_chat_id, current_text_batch, thread_id)
                 except Exception as e:
                     self.logger.warning("Failed to send final text batch: %s", e)
 
         except Exception as e:
             self.logger.error("Error during history migration for %s: %s", slave_chat_id, e)
 
-    def _send_text_batch_background(self, text_batch: List[str], tg_chat_id: int,
-                                   thread_id: Optional[TelegramTopicID] = None):
+    def _migration_send_text(self, tg_chat_id: int, text_batch: List[str],
+                             thread_id: Optional[TelegramTopicID] = None):
         """Send a batch of formatted text messages.
 
         Args:
@@ -1450,47 +1455,56 @@ class ChatBindingManager(LocaleMixin):
             return
 
         combined_text = "".join(text_batch)
-
-        kwargs = {
+        kwargs: dict = {
             'chat_id': tg_chat_id,
             'text': combined_text,
             'parse_mode': 'Markdown',
             'disable_notification': True
         }
-
         if thread_id:
             kwargs['message_thread_id'] = thread_id
 
-        try:
-            self.bot.send_message(**kwargs)
-        except Exception as e:
-            self.logger.warning("Failed to send with Markdown, trying plain text: %s", e)
-            kwargs['parse_mode'] = None
-            kwargs['text'] = combined_text.replace('*', '').replace('`', '')
-            self.bot.send_message(**kwargs)
+        def _do_send(**extra):
+            kw = {**kwargs, **extra}
+            try:
+                self.bot.send_message(**kw)
+            except Exception:
+                kw['parse_mode'] = None
+                kw['text'] = combined_text.replace('*', '').replace('`', '')
+                self.bot.send_message(**kw)
 
-    def _forward_media_message(self, msg_log: MsgLog, tg_chat_id: int,
-                             thread_id: Optional[TelegramTopicID] = None):
-        """Forward(Actually copy for better user experience) a media message to the target chat."""
-        # Parse the original message ID
+        if self.bot.bot_pool:
+            self.bot.send_blocking_migration(tg_chat_id, _do_send, timeout=30.0)
+        else:
+            _do_send(_bypass_rate_limit=False)
+
+    def _migration_forward_media(self, msg_log, tg_chat_id: int,
+                                  thread_id: Optional[TelegramTopicID] = None):
+        """Wait for a slot, then forward a media message through the best available bot."""
         try:
+            # Parse the original message ID
             original_chat_id, original_msg_id = utils.message_id_str_to_id(msg_log.master_msg_id)
-
-            # Use copy_message to copy the media
-            kwargs = {
-                'chat_id': tg_chat_id,
-                'from_chat_id': original_chat_id,
-                'message_id': original_msg_id,
-                'disable_notification': True
-            }
-
-            if thread_id:
-                kwargs['message_thread_id'] = thread_id
-
-            self.bot.copy_message(**kwargs)
-
         except Exception as e:
-            self.logger.warning("Failed to forward media message %s: %s", msg_log.master_msg_id, e)
+            self.logger.warning("Failed to parse message ID %s: %s", msg_log.master_msg_id, e)
+            return
+
+        # Use copy_message to copy the media
+        kwargs: dict = {
+            'chat_id': tg_chat_id,
+            'from_chat_id': original_chat_id,
+            'message_id': original_msg_id,
+            'disable_notification': True
+        }
+        if thread_id:
+            kwargs['message_thread_id'] = thread_id
+
+        def _do_copy(**extra):
+            self.bot.copy_message(**{**kwargs, **extra})
+
+        if self.bot.bot_pool:
+            self.bot.send_blocking_migration(tg_chat_id, _do_copy, timeout=30.0)
+        else:
+            _do_copy(_bypass_rate_limit=False)
 
     @staticmethod
     def truncate_ellipsis(text: str, length: int) -> str:

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -102,6 +102,8 @@ class MsgLog(BaseModel):
     """
     sent_to = TextField()
     """Module ID of the message sent to."""
+    sender_bot_id = TextField(null=True)
+    """Telegram bot user ID that sent this message. NULL means the main bot."""
     time = DateTimeField(default=datetime.datetime.now, null=True)
     """Time of the message sent."""
 
@@ -121,6 +123,7 @@ class MsgLog(BaseModel):
             mime=self.mime or None,
             file_id=self.file_id or None,
         )
+        msg.sender_bot_id = self.sender_bot_id
         with suppress(NameError):
             to_module = coordinator.get_module_by_id(self.sent_to)
             if isinstance(to_module, Channel):
@@ -315,6 +318,8 @@ class DatabaseManager:
             self._migrate(2)
         elif "file_unique_id" not in msg_log_columns:
             self._migrate(3)
+        elif "sender_bot_id" not in msg_log_columns:
+            self._migrate(4)
 
     def _migrate(self, i: int):
         """
@@ -352,6 +357,11 @@ class DatabaseManager:
             # 2019NOV18
             migrate(
                 migrator.add_column("msglog", "file_unique_id", MsgLog.file_unique_id)
+            )
+        if i <= 4:
+            # Migration 4: Add column for sender bot ID (multi-bot pool support)
+            migrate(
+                migrator.add_column("msglog", "sender_bot_id", MsgLog.sender_bot_id)
             )
 
     def add_chat_assoc(self, master_uid: EFBChannelChatIDStr,
@@ -597,7 +607,8 @@ class DatabaseManager:
     def add_or_update_message_log(self,
                                   msg: ETMMsg,
                                   master_message: Message,
-                                  old_message_id: Optional[OldMsgID] = None):
+                                  old_message_id: Optional[OldMsgID] = None,
+                                  sender_bot_id: Optional[str] = None):
         """Add or update a message into the database."""
         master_msg_id = message_id_to_str(TelegramChatID(master_message.chat_id), TelegramMessageID(master_message.message_id))
         master_msg_id_alt = None
@@ -632,6 +643,7 @@ class DatabaseManager:
         row.file_id = msg.file_id
         row.file_unique_id = msg.file_unique_id
         row.mime = msg.mime
+        row.sender_bot_id = sender_bot_id or getattr(msg, 'sender_bot_id', None)
         pickle_data = self.pickle_misc_msg(msg)
         if pickle_data:
             row.pickle = pickle_data

--- a/efb_telegram_master/message.py
+++ b/efb_telegram_master/message.py
@@ -32,6 +32,8 @@ class ETMMsg(Message):
     """File ID from Telegram Bot API"""
     file_unique_id: Optional[str] = None
     """Unique file ID from Telegram Bot API"""
+    sender_bot_id: Optional[str] = None
+    """Telegram bot user ID that sent this message. None means the main bot."""
     type_telegram: TGMsgType
     """Type of message in Telegram Bot API"""
     chat: ETMChatType
@@ -60,13 +62,33 @@ class ETMMsg(Message):
     def _load_file(self):
         if self.file_id:
             # noinspection PyUnresolvedReferences
-            bot = coordinator.master.bot_manager
+            bot_manager = coordinator.master.bot_manager
+
+            # Route get_file through the correct bot based on sender_bot_id
+            file_bot = None
+            if self.sender_bot_id:
+                bot_pool = getattr(bot_manager, 'bot_pool', None)
+                if bot_pool:
+                    aux_bot = bot_pool.get_bot_by_id(self.sender_bot_id)
+                    if aux_bot and not aux_bot.disabled:
+                        file_bot = aux_bot.bot
 
             try:
-                file_meta = bot.get_file(self.file_id)
+                if file_bot:
+                    file_meta = file_bot.get_file(self.file_id)
+                else:
+                    file_meta = bot_manager.get_file(self.file_id)
             except BadRequest as e:
-                logger.exception("Bad request while trying to get file metadata: %s", e)
-                return
+                if file_bot:
+                    logger.warning("Failed to get file from aux bot, trying main bot: %s", e)
+                    try:
+                        file_meta = bot_manager.get_file(self.file_id)
+                    except BadRequest as e2:
+                        logger.exception("Bad request from main bot too: %s", e2)
+                        return
+                else:
+                    logger.exception("Bad request while trying to get file metadata: %s", e)
+                    return
             if not self.mime:
                 ext = os.path.splitext(file_meta.file_path)[1]
                 mime = mimetypes.guess_type(file_meta.file_path, strict=False)[0]

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -55,6 +55,18 @@ class SlaveMessageProcessor(LocaleMixin):
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
 
+    def _get_edit_context(self, msg: Message):
+        """Get a context manager for routing edits through the correct bot.
+        Returns the bot_manager's _using_bot context manager if sender_bot_id is set,
+        otherwise returns a no-op context manager."""
+        from contextlib import nullcontext
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+        if _sender_bot_id and self.bot.bot_pool:
+            aux_bot = self.bot.bot_pool.get_bot_by_id(_sender_bot_id)
+            if aux_bot and not aux_bot.disabled:
+                return self.bot._using_bot(aux_bot.bot)
+        return nullcontext()
+
     def is_silent(self, msg: Message) -> Optional[bool]:
         """Determine if a message shall be sent silently.
         Returns None if the message shall not be sent at all.
@@ -104,10 +116,12 @@ class SlaveMessageProcessor(LocaleMixin):
 
             # When editing message
             old_msg_id: Optional[OldMsgID] = None
+            _edit_sender_bot_id: Optional[str] = None
             if msg.edit:
                 old_msg = self.db.get_msg_log(slave_msg_id=msg.uid,
                                               slave_origin_uid=utils.chat_id_to_str(chat=msg.chat))
                 if old_msg:
+                    _edit_sender_bot_id = old_msg.sender_bot_id
 
                     if old_msg.master_msg_id_alt:
                         old_msg_id = utils.message_id_str_to_id(old_msg.master_msg_id_alt)
@@ -117,6 +131,11 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.info('[%s] Was supposed to edit this message, '
                                      'but it does not exist in database. Sending new message instead.',
                                      msg.uid)
+
+            # Store sender_bot_id for routing edits to the correct bot
+            if _edit_sender_bot_id:
+                msg.vendor_specific = msg.vendor_specific or {}
+                msg.vendor_specific['_sender_bot_id'] = _edit_sender_bot_id
 
             self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
         except Exception as e:
@@ -264,7 +283,12 @@ class SlaveMessageProcessor(LocaleMixin):
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
             etm_msg.type_telegram = get_msg_type(tg_msg)
             etm_msg.put_telegram_file(tg_msg)
-            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id)
+
+            # Capture sender_bot_id annotated by rate_limit_decorator
+            sender_bot_id = getattr(tg_msg, '_sender_bot_id', None)
+
+            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id,
+                                              sender_bot_id=sender_bot_id)
             # self.logger.debug("[%s] Message inserted/updated to the database.", xid)
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:
@@ -376,6 +400,8 @@ class SlaveMessageProcessor(LocaleMixin):
 
         text = self.html_substitutions(msg)
 
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+
         if not old_msg_id:
             tg_msg = self.bot.send_message(tg_dest,
                                            text=text, prefix=msg_template, suffix=reactions,
@@ -386,11 +412,14 @@ class SlaveMessageProcessor(LocaleMixin):
                                            disable_notification=silent)
         else:
             # Cannot change reply_to_message_id when editing a message
-            tg_msg = self.bot.edit_message_text(chat_id=old_msg_id[0],
-                                                message_id=old_msg_id[1],
-                                                text=text, prefix=msg_template, suffix=reactions,
-                                                parse_mode='HTML',
-                                                reply_markup=reply_markup)
+            edit_kwargs = dict(chat_id=old_msg_id[0],
+                               message_id=old_msg_id[1],
+                               text=text, prefix=msg_template, suffix=reactions,
+                               parse_mode='HTML',
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            tg_msg = self.bot.edit_message_text(**edit_kwargs)
 
         self.logger.debug("[%s] Processed and sent as text message", msg.uid)
         return tg_msg
@@ -417,9 +446,13 @@ class SlaveMessageProcessor(LocaleMixin):
         if msg.text:
             text += "\n\n" + self.html_substitutions(msg)
         if old_msg_id:
-            return self.bot.edit_message_text(text=text, chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                              prefix=msg_template, suffix=reactions, parse_mode='HTML',
-                                              reply_markup=reply_markup)
+            _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+            edit_kwargs = dict(text=text, chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                               prefix=msg_template, suffix=reactions, parse_mode='HTML',
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            return self.bot.edit_message_text(**edit_kwargs)
         else:
             return self.bot.send_message(chat_id=tg_dest,
                                          text=text,
@@ -511,21 +544,22 @@ class SlaveMessageProcessor(LocaleMixin):
 
             if old_msg_id:
                 try:
-                    if edit_media:
-                        assert msg.path
-                        media: InputMedia
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                        if send_as_file:
-                            media = InputMediaDocument(file)
-                        else:
-                            media = InputMediaPhoto(file)
-                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
-                                                    reply_markup=reply_markup)
-                        if not text:
-                            return res
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                         reply_markup=reply_markup,
-                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                    with self._get_edit_context(msg):
+                        if edit_media:
+                            assert msg.path
+                            media: InputMedia
+                            file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                            if send_as_file:
+                                media = InputMediaDocument(file)
+                            else:
+                                media = InputMediaPhoto(file)
+                            res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
+                                                        reply_markup=reply_markup)
+                            if not text:
+                                return res
+                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                             reply_markup=reply_markup,
+                                                             prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
                 except telegram.error.BadRequest as e:
                     self.logger.warning("[%s] Failed to edit media/caption (BadRequest: %s). Sending new message instead.", msg.uid, e)
                     # Send as a reply if cannot edit previous message.
@@ -607,17 +641,18 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file and msg.path
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
-                                                reply_markup=reply_markup)
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                     prefix=msg_template, suffix=reactions,
-                                                     reply_markup=reply_markup,
-                                                     caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file and msg.path
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
+                                                    reply_markup=reply_markup)
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         prefix=msg_template, suffix=reactions,
+                                                         reply_markup=reply_markup,
+                                                         caption=text, parse_mode="HTML")
             else:
                 assert msg.file and msg.path
                 file = self.process_file_obj(msg.file, msg.path, msg.filename)
@@ -655,14 +690,18 @@ class SlaveMessageProcessor(LocaleMixin):
             if msg.edit_media and old_msg_id is not None:
                  if old_msg_id[0] == str(tg_dest):
                     target_msg_id = old_msg_id[1] # Set reply target to the message being "edited"
-                 old_msg_id = None # Force sending a new message
+                 old_msg_id = None  # Force sending new message below
 
             # If not editing media, but have old_msg_id, try editing reply_markup (e.g., for reactions)
             if old_msg_id and not msg.edit_media:
                 try:
+                    _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+                    edit_kwargs = dict(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                       reply_markup=sticker_reply_markup)
+                    if _sender_bot_id:
+                        edit_kwargs['_sender_bot_id'] = _sender_bot_id
                     # Editing reply markup doesn't involve thread_id
-                    return self.bot.edit_message_reply_markup(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                              reply_markup=sticker_reply_markup)
+                    return self.bot.edit_message_reply_markup(**edit_kwargs)
                 except TelegramError:
                     return self.bot.send_message(chat_id=old_msg_id[0], reply_to_message_id=old_msg_id[1],
                                                  prefix=msg_template, text=msg.text, suffix=reactions,
@@ -787,14 +826,15 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file is not None and msg.path is not None
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
             assert msg.file is not None and msg.path is not None
             self.logger.debug("[%s] Uploading file %s (%s) as %s", msg.uid,
                               msg.file.name, msg.mime, file_name)
@@ -846,11 +886,12 @@ class SlaveMessageProcessor(LocaleMixin):
                     msg_template += " " + self._("[Edited]")
                     if str(tg_dest) == old_msg_id[0]:
                         target_msg_id = target_msg_id or old_msg_id[1]
-                    old_msg_id = None # Force sending new message below
+                    old_msg_id = None
                 else:
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                         reply_markup=reply_markup, prefix=msg_template,
-                                                         suffix=reactions, caption=text, parse_mode="HTML")
+                    with self._get_edit_context(msg):
+                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                             reply_markup=reply_markup, prefix=msg_template,
+                                                             suffix=reactions, caption=text, parse_mode="HTML")
             # Sending new message (initial or fallback)
             if not old_msg_id: # Ensure we are in the 'send new' path
                 assert msg.file is not None
@@ -949,15 +990,16 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                if edit_media:
-                    assert msg.file is not None and msg.path is not None
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
-                                                reply_markup=reply_markup)
-                    if not text:
-                        return res
-                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                with self._get_edit_context(msg):
+                    if edit_media:
+                        assert msg.file is not None and msg.path is not None
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
+                                                    reply_markup=reply_markup)
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
             assert msg.file is not None and msg.path is not None
             file = self.process_file_obj(msg.file, msg.path, msg.filename)
             return self.bot.send_video(tg_dest, file, prefix=msg_template, suffix=reactions,
@@ -985,21 +1027,26 @@ class SlaveMessageProcessor(LocaleMixin):
         else:
             text = ""
 
+        _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
+
         if not old_msg_id:
             tg_msg = self.bot.send_message(tg_dest,
                                            text=text, parse_mode="HTML",
                                            prefix=msg_template + " " + self._("(unsupported)"),
                                            suffix=reactions,
-                                           reply_to_message_id=target_msg_id, message_thread_id=thread_id, reply_markup=reply_markup,
+                                           reply_to_message_id=target_msg_id, message_thread_id=thread_id,                                            reply_markup=reply_markup,
                                            disable_notification=silent)
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
-            tg_msg = self.bot.edit_message_text(chat_id=old_msg_id[0],
-                                                message_id=old_msg_id[1],
-                                                text=text, parse_mode="HTML",
-                                                prefix=msg_template + " " + self._("(unsupported) [Edited]"), # Mark as edited
-                                                suffix=reactions,
-                                                reply_markup=reply_markup)
+            edit_kwargs = dict(chat_id=old_msg_id[0],
+                               message_id=old_msg_id[1],
+                               text=text, parse_mode="HTML",
+                               prefix=msg_template + " " + self._("(unsupported) [Edited]"),  # Mark as edited
+                               suffix=reactions,
+                               reply_markup=reply_markup)
+            if _sender_bot_id:
+                edit_kwargs['_sender_bot_id'] = _sender_bot_id
+            tg_msg = self.bot.edit_message_text(**edit_kwargs)
 
         self.logger.debug("[%s] Processed and sent as text message", msg.uid)
         return tg_msg
@@ -1048,7 +1095,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                   *old_msg_id)
                 try:
                     if not self.channel.flag('prevent_message_removal'):
-                        self.bot.delete_message(*old_msg_id)
+                        self.bot.delete_message(*old_msg_id,
+                                                _sender_bot_id=old_msg.sender_bot_id)
                         return
                 except TelegramError as e:
                     self.logger.warning("Failed to delete message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
@@ -1056,7 +1104,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.bot.send_message(chat_id=old_msg_id[0],
                                       text=self._("Message is removed in remote chat."),
                                       reply_to_message_id=old_msg_id[1],
-                                      disable_notification=True) # Probably silent notification
+                                      disable_notification=True)  # Probably silent notification
             else:
                 self.logger.info('Was supposed to delete a message, '
                                  'but it does not exist in database: %s', status)
@@ -1086,8 +1134,13 @@ class SlaveMessageProcessor(LocaleMixin):
 
         old_msg: ETMMsg = old_msg_db.build_etm_msg(chat_manager=self.chat_manager)
         old_msg.reactions = status.reactions
-        old_msg.edit = True # Mark as edit so dispatch knows it's an update
-        old_msg.edit_media = False # Ensure media is not considered edited
+        old_msg.edit = True  # Mark as edit so dispatch knows it's an update
+        old_msg.edit_media = False  # Ensure media is not considered edited
+
+        # Thread sender_bot_id for routing edits to the correct bot
+        if old_msg_db.sender_bot_id:
+            old_msg.vendor_specific = old_msg.vendor_specific or {}
+            old_msg.vendor_specific['_sender_bot_id'] = old_msg_db.sender_bot_id
 
         msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(old_msg)
         if tg_dest is None:


### PR DESCRIPTION
This pull request introduces support for auxiliary (send-only) bot pools to the Telegram master channel, allowing the system to distribute outgoing messages across multiple bot tokens for higher throughput and reliability. It adds a new `AuxiliaryBot` class, integrates a multi-bot pool with rate limiting and routing logic, and updates the configuration validation to support auxiliary bots. The most important changes are grouped below.

**Auxiliary Bot Support and Pool Integration**

* Added the new `AuxiliaryBot` class (`efb_telegram_master/auxiliary_bot.py`) implementing a lightweight, send-only bot wrapper with independent rate limiting and group membership caching.
* Integrated auxiliary bot pool initialization and management in `TelegramBotManager`, including a thread-safe pool, per-chat usage tracking, and selection logic for distributing outgoing messages.

**Rate Limiting and Message Routing Enhancements**

* Updated the rate limiting decorator in `TelegramBotManager` to support two routing modes: forced routing for message edits/deletes (ensuring the same bot is used), and pool routing for new sends (choosing the best available bot to minimize delay). [[1]](diffhunk://#diff-c7fd2399cff5d52b243dbd41efa4c823c1cc8b11c88ee97c5d708fd36b1fa844L82-L87) [[2]](diffhunk://#diff-c7fd2399cff5d52b243dbd41efa4c823c1cc8b11c88ee97c5d708fd36b1fa844L98-R160)
* Modified the logic for skipping non-essential calls (like typing indicators) to suppress them if auxiliary bots were recently used for the target chat, reducing unnecessary API calls in high-volume situations.

**Configuration and Validation Improvements**

* Enhanced the configuration loader to validate the `auxiliary_bots` section, ensuring it is a list of unique bot tokens and preventing duplicate tokens across the main and auxiliary bots.

**Internal API and Utility Additions**

* Added the `_has_callback_keyboard` utility to detect callback keyboards, ensuring that pool routing is bypassed for messages requiring callback data (to avoid functional issues).
* Ensured that the correct bot instance is used for sending documents with long captions by referencing the active bot in the context.