### PR TITLE
Count Telegram edits against send quota

### DIFF
--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -39,6 +39,7 @@ class DelayedTask(NamedTuple):
     kwargs: dict       # Function keyword arguments
     task_id: str       # Unique task identifier
     cleanup_files: list = []  # Files to delete after task completes
+    allow_aux_routing: bool = True  # Whether delayed execution may switch to an auxiliary bot
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -113,6 +114,8 @@ class TelegramBotManager(LocaleMixin):
             """Apply rate limiting to API calls with two-mode routing for multi-bot pool."""
             @wraps(fn)
             def rate_limit_wrapper(self: 'TelegramBotManager', *args, **kwargs):
+                is_edit_method = fn.__name__.startswith('edit_message_')
+
                 # Bypass: caller already reserved a slot and set _using_bot
                 if kwargs.pop('_bypass_rate_limit', False):
                     return fn(self, *args, **kwargs)
@@ -137,6 +140,10 @@ class TelegramBotManager(LocaleMixin):
                     aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
                     if aux_bot and not aux_bot.disabled:
                         try:
+                            if chat_id:
+                                delay_time = aux_bot.reserve_slot(chat_id)
+                                if delay_time > 0:
+                                    time.sleep(delay_time)
                             with self._using_bot(aux_bot.bot):
                                 result = fn(self, *args, **kwargs)
                             if result and hasattr(result, '__dict__'):
@@ -146,11 +153,15 @@ class TelegramBotManager(LocaleMixin):
                             aux_bot.mark_disabled("Unauthorized during forced-route API call")
                             self._notify_admin_disabled_bot(aux_bot)
                     # Fallback: sender bot unavailable, try main bot
+                    if chat_id:
+                        delay_time, _, _ = self._calculate_rate_limit_delay(chat_id)
+                        if delay_time > 0:
+                            time.sleep(delay_time)
                     return fn(self, *args, **kwargs)
 
                 # MODE 2: Pool routing (new sends pick best available bot)
                 # Only attempt aux bots when the main bot would impose a delay.
-                if chat_id and self.bot_pool:
+                if chat_id and self.bot_pool and not is_edit_method:
                     # Skip pool for messages with callback keyboards (EC-4)
                     has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
                     if not has_callback:
@@ -192,7 +203,8 @@ class TelegramBotManager(LocaleMixin):
                             function=fn,
                             args=(self,) + args,
                             kwargs=kwargs,
-                            cleanup_files=cleanup_files
+                            cleanup_files=cleanup_files,
+                            allow_aux_routing=not is_edit_method
                         )
 
                         # Return a placeholder response to indicate message was scheduled
@@ -705,7 +717,8 @@ class TelegramBotManager(LocaleMixin):
         return mock_msg
 
     def _schedule_delayed_task(self, chat_id: int, delay_time: float, function: Callable,
-                              args: tuple, kwargs: dict, cleanup_files: Optional[list] = None) -> str:
+                              args: tuple, kwargs: dict, cleanup_files: Optional[list] = None,
+                              allow_aux_routing: bool = True) -> str:
         """
         Schedule a task for delayed execution.
 
@@ -715,6 +728,7 @@ class TelegramBotManager(LocaleMixin):
             function: Function to execute
             args: Function arguments
             kwargs: Function keyword arguments
+            allow_aux_routing: If True, delayed execution may switch to an auxiliary bot.
 
         Returns:
             Task ID for tracking
@@ -729,7 +743,8 @@ class TelegramBotManager(LocaleMixin):
             args=args,
             kwargs=kwargs,
             task_id=task_id,
-            cleanup_files=cleanup_files or []
+            cleanup_files=cleanup_files or [],
+            allow_aux_routing=allow_aux_routing
         )
 
         with self._delayed_queue_lock:
@@ -768,7 +783,7 @@ class TelegramBotManager(LocaleMixin):
                         # Re-check pool: if an aux bot has become available, route through it
                         result = None
                         routed_to_aux = False
-                        if self.bot_pool and task.chat_id:
+                        if task.allow_aux_routing and self.bot_pool and task.chat_id:
                             slot = self.bot_pool.acquire_send_slot(task.chat_id, max_delay=0.01)
                             if slot is not None:
                                 aux_bot, _ = slot
@@ -1220,12 +1235,14 @@ class TelegramBotManager(LocaleMixin):
                                chat_id=update.effective_chat.id,
                                message_id=update.effective_message.message_id)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.caption_affix_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_caption(self, *args, **kwargs):
         return self._active_bot.edit_message_caption(*args, **kwargs)
 
+    @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
     @Decorators.retry_on_chat_migration
     def edit_message_media(self, *args, **kwargs):

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -55,17 +55,13 @@ class SlaveMessageProcessor(LocaleMixin):
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
 
-    def _get_edit_context(self, msg: Message):
-        """Get a context manager for routing edits through the correct bot.
-        Returns the bot_manager's _using_bot context manager if sender_bot_id is set,
-        otherwise returns a no-op context manager."""
-        from contextlib import nullcontext
+    @staticmethod
+    def _get_edit_kwargs(msg: Message):
+        """Forward sender bot metadata so edit wrappers reserve the matching quota."""
         _sender_bot_id = (msg.vendor_specific or {}).get('_sender_bot_id')
-        if _sender_bot_id and self.bot.bot_pool:
-            aux_bot = self.bot.bot_pool.get_bot_by_id(_sender_bot_id)
-            if aux_bot and not aux_bot.disabled:
-                return self.bot._using_bot(aux_bot.bot)
-        return nullcontext()
+        if _sender_bot_id:
+            return {'_sender_bot_id': _sender_bot_id}
+        return {}
 
     def is_silent(self, msg: Message) -> Optional[bool]:
         """Determine if a message shall be sent silently.
@@ -549,22 +545,23 @@ class SlaveMessageProcessor(LocaleMixin):
 
             if old_msg_id:
                 try:
-                    with self._get_edit_context(msg):
-                        if edit_media:
-                            assert msg.path
-                            media: InputMedia
-                            file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                            if send_as_file:
-                                media = InputMediaDocument(file)
-                            else:
-                                media = InputMediaPhoto(file)
-                            res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
-                                                        reply_markup=reply_markup)
-                            if not text:
-                                return res
-                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                             reply_markup=reply_markup,
-                                                             prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                    edit_kwargs = self._get_edit_kwargs(msg)
+                    if edit_media:
+                        assert msg.path
+                        media: InputMedia
+                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        if send_as_file:
+                            media = InputMediaDocument(file)
+                        else:
+                            media = InputMediaPhoto(file)
+                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=media,
+                                                    reply_markup=reply_markup, **edit_kwargs)
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML",
+                                                         **edit_kwargs)
                 except telegram.error.BadRequest as e:
                     self.logger.warning("[%s] Failed to edit media/caption (BadRequest: %s). Sending new message instead.", msg.uid, e)
                     # Send as a reply if cannot edit previous message.
@@ -646,18 +643,18 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                with self._get_edit_context(msg):
-                    if edit_media:
-                        assert msg.file and msg.path
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
-                                                    reply_markup=reply_markup)
-                        if not text:
-                            return res
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                         prefix=msg_template, suffix=reactions,
-                                                         reply_markup=reply_markup,
-                                                         caption=text, parse_mode="HTML")
+                edit_kwargs = self._get_edit_kwargs(msg)
+                if edit_media:
+                    assert msg.file and msg.path
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAnimation(file),
+                                                reply_markup=reply_markup, **edit_kwargs)
+                    if not text:
+                        return res
+                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                     prefix=msg_template, suffix=reactions,
+                                                     reply_markup=reply_markup,
+                                                     caption=text, parse_mode="HTML", **edit_kwargs)
             else:
                 assert msg.file and msg.path
                 file = self.process_file_obj(msg.file, msg.path, msg.filename)
@@ -832,15 +829,17 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                with self._get_edit_context(msg):
-                    if edit_media:
-                        assert msg.file is not None and msg.path is not None
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaDocument(file))
-                        if not text:
-                            return res
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                edit_kwargs = self._get_edit_kwargs(msg)
+                if edit_media:
+                    assert msg.file is not None and msg.path is not None
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                      media=InputMediaDocument(file), **edit_kwargs)
+                    if not text:
+                        return res
+                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML",
+                                                     **edit_kwargs)
             assert msg.file is not None and msg.path is not None
             self.logger.debug("[%s] Uploading file %s (%s) as %s", msg.uid,
                               msg.file.name, msg.mime, file_name)
@@ -894,10 +893,10 @@ class SlaveMessageProcessor(LocaleMixin):
                         target_msg_id = target_msg_id or old_msg_id[1]
                     old_msg_id = None
                 else:
-                    with self._get_edit_context(msg):
-                        return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
-                                                             reply_markup=reply_markup, prefix=msg_template,
-                                                             suffix=reactions, caption=text, parse_mode="HTML")
+                    edit_kwargs = self._get_edit_kwargs(msg)
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         reply_markup=reply_markup, prefix=msg_template,
+                                                         suffix=reactions, caption=text, parse_mode="HTML", **edit_kwargs)
             # Sending new message (initial or fallback)
             if not old_msg_id: # Ensure we are in the 'send new' path
                 assert msg.file is not None
@@ -996,16 +995,17 @@ class SlaveMessageProcessor(LocaleMixin):
                     return message
 
             if old_msg_id:
-                with self._get_edit_context(msg):
-                    if edit_media:
-                        assert msg.file is not None and msg.path is not None
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
-                        res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
-                                                    reply_markup=reply_markup)
-                        if not text:
-                            return res
-                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
-                                                         prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                edit_kwargs = self._get_edit_kwargs(msg)
+                if edit_media:
+                    assert msg.file is not None and msg.path is not None
+                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                    res = self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaVideo(file),
+                                                reply_markup=reply_markup, **edit_kwargs)
+                    if not text:
+                        return res
+                return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1], reply_markup=reply_markup,
+                                                     prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML",
+                                                     **edit_kwargs)
             assert msg.file is not None and msg.path is not None
             file = self.process_file_obj(msg.file, msg.path, msg.filename)
             return self.bot.send_video(tg_dest, file, prefix=msg_template, suffix=reactions,
@@ -1322,4 +1322,3 @@ class SlaveMessageProcessor(LocaleMixin):
             except OSError as e:
                 self.logger.warning("Failed to clean up local API temp file %s: %s", path, e)
         tls.pending_cleanup = []
-

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -212,8 +212,7 @@ def test_edit_message_methods_reserve_send_quota(method_name, bot_method_name, k
     bot_method = getattr(manager._bot, bot_method_name)
     bot_method.return_value = SimpleNamespace(chat_id=123, message_id=456)
 
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=100.0):
-        result = getattr(manager, method_name)(**kwargs)
+    result = getattr(manager, method_name)(**kwargs)
 
     assert result.chat_id == 123
     chat_count, global_count = manager._rate_limiter.get_counts(123)

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1,6 +1,7 @@
 import string
 import random
 import threading
+from collections import defaultdict, deque
 from typing import IO, Iterator, BinaryIO
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -114,40 +115,91 @@ def test_malformed_html_caption(channel, bot_admin, image):
 
 def test_rate_limit_decorator_forced_routes_to_sender_bot():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
-    aux_bot = SimpleNamespace(bot=object(), bot_id=777, disabled=False)
+    aux_bot = SimpleNamespace(bot=object(), bot_id=777, disabled=False, reserve_slot=Mock(return_value=0.0))
+    used_bots = []
     manager = SimpleNamespace(
         _delayed_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
-        _using_bot=lambda bot: SimpleNamespace(__enter__=lambda *a: None, __exit__=lambda *a: None),
         logger=Mock(),
     )
 
     class DummyContext:
+        def __init__(self, bot):
+            self.bot = bot
+
         def __enter__(self):
+            used_bots.append(self.bot)
             return None
 
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    manager._using_bot = lambda bot: DummyContext()
+    manager._using_bot = lambda bot: DummyContext(bot)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
     assert result._sender_bot_id == "777"
+    assert used_bots == [aux_bot.bot]
     manager.bot_pool.get_bot_by_id.assert_called_once_with("777")
+    aux_bot.reserve_slot.assert_called_once_with(123)
 
 
 def test_rate_limit_decorator_falls_back_to_main_bot_when_sender_missing():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
+    bot_pool = SimpleNamespace(get_bot_by_id=Mock(return_value=None), acquire_send_slot=Mock())
     manager = SimpleNamespace(
         _delayed_worker_stop=threading.Event(),
-        bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=None)),
+        bot_pool=bot_pool,
+        _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
         logger=Mock(),
     )
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
     assert result.chat_id == 123
+    manager._calculate_rate_limit_delay.assert_called_once_with(123)
+    bot_pool.acquire_send_slot.assert_not_called()
+
+
+def _make_lightweight_bot_manager():
+    manager = TelegramBotManager.__new__(TelegramBotManager)
+    manager._bot = Mock()
+    manager._tls = threading.local()
+    manager.bot_pool = None
+    manager._delayed_worker_stop = threading.Event()
+    manager._rate_limit_lock = threading.Lock()
+    manager._global_timestamps = []
+    manager._chat_timestamps = defaultdict(deque)
+    manager.GLOBAL_LIMIT = 30
+    manager.GLOBAL_WINDOW = 1.0
+    manager.CHAT_LIMIT = 20
+    manager.CHAT_WINDOW = 60.0
+    manager._cleanup_tls = SimpleNamespace(pending_cleanup=[])
+    manager.logger = Mock()
+    manager._delayed_queue = []
+    manager._delayed_queue_lock = threading.Lock()
+    manager._task_counter = 0
+    return manager
+
+
+@pytest.mark.parametrize(("method_name", "bot_method_name", "kwargs"), [
+    ("edit_message_text", "edit_message_text", {"chat_id": 123, "message_id": 456, "text": "updated"}),
+    ("edit_message_caption", "edit_message_caption", {"chat_id": 123, "message_id": 456, "caption": "updated"}),
+    ("edit_message_media", "edit_message_media", {"chat_id": 123, "message_id": 456, "media": object()}),
+    ("edit_message_reply_markup", "edit_message_reply_markup", {"chat_id": 123, "message_id": 456, "reply_markup": None}),
+])
+def test_edit_message_methods_reserve_send_quota(method_name, bot_method_name, kwargs):
+    manager = _make_lightweight_bot_manager()
+    bot_method = getattr(manager._bot, bot_method_name)
+    bot_method.return_value = SimpleNamespace(chat_id=123, message_id=456)
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=100.0):
+        result = getattr(manager, method_name)(**kwargs)
+
+    assert result.chat_id == 123
+    assert len(manager._global_timestamps) == 1
+    assert list(manager._chat_timestamps[123]) == [100.0]
+    bot_method.assert_called_once()
 
 
 def test_rate_limit_decorator_routes_new_send_through_aux_pool():
@@ -175,6 +227,26 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
     assert result._sender_bot_id == "999"
     manager.bot_pool.acquire_send_slot.assert_called_once_with(123, max_delay=1.0)
     manager._record_aux_use.assert_called_once_with(123)
+
+
+@pytest.mark.parametrize(("method_name", "kwargs"), [
+    ("edit_message_caption", {"chat_id": 123, "message_id": 456, "caption": "updated"}),
+    ("edit_message_media", {"chat_id": 123, "message_id": 456, "media": object()}),
+])
+def test_no_sender_caption_and_media_edits_reserve_main_quota_without_aux_pool(method_name, kwargs):
+    manager = _make_lightweight_bot_manager()
+    manager.CHAT_LIMIT = 3
+    manager.bot_pool = SimpleNamespace(acquire_send_slot=Mock(return_value=(SimpleNamespace(), 0.0)))
+    manager._chat_timestamps[123].append(100.0)
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=159.0):
+        result = getattr(manager, method_name)(**kwargs)
+
+    assert result.is_delayed is True
+    assert len(manager._global_timestamps) == 1
+    assert list(manager._chat_timestamps[123]) == [100.0, 160.0]
+    manager.bot_pool.acquire_send_slot.assert_not_called()
+    assert manager._delayed_queue[0][2].allow_aux_routing is False
 
 
 def test_rate_limit_decorator_schedules_delayed_task_when_main_bot_is_limited():


### PR DESCRIPTION
## Summary
- Reserve send quota for Telegram editMessage* wrappers, including caption and media edits.
- Preserve original sender routing for auxiliary-bot edits by forwarding sender bot metadata into manager edit wrappers.
- Keep no-sender edits on the main bot quota path instead of generic auxiliary send routing.

## Verification
- python3 -m py_compile efb_telegram_master/bot_manager.py efb_telegram_master/slave_message.py tests/unit/test_bot_manager.py
- rtk git diff --check -- efb_telegram_master/bot_manager.py efb_telegram_master/slave_message.py tests/unit/test_bot_manager.py

Focused pytest could not complete locally because the environment is missing test runtime dependencies, including system libmagic.