### PR TITLE
Upgrade python-telegram-bot to 22.8

### DIFF
--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -15,7 +15,7 @@ from PIL import Image, WebPImagePlugin
 from pkg_resources import resource_filename
 from ruamel.yaml import YAML
 from telegram import Update, Message
-from telegram.ext import CommandHandler, CallbackQueryHandler, CallbackContext, Filters
+from telegram.ext import CallbackContext, filters
 
 import ehforwarderbot  # lgtm [py/import-and-import-from]
 from ehforwarderbot import Channel, coordinator
@@ -42,6 +42,7 @@ from .message import ETMMsg
 from .rpc_utils import RPCUtilities
 from .slave_message import SlaveMessageProcessor
 from .utils import ExperimentalFlagsManager, EFBChannelChatIDStr, TelegramChatID, TelegramMessageID
+from .ptb_compat import CallbackQueryHandler, CommandHandler, forbidden_errors
 
 
 class TelegramChannel(MasterChannel):
@@ -136,7 +137,7 @@ class TelegramChannel(MasterChannel):
                                           fallback=True)
 
         # Basic message handlers
-        non_edit_filter = Filters.update.message | Filters.update.channel_post
+        non_edit_filter = filters.UpdateType.MESSAGE | filters.UpdateType.CHANNEL_POSTS
         self.bot_manager.dispatcher.add_handler(
             CommandHandler("start", self.start, filters=non_edit_filter))
         self.bot_manager.dispatcher.add_handler(
@@ -529,7 +530,7 @@ class TelegramChannel(MasterChannel):
         # noinspection PyBroadException
         try:
             raise error
-        except telegram.error.Unauthorized:
+        except forbidden_errors():
             self.logger.error("The bot is not authorised to send update:\n%s\n%s", str(update), str(error))
         except telegram.error.BadRequest as e:
             assert isinstance(update, Update)

--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -42,7 +42,7 @@ from .message import ETMMsg
 from .rpc_utils import RPCUtilities
 from .slave_message import SlaveMessageProcessor
 from .utils import ExperimentalFlagsManager, EFBChannelChatIDStr, TelegramChatID, TelegramMessageID
-from .ptb_compat import CallbackQueryHandler, CommandHandler, forbidden_errors
+from .ptb_compat import CallbackQueryHandler, CommandHandler, forbidden_errors, forwarded_from_chat, sync_message, sync_update
 
 
 class TelegramChannel(MasterChannel):
@@ -220,23 +220,25 @@ class TelegramChannel(MasterChannel):
         Triggered by `/info`.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert isinstance(update.effective_message, Message)
+        message = sync_message(update.effective_message)
         if update.effective_message.chat.type != telegram.Chat.PRIVATE:  # Group message
             if update.effective_chat and update.effective_chat.is_forum:
                 msg = self.info_topic(update)
             else:
                 msg = self.info_group(update)
-        elif update.effective_message.forward_from_chat and \
-                update.effective_message.forward_from_chat.type == 'channel':  # Forwarded channel command.
+        elif (forwarded_chat := forwarded_from_chat(update.effective_message)) and \
+                forwarded_chat.type == 'channel':  # Forwarded channel command.
             msg = self.info_channel(update)
         else:  # Talking to the bot.
             msg = self.info_general()
 
         if len(msg) > 4095:
             for x in range(0, len(msg), 4095):
-                update.effective_message.reply_text(msg[x:x+4095])
+                message.reply_text(msg[x:x+4095])
         else:
-            update.effective_message.reply_text(msg)
+            message.reply_text(msg)
 
     def info_topic(self, update: Update):
         """Generate string for chat linking info of a topic."""
@@ -302,7 +304,8 @@ class TelegramChannel(MasterChannel):
 
     def info_channel(self, update):
         """Generate string for chat linking info of a channel."""
-        chat = update.effective_message.forward_from_chat
+        chat = forwarded_from_chat(update.effective_message)
+        assert chat
         links = self.db.get_chat_assoc(master_uid=etm_utils.chat_id_to_str(self.channel_id, chat.id))
         if links:  # Linked chat
             # TRANSLATORS: ‘channel’ here refers to a Telegram channel.
@@ -370,13 +373,15 @@ class TelegramChannel(MasterChannel):
         Process bot command `/start`.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert isinstance(update.effective_message, telegram.Message)
         assert isinstance(update.effective_chat, telegram.Chat)
         if context.args:  # Group binding command
+            forwarded_chat = forwarded_from_chat(update.effective_message)
             if (update.effective_message.chat.type != telegram.Chat.PRIVATE and update.effective_chat.id != self.topic_group) or \
-                    (update.effective_message.forward_from_chat and
-                     update.effective_message.forward_from_chat.type == telegram.Chat.CHANNEL and
-                     update.effective_message.forward_from_chat.id != self.topic_group):
+                    (forwarded_chat and
+                     forwarded_chat.type == telegram.Chat.CHANNEL and
+                     forwarded_chat.id != self.topic_group):
                 self.chat_binding.link_chat(update, context.args)
             else:
                 self.bot_manager.send_message(update.effective_chat.id,
@@ -389,8 +394,9 @@ class TelegramChannel(MasterChannel):
     def react(self, update: Update, context: CallbackContext):
         """React to a message."""
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert isinstance(update.effective_message, Message)
-        message: Message = update.effective_message
+        message = sync_message(update.effective_message)
 
         reaction = None
         args = message.text and message.text.split(' ', 1)
@@ -474,6 +480,7 @@ class TelegramChannel(MasterChannel):
 
     def help(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert isinstance(update.message, Message)
         txt = self._("EFB Telegram Master Channel\n"
                      "/link\n"
@@ -497,7 +504,7 @@ class TelegramChannel(MasterChannel):
                      "    Remove the quoted message from its remote chat.\n"
                      "/help\n"
                      "    Print this command list.")
-        update.message.reply_text(txt)
+        sync_message(update.message).reply_text(txt)
 
     def poll(self):
         """
@@ -549,11 +556,13 @@ class TelegramChannel(MasterChannel):
                               "Number of network error occurred since last startup: %s\n%s\nUpdate: %s",
                               self.timeout_count, str(error), str(update))
             if isinstance(update, Update) and isinstance(update.message, Message):
-                update.message.reply_text(self._("This message is not processed due to poor internet environment "
-                                                 "of the server.\n"
-                                                 "<code>{code}</code>").format(code=html.escape(str(error))),
-                                          quote=True,
-                                          parse_mode="HTML")
+                sync_error_update = sync_update(update)
+                sync_message(sync_error_update.message).reply_text(
+                    self._("This message is not processed due to poor internet environment "
+                           "of the server.\n"
+                           "<code>{code}</code>").format(code=html.escape(str(error))),
+                    quote=True,
+                    parse_mode="HTML")
 
             timeout_interval = self.flag('network_error_prompt_interval')
             if timeout_interval > 0 and self.timeout_count % timeout_interval == 0:

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -5,11 +5,12 @@ import logging
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import telegram
 import telegram.error
-from telegram.utils.request import Request
+
+from .ptb_compat import SyncTelegramBot, build_bot, forbidden_errors
 
 if TYPE_CHECKING:
     pass
@@ -35,15 +36,10 @@ class AuxiliaryBot:
                  global_window: float = 1.0,
                  chat_limit: int = 20,
                  chat_window: float = 60.0):
-        kwargs: Dict[str, Any] = {}
-        if base_url:
-            kwargs['base_url'] = base_url
-        if base_file_url:
-            kwargs['base_file_url'] = base_file_url
-        if request_kwargs:
-            kwargs['request'] = Request(**request_kwargs)
-
-        self.bot: telegram.Bot = telegram.Bot(token=token, **kwargs)
+        self.bot: SyncTelegramBot = build_bot(token=token,
+                                              base_url=base_url,
+                                              base_file_url=base_file_url,
+                                              request_kwargs=request_kwargs)
 
         # Identity (populated by initialize())
         self.bot_id: int = 0
@@ -75,7 +71,7 @@ class AuxiliaryBot:
             self.username = me.username or ""
             logger.info("Auxiliary bot initialized: @%s (id=%d)", self.username, self.bot_id)
             return True
-        except telegram.error.Unauthorized as e:
+        except forbidden_errors() as e:
             self.disabled = True
             self._disable_reason = str(e)
             logger.error("Failed to initialize auxiliary bot: %s", e)
@@ -252,7 +248,7 @@ class AuxiliaryBot:
             self.update_membership(chat_id, is_member)
             logger.debug("Membership probe for bot %d in chat %d: %s (status=%s)",
                          self.bot_id, chat_id, is_member, member.status)
-        except telegram.error.Unauthorized:
+        except forbidden_errors():
             self.disabled = True
             self._disable_reason = "Unauthorized during membership probe"
             logger.error("Auxiliary bot %d got Unauthorized during membership probe", self.bot_id)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -21,13 +21,14 @@ import telegram.error
 from retrying import retry
 from telegram import File, ForumTopic, InlineKeyboardMarkup, InputFile, Update, User
 from telegram import Message as TelegramMessage
-from telegram.ext import CallbackContext, Dispatcher, Filters, MessageHandler, Updater
+from telegram.ext import CallbackContext, filters
 
 from .auxiliary_bot import AuxiliaryBot
 from .bot_pool import BotPool
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
 from .msg_type import get_msg_type
+from .ptb_compat import MessageHandler, SyncApplication, SyncTelegramBot, build_application, forbidden_errors
 
 
 class DelayedTask(NamedTuple):
@@ -65,19 +66,19 @@ class TelegramBotManager(LocaleMixin):
     Attributes:
         me (telegram.User): Telegram User
         admins (List[int]): List of admin user IDs.
-        updater (telegram.ext.Updater): Updater of the bot
-        dispatcher (telegram.ext.Dispatcher): Dispatcher of the updater
+        updater (telegram.ext.Application): Telegram bot application
+        dispatcher (telegram.ext.Application): Application handler registry
     """
 
     webhook = False
     logger = logging.getLogger(__name__)
 
     # Type declarations for instance attributes assigned in __init__
-    updater: Updater
-    _bot: telegram.Bot
+    updater: SyncApplication
+    _bot: SyncTelegramBot
     me: User
     admins: List[int]
-    dispatcher: Dispatcher
+    dispatcher: SyncApplication
     bot_pool: Optional['BotPool']
     _delayed_worker_stop: threading.Event
     _delayed_queue_lock: threading.Lock
@@ -142,7 +143,7 @@ class TelegramBotManager(LocaleMixin):
                             if result and hasattr(result, '__dict__'):
                                 result._sender_bot_id = str(sender_bot_id)
                             return result
-                        except telegram.error.Unauthorized:
+                        except forbidden_errors():
                             aux_bot.mark_disabled("Unauthorized during forced-route API call")
                             self._notify_admin_disabled_bot(aux_bot)
                     # Fallback: sender bot unavailable, try main bot
@@ -167,7 +168,7 @@ class TelegramBotManager(LocaleMixin):
                                     result._sender_bot_id = str(aux_bot.bot_id)
                                 self._record_aux_use(chat_id)
                                 return result
-                            except telegram.error.Unauthorized:
+                            except forbidden_errors():
                                 aux_bot.mark_disabled("Unauthorized during pool-route API call")
                                 self._notify_admin_disabled_bot(aux_bot)
                                 # Fallback: continue to main bot path below
@@ -413,11 +414,10 @@ class TelegramBotManager(LocaleMixin):
             req_kwargs.update(conf_req_kwargs)
 
         self.logger.debug("Setting up Telegram bot updater...")
-        self.updater: Updater = Updater(config['token'],
-                                        base_url=channel.flag('api_base_url'),
-                                        base_file_url=channel.flag('api_base_file_url'),
-                                        request_kwargs=req_kwargs,
-                                        use_context=True)
+        self.updater = build_application(config['token'],
+                                         base_url=channel.flag('api_base_url'),
+                                         base_file_url=channel.flag('api_base_file_url'),
+                                         request_kwargs=req_kwargs)
 
         if isinstance(config.get('webhook'), dict):
             self.logger.debug("Setting up webhook...")
@@ -425,16 +425,13 @@ class TelegramBotManager(LocaleMixin):
             self.logger.debug("Webhook is set...")
 
         self.logger.debug("Checking connection to Telegram bot API...")
-        # Updater.__init__ uses __slots__ + @no_type_check, so mypy cannot
-        # determine the types of .bot / .dispatcher.  getattr returns Any,
-        # then cast narrows to the correct type.
-        self._bot = cast(telegram.Bot, getattr(self.updater, 'bot'))
+        self._bot = cast(SyncTelegramBot, getattr(self.updater, 'bot'))
         me = self._bot.get_me()
         assert me, "Invalid bot credential provided."
         self.me = me
         self.logger.debug("Connection to Telegram bot API is OK...")
         self.admins = config['admins']
-        self.dispatcher = cast(Dispatcher, getattr(self.updater, 'dispatcher'))
+        self.dispatcher = cast(SyncApplication, getattr(self.updater, 'dispatcher'))
 
         # Initialize sliding window rate limiting
         self._rate_limit_lock = threading.Lock()
@@ -476,7 +473,7 @@ class TelegramBotManager(LocaleMixin):
 
         self.logger.debug("Adding base dispatchers...")
         # New whitelist handler
-        whitelist_filter = ~Filters.user(user_id=self.admins)
+        whitelist_filter = ~filters.User(user_id=self.admins)
         self.dispatcher.add_handler(
             MessageHandler(whitelist_filter, lambda update, context: ...))
         self.dispatcher.add_handler(LocaleHandler(channel))
@@ -582,7 +579,7 @@ class TelegramBotManager(LocaleMixin):
                     try:
                         with self._using_bot(aux_bot.bot):
                             return send_callable(_bypass_rate_limit=True)
-                    except telegram.error.Unauthorized:
+                    except forbidden_errors():
                         aux_bot.mark_disabled("Unauthorized during migration send")
                         self._notify_admin_disabled_bot(aux_bot)
 
@@ -780,7 +777,7 @@ class TelegramBotManager(LocaleMixin):
                                     self._record_aux_use(task.chat_id)
                                     routed_to_aux = True
                                     self.logger.debug(f"Delayed task {task.task_id} routed to aux bot @{aux_bot.username}")
-                                except telegram.error.Unauthorized:
+                                except forbidden_errors():
                                     aux_bot.mark_disabled("Unauthorized during delayed task")
                                     self._notify_admin_disabled_bot(aux_bot)
 
@@ -1254,7 +1251,7 @@ class TelegramBotManager(LocaleMixin):
             if aux_bot and not aux_bot.disabled:
                 try:
                     return aux_bot.bot.delete_message(chat_id, message_id)
-                except telegram.error.Unauthorized:
+                except forbidden_errors():
                     aux_bot.mark_disabled("Unauthorized during delete_message")
                     self._notify_admin_disabled_bot(aux_bot)
                 except telegram.error.BadRequest:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -20,6 +20,7 @@ import telegram.constants
 import telegram.error
 from retrying import retry
 from telegram import File, ForumTopic, InlineKeyboardMarkup, InputFile, Update, User
+from telegram.constants import MessageLimit
 from telegram import Message as TelegramMessage
 from telegram.ext import CallbackContext, filters
 
@@ -28,7 +29,7 @@ from .bot_pool import BotPool
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
 from .msg_type import get_msg_type
-from .ptb_compat import MessageHandler, SyncApplication, SyncTelegramBot, build_application, forbidden_errors
+from .ptb_compat import MessageHandler, SyncApplication, SyncTelegramBot, build_application, forbidden_errors, sync_callback_query
 
 
 class DelayedTask(NamedTuple):
@@ -247,18 +248,19 @@ class TelegramBotManager(LocaleMixin):
                             raise
 
                         retry_after = e.retry_after
+                        retry_after_seconds = retry_after.total_seconds() if hasattr(retry_after, "total_seconds") else retry_after
                         cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
 
                         # Use interruptible sleep for rate limit waits
                         if hasattr(self, '_delayed_worker_stop'):
                             # Sleep in small chunks to allow for interruption during shutdown
-                            remaining = retry_after
+                            remaining = retry_after_seconds
                             while remaining > 0 and not self._delayed_worker_stop.is_set():
                                 sleep_chunk = min(1.0, remaining)
                                 time.sleep(sleep_chunk)
                                 remaining -= sleep_chunk
                         else:
-                            time.sleep(retry_after)
+                            time.sleep(retry_after_seconds)
                     except telegram.error.TelegramError as e:
                         if not cls.enable_retry:
                             raise
@@ -268,7 +270,7 @@ class TelegramBotManager(LocaleMixin):
                                 cls.logger.error(f"Max retries exceeded for rate limit error: {e} (chat_id: {chat_id}){timestamp_info}")
                                 raise
 
-                            delay = 60
+                            delay = 60.0
                             cls.logger.warning(f"Rate limit detected, waiting {delay}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
                             if chat_id and hasattr(self, '_chat_timestamps'):
                                 for timestamp in self._chat_timestamps[chat_id]:
@@ -895,7 +897,7 @@ class TelegramBotManager(LocaleMixin):
         else:
             text = kwargs.pop('text')
         args = args[:1]
-        if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
+        if len(prefix + text + suffix) >= MessageLimit.MAX_TEXT_LENGTH:
             full_message = io.BytesIO((prefix + text + suffix).encode('utf-8'))
             truncated = prefix + text[:100] + "\n...\n" + text[-100:] + suffix
             msg = self._bot_send_message_fallback(args[0], text=truncated, **kwargs)
@@ -947,7 +949,7 @@ class TelegramBotManager(LocaleMixin):
             prefix = html.escape(prefix)
             suffix = html.escape(suffix)
         text = kwargs.pop('text', '')
-        if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
+        if len(prefix + text + suffix) >= MessageLimit.MAX_TEXT_LENGTH:
             full_message = io.BytesIO((prefix + text + suffix).encode())
             truncated = prefix + text[:100] + "\n...\n" + text[-100:] + suffix
             msg = self._bot_edit_message_text_fallback(text=truncated, **kwargs)
@@ -1209,10 +1211,12 @@ class TelegramBotManager(LocaleMixin):
 
     def session_expired(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
+        from .ptb_compat import sync_update
+        update = sync_update(update)
         assert update.effective_message
         assert update.effective_chat
         if update.callback_query:
-            update.callback_query.answer()
+            sync_callback_query(update.callback_query).answer()
         self.edit_message_text(text=self._("Session expired. Please try again. (SE01)"),
                                chat_id=update.effective_chat.id,
                                message_id=update.effective_message.message_id)

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -12,11 +12,10 @@ from typing import Tuple, Dict, Optional, List, TYPE_CHECKING, IO, Union, Patter
 
 import telegram  # lgtm [py/import-and-import-from]
 from PIL import Image
-from telegram import Update, Message, TelegramError, InlineKeyboardButton, ChatAction, InlineKeyboardMarkup, \
-    ParseMode
-from telegram.error import BadRequest
-from telegram.ext import ConversationHandler, CommandHandler, CallbackQueryHandler, CallbackContext, Filters, \
-    MessageHandler
+from telegram import Update, Message, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.constants import ChatAction, ParseMode
+from telegram.error import BadRequest, TelegramError
+from telegram.ext import CallbackContext, ConversationHandler, filters
 
 from ehforwarderbot import coordinator, Channel, MsgType
 from ehforwarderbot.channel import SlaveChannel
@@ -29,6 +28,7 @@ from .constants import Emoji, Flags
 from .locale_mixin import LocaleMixin
 from .message import ETMMsg
 from .msg_type import TGMsgType
+from .ptb_compat import CallbackQueryHandler, CommandHandler, MessageHandler
 from .utils import EFBChannelChatIDStr, TelegramChatID, TelegramMessageID, TgChatMsgIDStr, TelegramTopicID
 
 if TYPE_CHECKING:
@@ -105,7 +105,7 @@ class ChatBindingManager(LocaleMixin):
         self._topic_mutex = threading.Lock()
 
         # Link handler
-        non_edit_filter = Filters.update.message | Filters.update.channel_post
+        non_edit_filter = filters.UpdateType.MESSAGE | filters.UpdateType.CHANNEL_POSTS
         self.bot.dispatcher.add_handler(
             CommandHandler("link", self.link_chat_show_list, filters=non_edit_filter))
         self.link_handler = ConversationHandler(
@@ -157,11 +157,11 @@ class ChatBindingManager(LocaleMixin):
         self.bot.dispatcher.add_handler(CommandHandler('init_topics', self.topic_migration))
 
         self.bot.dispatcher.add_handler(
-            MessageHandler(Filters.status_update.migrate, self.chat_migration))
+            MessageHandler(filters.StatusUpdate.MIGRATE, self.chat_migration))
         self.bot.dispatcher.add_handler(
-            MessageHandler(Filters.status_update.new_chat_members, self.chat_joined))
+            MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, self.chat_joined))
         self.bot.dispatcher.add_handler(
-            MessageHandler(Filters.status_update.left_chat_member, self.chat_left))
+            MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, self.chat_left))
 
     def pre_link_check(self, message: Message):
         """Check if the bot would work properly in a linked group.

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -15,7 +15,7 @@ from PIL import Image
 from telegram import Update, Message, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ChatAction, ParseMode
 from telegram.error import BadRequest, TelegramError
-from telegram.ext import CallbackContext, ConversationHandler, filters
+from telegram.ext import CallbackContext, ConversationHandler as PTBConversationHandler, filters
 
 from ehforwarderbot import coordinator, Channel, MsgType
 from ehforwarderbot.channel import SlaveChannel
@@ -28,7 +28,16 @@ from .constants import Emoji, Flags
 from .locale_mixin import LocaleMixin
 from .message import ETMMsg
 from .msg_type import TGMsgType
-from .ptb_compat import CallbackQueryHandler, CommandHandler, MessageHandler
+from .ptb_compat import (
+    CallbackQueryHandler,
+    CommandHandler,
+    MessageHandler,
+    conversation_state,
+    forwarded_from_chat,
+    sync_callback_query,
+    sync_message,
+    sync_update,
+)
 from .utils import EFBChannelChatIDStr, TelegramChatID, TelegramMessageID, TgChatMsgIDStr, TelegramTopicID
 
 if TYPE_CHECKING:
@@ -108,7 +117,7 @@ class ChatBindingManager(LocaleMixin):
         non_edit_filter = filters.UpdateType.MESSAGE | filters.UpdateType.CHANNEL_POSTS
         self.bot.dispatcher.add_handler(
             CommandHandler("link", self.link_chat_show_list, filters=non_edit_filter))
-        self.link_handler = ConversationHandler(
+        self.link_handler = PTBConversationHandler(
             entry_points=[],
             states={
                 Flags.LINK_CONFIRM: [CallbackQueryHandler(self.link_chat_confirm)],
@@ -124,7 +133,7 @@ class ChatBindingManager(LocaleMixin):
         # Chat head handler
         self.bot.dispatcher.add_handler(
             CommandHandler("chat", self.start_chat_list, filters=non_edit_filter))
-        self.chat_head_handler = ConversationHandler(
+        self.chat_head_handler = PTBConversationHandler(
             entry_points=[],
             states={
                 Flags.CHAT_HEAD_CONFIRM: [CallbackQueryHandler(self.make_chat_head)],
@@ -141,7 +150,7 @@ class ChatBindingManager(LocaleMixin):
             CommandHandler("unlink_all", self.unlink_all))
 
         # Recipient suggestion
-        self.suggestion_handler: ConversationHandler = ConversationHandler(
+        self.suggestion_handler: PTBConversationHandler = PTBConversationHandler(
             entry_points=[],
             states={Flags.SUGGEST_RECIPIENTS: [CallbackQueryHandler(self.suggested_recipient)]},
             fallbacks=[CallbackQueryHandler(self.bot.session_expired)],
@@ -194,7 +203,7 @@ class ChatBindingManager(LocaleMixin):
             ))
 
         if err_msg:
-            message.reply_text("\n".join(err_msg))
+            sync_message(message).reply_text("\n".join(err_msg))
 
     def link_chat_show_list(self, update: Update, context: CallbackContext):
         """
@@ -207,10 +216,11 @@ class ChatBindingManager(LocaleMixin):
         the full list privately.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
 
         args = context.args or []
-        message: Message = update.effective_message
+        message = sync_message(update.effective_message)
 
         # Perform pre-link check
         self.pre_link_check(message)
@@ -218,7 +228,7 @@ class ChatBindingManager(LocaleMixin):
         # Send link confirmation message when replying to a Telegram message
         # that is recorded in database.
         if message.reply_to_message:
-            rtm: Message = message.reply_to_message
+            rtm = sync_message(message.reply_to_message)
             msg_log = self.db.get_msg_log(
                 master_msg_id=utils.message_id_to_str(
                     chat_id=TelegramChatID(rtm.chat_id),
@@ -231,7 +241,7 @@ class ChatBindingManager(LocaleMixin):
                 tg_chat_id = TelegramChatID(message.chat_id)
                 tg_msg_id = TelegramMessageID(message.reply_text(self._("Processing...")).message_id)
                 storage_id: Tuple[TelegramChatID, TelegramMessageID] = (tg_chat_id, tg_msg_id)
-                self.link_handler.conversations[storage_id] = Flags.LINK_EXEC
+                conversation_state(self.link_handler)[storage_id] = Flags.LINK_EXEC
                 self.msg_storage[storage_id] = ChatListStorage([chat])
                 return self.build_link_action_message(chat, tg_chat_id, tg_msg_id)
             if message.message_thread_id:
@@ -247,19 +257,19 @@ class ChatBindingManager(LocaleMixin):
                         topic_tg_chat_id = TelegramChatID(message.chat_id)
                         topic_tg_msg_id = TelegramMessageID(message.reply_text(self._("Processing...")).message_id)
                         topic_storage_id: Tuple[TelegramChatID, TelegramMessageID] = (topic_tg_chat_id, topic_tg_msg_id)
-                        self.link_handler.conversations[topic_storage_id] = Flags.LINK_EXEC
+                        conversation_state(self.link_handler)[topic_storage_id] = Flags.LINK_EXEC
                         self.msg_storage[topic_storage_id] = ChatListStorage([topic_chat])
                         return self.build_link_action_message(topic_chat, topic_tg_chat_id, topic_tg_msg_id)
 
+        forwarded_chat = forwarded_from_chat(message)
         if message.chat.type != telegram.Chat.PRIVATE:
             links = self.db.get_chat_assoc(
                 master_uid=utils.chat_id_to_str(self.channel.channel_id, ChatID(str(message.chat.id))))
             if links:
                 return self.link_chat_gen_list(TelegramChatID(message.chat.id), pattern=" ".join(args),
                                                chats=links, filter_availability=False)
-        elif message.forward_from_chat and \
-                message.forward_from_chat.type == telegram.Chat.CHANNEL:
-            chat_id = ChatID(str(message.forward_from_chat.id))
+        elif forwarded_chat and forwarded_chat.type == telegram.Chat.CHANNEL:
+            chat_id = ChatID(str(forwarded_chat.id))
             links = self.db.get_chat_assoc(
                 master_uid=utils.chat_id_to_str(self.channel.channel_id, chat_id))
             if links:
@@ -415,7 +425,7 @@ class ChatBindingManager(LocaleMixin):
         self.bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=msg_text,
                                    reply_markup=InlineKeyboardMarkup(chat_btn_list))
 
-        self.link_handler.conversations[(chat_id, message_id)] = Flags.LINK_CONFIRM
+        conversation_state(self.link_handler)[(chat_id, message_id)] = Flags.LINK_CONFIRM
 
         return Flags.LINK_CONFIRM
 
@@ -429,6 +439,7 @@ class ChatBindingManager(LocaleMixin):
             int: Next status
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_chat
         assert update.effective_message
         assert update.callback_query
@@ -436,10 +447,12 @@ class ChatBindingManager(LocaleMixin):
 
         tg_chat_id = TelegramChatID(update.effective_chat.id)
         tg_msg_id = TelegramMessageID(update.effective_message.message_id)
-        callback_uid: str = update.callback_query.data
+        query = sync_callback_query(update.callback_query)
+        callback_uid = query.data
+        assert callback_uid is not None
         if callback_uid.split()[0] == "offset":
             # Offer a new page of chats
-            update.callback_query.answer()
+            query.answer()
             return self.link_chat_gen_list(tg_chat_id, message_id=tg_msg_id, offset=int(callback_uid.split()[1]))
 
         if callback_uid == Flags.CANCEL_PROCESS:
@@ -449,8 +462,8 @@ class ChatBindingManager(LocaleMixin):
                                        chat_id=tg_chat_id,
                                        message_id=tg_msg_id)
             self.msg_storage.pop((tg_chat_id, tg_msg_id), None)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         if callback_uid[:4] != "chat":
             # The only possible command now is "chat".
@@ -459,15 +472,15 @@ class ChatBindingManager(LocaleMixin):
                                        chat_id=tg_chat_id,
                                        message_id=tg_msg_id)
             self.msg_storage.pop((tg_chat_id, tg_msg_id), None)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         callback_idx: int = int(callback_uid.split()[1])
         chat: ETMChatType = self.msg_storage[(tg_chat_id, tg_msg_id)].chats[callback_idx]
 
         self.build_link_action_message(chat, tg_chat_id, tg_msg_id)
 
-        update.callback_query.answer()
+        query.answer()
         return Flags.LINK_EXEC
 
     def build_link_action_message(self, chat: ETMChatType,
@@ -505,6 +518,7 @@ class ChatBindingManager(LocaleMixin):
         Action to link a chat. Triggered by callback message with status `Flags.LINK_EXEC`.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_chat
         assert update.effective_message
         assert update.callback_query
@@ -512,14 +526,16 @@ class ChatBindingManager(LocaleMixin):
 
         tg_chat_id = TelegramChatID(update.effective_chat.id)
         tg_msg_id = TelegramMessageID(update.effective_message.message_id)
-        callback_uid = update.callback_query.data
+        query = sync_callback_query(update.callback_query)
+        callback_uid = query.data
+        assert callback_uid is not None
 
         if callback_uid == Flags.CANCEL_PROCESS:
             txt = self._("Cancelled.")
             self.bot.edit_message_text(text=txt, chat_id=tg_chat_id, message_id=tg_msg_id)
             self.msg_storage.pop((tg_chat_id, tg_msg_id), None)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         cmd, chat_lid = callback_uid.split()
         chat: ETMChatType = self.msg_storage[(tg_chat_id, tg_msg_id)].chats[int(chat_lid)]
@@ -555,15 +571,16 @@ class ChatBindingManager(LocaleMixin):
             txt = self._("Command ‘{command}’ ({query}) is not recognised, please try again.") \
                 .format(command=cmd, query=callback_uid)
             self.bot.edit_message_text(text=txt, chat_id=tg_chat_id, message_id=tg_msg_id)
-        update.callback_query.answer()
+        query.answer()
         self.msg_storage.pop((tg_chat_id, tg_msg_id), None)
-        return ConversationHandler.END
+        return PTBConversationHandler.END
 
     def link_chat(self, update: Update, args: Optional[List[str]]):
         """Actual code of linking a chat by manipulating database.
         Triggered by ``/start BASE64(msg_id_to_str(chat_id, msg_id))``.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.message
         assert update.effective_message
         assert update.effective_chat
@@ -590,7 +607,7 @@ class ChatBindingManager(LocaleMixin):
                 message_id=storage_key[1])
 
         # Use channel ID if command is forwarded from a channel.
-        forwarded_chat = update.effective_message.forward_from_chat
+        forwarded_chat = forwarded_from_chat(update.effective_message)
         if forwarded_chat and forwarded_chat.type == telegram.Chat.CHANNEL:
             tg_chat_to_link = forwarded_chat
         else:
@@ -726,7 +743,7 @@ class ChatBindingManager(LocaleMixin):
                                                            len(links)).format(len(links)),
                                              reply_to_message_id=update.message.message_id)
         else:
-            forwarded_chat = update.message.forward_from_chat
+            forwarded_chat = forwarded_from_chat(update.message)
             if forwarded_chat and forwarded_chat.type == telegram.Chat.CHANNEL:
                 links = self.db.get_chat_assoc(
                     master_uid=utils.chat_id_to_str(self.channel.channel_id, ChatID(str(forwarded_chat.id))))
@@ -822,7 +839,7 @@ class ChatBindingManager(LocaleMixin):
                 self.bot.edit_message_text(text=msg_text,
                                            chat_id=chat_id,
                                            message_id=message_id)
-                return ConversationHandler.END
+                return PTBConversationHandler.END
             else:
                 msg_text = self._("This Telegram group is linked to the following chats, "
                                   "choose one to start a conversation with.")
@@ -840,7 +857,7 @@ class ChatBindingManager(LocaleMixin):
                                    message_id=message_id,
                                    reply_markup=InlineKeyboardMarkup(chat_btn_list))
 
-        self.chat_head_handler.conversations[(chat_id, message_id)] = Flags.CHAT_HEAD_CONFIRM
+        conversation_state(self.chat_head_handler)[(chat_id, message_id)] = Flags.CHAT_HEAD_CONFIRM
 
     def make_chat_head(self, update: Update, context: CallbackContext) -> int:
         """
@@ -849,6 +866,7 @@ class ChatBindingManager(LocaleMixin):
         This message is a part of the ``/chat`` conversation handler.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_chat
         assert update.effective_message
         assert update.callback_query
@@ -856,11 +874,13 @@ class ChatBindingManager(LocaleMixin):
 
         tg_chat_id = TelegramChatID(update.effective_chat.id)
         tg_msg_id = TelegramMessageID(update.effective_message.message_id)
-        callback_uid: str = update.callback_query.data
+        query = sync_callback_query(update.callback_query)
+        callback_uid = query.data
+        assert callback_uid is not None
 
         # Refresh with a new set of pages
         if callback_uid.split()[0] == "offset":
-            update.callback_query.answer()
+            query.answer()
             return self.chat_head_req_generate(tg_chat_id, message_id=tg_msg_id,
                                                offset=int(callback_uid.split()[1]))
         if callback_uid == Flags.CANCEL_PROCESS:
@@ -869,8 +889,8 @@ class ChatBindingManager(LocaleMixin):
             self.bot.edit_message_text(text=txt,
                                        chat_id=tg_chat_id,
                                        message_id=tg_msg_id)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         if not callback_uid.startswith("chat "):
             # Invalid command
@@ -879,8 +899,8 @@ class ChatBindingManager(LocaleMixin):
             self.bot.edit_message_text(text=txt,
                                        chat_id=tg_chat_id,
                                        message_id=tg_msg_id)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         callback_idx = int(callback_uid.split()[1])
         chat: ETMChatType = self.msg_storage[(tg_chat_id, tg_msg_id)].chats[callback_idx]
@@ -897,8 +917,8 @@ class ChatBindingManager(LocaleMixin):
         chat_head_etm.deliver_to = self.channel
         self.db.add_or_update_message_log(chat_head_etm, update.effective_message)
         self.bot.edit_message_text(text=txt, chat_id=tg_chat_id, message_id=tg_msg_id)
-        update.callback_query.answer()
-        return ConversationHandler.END
+        query.answer()
+        return PTBConversationHandler.END
 
     def register_suggestions(self, update: Update,
                              candidates: List[EFBChannelChatIDStr],
@@ -918,7 +938,7 @@ class ChatBindingManager(LocaleMixin):
                                                "or choose a recipient:\n\nLegend:\n") + "\n".join(legends),
                                    chat_id=chat_id, message_id=message_id,
                                    reply_markup=InlineKeyboardMarkup(buttons))
-        self.suggestion_handler.conversations[storage_id] = Flags.SUGGEST_RECIPIENTS
+        conversation_state(self.suggestion_handler)[storage_id] = Flags.SUGGEST_RECIPIENTS
 
     def suggested_recipient(self, update: Update, context: CallbackContext):
         """Send the message to selected recipient among all suggested when a
@@ -927,6 +947,7 @@ class ChatBindingManager(LocaleMixin):
         Triggered by flag ``SUGGEST_RECIPIENTS``.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
         assert update.effective_chat
         assert update.callback_query
@@ -934,7 +955,9 @@ class ChatBindingManager(LocaleMixin):
 
         chat_id = TelegramChatID(update.effective_chat.id)
         msg_id = TelegramMessageID(update.effective_message.message_id)
-        param = update.callback_query.data
+        query = sync_callback_query(update.callback_query)
+        param = query.data
+        assert param is not None
 
         storage_id = (chat_id, msg_id)
         if param.startswith("chat "):
@@ -946,7 +969,7 @@ class ChatBindingManager(LocaleMixin):
                                            message_id=msg_id)
             update_ = self.msg_storage[storage_id].update
             assert update_
-            update = update_
+            update = sync_update(update_)
             chats = self.msg_storage[storage_id].chats
             if not chats:
                 self.bot.edit_message_text(text=self._("Error: No recipient specified.\n"
@@ -955,8 +978,8 @@ class ChatBindingManager(LocaleMixin):
                                            chat_id=chat_id,
                                            message_id=msg_id)
                 if update.callback_query:
-                    update.callback_query.answer()
-                return ConversationHandler.END
+                    sync_callback_query(update.callback_query).answer()
+                return PTBConversationHandler.END
             slave_chat = chats[int(param.split(' ', 1)[1])]
             slave_chat_id = utils.chat_id_to_str(chat=slave_chat)
             self.channel.master_messages.process_telegram_message(update, context, slave_chat_id)
@@ -976,8 +999,8 @@ class ChatBindingManager(LocaleMixin):
                                        message_id=msg_id)
         del self.msg_storage[storage_id]
         if update.callback_query:
-            update.callback_query.answer()
-        return ConversationHandler.END
+            sync_callback_query(update.callback_query).answer()
+        return PTBConversationHandler.END
 
     def update_group_info(self, update: Update, context: CallbackContext):
         """
@@ -987,6 +1010,7 @@ class ChatBindingManager(LocaleMixin):
         Triggered by ``/update_info`` command.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
         assert update.effective_chat
 
@@ -997,9 +1021,9 @@ class ChatBindingManager(LocaleMixin):
         # if update.effective_chat.is_forum:
         #     return self.update_thread_info(update, context)
 
-        forwarded_from_chat = update.effective_message.forward_from_chat
-        if forwarded_from_chat and forwarded_from_chat.type == telegram.Chat.CHANNEL:
-            tg_chat = forwarded_from_chat
+        forwarded_chat = forwarded_from_chat(update.effective_message)
+        if forwarded_chat and forwarded_chat.type == telegram.Chat.CHANNEL:
+            tg_chat = forwarded_chat
         else:
             tg_chat = update.effective_chat
 
@@ -1013,7 +1037,7 @@ class ChatBindingManager(LocaleMixin):
                     TelegramChatID(tg_chat.id), TelegramTopicID(current_thread_id) if current_thread_id else None
                 )
                 if success:
-                    update.effective_message.reply_text(message)
+                    sync_message(update.effective_message).reply_text(message)
                 else:
                     return self.bot.reply_error(update, message)
             except Exception as e:
@@ -1058,7 +1082,7 @@ class ChatBindingManager(LocaleMixin):
             else:
                 raise EFBOperationNotSupported()
 
-            update.effective_message.reply_text(self._('Chat details updated.'))
+            sync_message(update.effective_message).reply_text(self._('Chat details updated.'))
         except EFBChatNotFound:
             self.logger.exception("Chat linked (%s) is not found in the slave channel "
                                   "(%s).", channel_id, chat_uid)
@@ -1272,6 +1296,7 @@ class ChatBindingManager(LocaleMixin):
 
     def update_thread_info(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
         assert update.effective_chat
 
@@ -1298,7 +1323,7 @@ class ChatBindingManager(LocaleMixin):
                 name=self.truncate_ellipsis(etm_chat.chat_title, self.MAX_LEN_CHAT_TITLE),
                 icon_custom_emoji_id=""  # param required by telegram
             )
-            update.effective_message.reply_text(self._('Chat details updated.'))
+            sync_message(update.effective_message).reply_text(self._('Chat details updated.'))
         except EFBChatNotFound:
             self.logger.exception("Chat linked (%s) is not found in the slave channel "
                                   "(%s).", channel_id, chat_uid)
@@ -1308,7 +1333,7 @@ class ChatBindingManager(LocaleMixin):
                                                 chat_uid=chat_uid))
         except TelegramError as e:
             if e.message == "Topic_not_modified":
-                update.effective_message.reply_text(self._('Chat details updated.'))
+                sync_message(update.effective_message).reply_text(self._('Chat details updated.'))
             else:
                 self.logger.exception("Error occurred while update chat details.")
                 return self.bot.reply_error(update, self._('Error occurred while update chat details.\n'

--- a/efb_telegram_master/commands.py
+++ b/efb_telegram_master/commands.py
@@ -4,7 +4,7 @@ import logging
 from typing import Tuple, Dict, TYPE_CHECKING, List, Any, Union, Optional
 
 from telegram import Message, Update
-from telegram.ext import CallbackContext, ConversationHandler, filters
+from telegram.ext import CallbackContext, ConversationHandler as PTBConversationHandler, filters
 
 from ehforwarderbot import coordinator, Channel, Middleware
 from ehforwarderbot.channel import SlaveChannel
@@ -12,7 +12,14 @@ from ehforwarderbot.message import MessageCommand
 from ehforwarderbot.types import ExtraCommandName
 from .constants import Flags
 from .locale_mixin import LocaleMixin
-from .ptb_compat import CallbackQueryHandler, CommandHandler, MessageHandler
+from .ptb_compat import (
+    CallbackQueryHandler,
+    CommandHandler,
+    MessageHandler,
+    conversation_state,
+    sync_callback_query,
+    sync_update,
+)
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -53,7 +60,7 @@ class CommandsManager(LocaleMixin):
                 filters.Regex(r"^/(?P<id>[0-9]+)_(?P<command>[a-z0-9_-]+)"),
                 self.extra_call))
 
-        self.command_conv = ConversationHandler(
+        self.command_conv = PTBConversationHandler(
             entry_points=[],
             states={Flags.COMMAND_PENDING: [CallbackQueryHandler(self.command_exec)]},
             fallbacks=[CallbackQueryHandler(self.bot.session_expired)],
@@ -71,7 +78,7 @@ class CommandsManager(LocaleMixin):
 
     def register_command(self, message: Message, commands: ETMCommandMsgStorage):
         message_identifier = (message.chat.id, message.message_id)
-        self.command_conv.conversations[message_identifier] = Flags.COMMAND_PENDING
+        conversation_state(self.command_conv)[message_identifier] = Flags.COMMAND_PENDING
         self.msg_storage[message_identifier] = commands
 
     def command_exec(self, update: Update, context: CallbackContext) -> Optional[int]:
@@ -85,13 +92,15 @@ class CommandsManager(LocaleMixin):
             The next state
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_chat
         assert update.effective_message
         assert update.callback_query
 
         chat_id = update.effective_chat.id
         message_id = update.effective_message.message_id
-        callback = update.callback_query.data
+        query = sync_callback_query(update.callback_query)
+        callback = query.data
 
         assert callback
 
@@ -101,14 +110,14 @@ class CommandsManager(LocaleMixin):
             msg = self._("Invalid parameter: {0}. (CE01)").format(callback)
             self.msg_storage.pop(index, None)
             self.bot.edit_message_text(text=msg, chat_id=chat_id, message_id=message_id)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
         elif not (0 <= int(callback) < len(self.msg_storage[index].commands)):
             msg = self._("Index out of bound: {0}. (CE02)").format(callback)
             self.msg_storage.pop(index, None)
             self.bot.edit_message_text(text=msg, chat_id=chat_id, message_id=message_id)
-            update.callback_query.answer()
-            return ConversationHandler.END
+            query.answer()
+            return PTBConversationHandler.END
 
         callback_idx = int(callback)
         command_storage = self.msg_storage[index]
@@ -119,7 +128,7 @@ class CommandsManager(LocaleMixin):
         self.logger.debug("[%s.%s] Command execution callback is valid. Command storage item: %s", chat_id, message_id, command_storage)
 
         # Clear inline buttons.
-        update.callback_query.edit_message_reply_markup(None)
+        query.edit_message_reply_markup(None)
         self.logger.debug("[%s.%s] Inline buttons cleared", chat_id, message_id)
 
         fn = getattr(module, command.callable_name, None)
@@ -141,13 +150,13 @@ class CommandsManager(LocaleMixin):
         # self.bot.edit_message_text(prefix=prefix, text=msg,
         #                            chat_id=chat_id, message_id=message_id)
         if msg is None:
-            update.callback_query.answer()
+            query.answer()
             return None
         self.bot.answer_callback_query(
             prefix=prefix, text=msg,
-            callback_query_id=update.callback_query.id
+            callback_query_id=query.id
         )
-        return ConversationHandler.END
+        return PTBConversationHandler.END
 
     def extra_listing(self, update: Update, context: CallbackContext):
         """

--- a/efb_telegram_master/commands.py
+++ b/efb_telegram_master/commands.py
@@ -4,8 +4,7 @@ import logging
 from typing import Tuple, Dict, TYPE_CHECKING, List, Any, Union, Optional
 
 from telegram import Message, Update
-from telegram.ext import CommandHandler, ConversationHandler, CallbackQueryHandler, MessageHandler, CallbackContext
-from telegram.ext.filters import Filters
+from telegram.ext import CallbackContext, ConversationHandler, filters
 
 from ehforwarderbot import coordinator, Channel, Middleware
 from ehforwarderbot.channel import SlaveChannel
@@ -13,6 +12,7 @@ from ehforwarderbot.message import MessageCommand
 from ehforwarderbot.types import ExtraCommandName
 from .constants import Flags
 from .locale_mixin import LocaleMixin
+from .ptb_compat import CallbackQueryHandler, CommandHandler, MessageHandler
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -46,11 +46,11 @@ class CommandsManager(LocaleMixin):
             CommandHandler("extra", self.extra_listing))
         self.bot.dispatcher.add_handler(
             MessageHandler(
-                Filters.regex(r"^/h_(?P<id>[0-9]+)_(?P<command>[a-z0-9_-]+)"),
+                filters.Regex(r"^/h_(?P<id>[0-9]+)_(?P<command>[a-z0-9_-]+)"),
                 self.extra_usage))
         self.bot.dispatcher.add_handler(
             MessageHandler(
-                Filters.regex(r"^/(?P<id>[0-9]+)_(?P<command>[a-z0-9_-]+)"),
+                filters.Regex(r"^/(?P<id>[0-9]+)_(?P<command>[a-z0-9_-]+)"),
                 self.extra_call))
 
         self.command_conv = ConversationHandler(

--- a/efb_telegram_master/locale_handler.py
+++ b/efb_telegram_master/locale_handler.py
@@ -6,14 +6,14 @@ from pkg_resources import resource_filename
 from typing import TYPE_CHECKING
 
 from language_tags import tags
-from telegram.ext.handler import Handler
+from telegram.ext import BaseHandler
 from telegram import Update
 
 if TYPE_CHECKING:
     from . import TelegramChannel
 
 
-class LocaleHandler(Handler):
+class LocaleHandler(BaseHandler):
     """
     Handler class Extract.
 
@@ -25,10 +25,12 @@ class LocaleHandler(Handler):
     """
 
     def __init__(self, channel: 'TelegramChannel', pass_update_queue: bool = False):
-        def void_function(*args, **kwargs):
+        del pass_update_queue
+
+        async def void_function(*args, **kwargs):
             pass
 
-        super().__init__(void_function, pass_update_queue)
+        super().__init__(void_function)
         self.logger = logging.getLogger(__name__)
 
         self.channel = channel
@@ -58,5 +60,5 @@ class LocaleHandler(Handler):
                                                           fallback=True)
         return False
 
-    def handle_update(self, update, dispatcher, check_result, context=None):
+    async def handle_update(self, update, dispatcher, check_result, context=None):
         pass

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -8,7 +8,7 @@ from typing import Optional, TYPE_CHECKING, Tuple, Any
 
 import humanize
 from telegram import Update, Message, Chat, Contact, File
-from telegram.constants import MAX_FILESIZE_DOWNLOAD
+from telegram.constants import FileSizeLimit
 from telegram.error import TelegramError
 from telegram.ext import CallbackContext, filters
 from telegram.helpers import escape_markdown
@@ -25,7 +25,7 @@ from .chat_destination_cache import ChatDestinationCache
 from .locale_mixin import LocaleMixin
 from .message import ETMMsg
 from .msg_type import TGMsgType, get_msg_type
-from .ptb_compat import CommandHandler, MessageHandler
+from .ptb_compat import CommandHandler, MessageHandler, sync_message, sync_update
 from .utils import EFBChannelChatIDStr, TelegramChatID, TelegramMessageID
 
 if TYPE_CHECKING:
@@ -107,6 +107,7 @@ class MasterMessageProcessor(LocaleMixin):
                 self.logger.exception(
                     "Error [%r] occurred while processing update %s.", e, update)
                 if update.effective_message:
+                    update = sync_update(update)
                     update.effective_message.reply_text(
                         self._("Unknown error has occurred while "
                                "trying to process this message. See log for "
@@ -137,11 +138,12 @@ class MasterMessageProcessor(LocaleMixin):
 
     def enqueue_message(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
+        update = sync_update(update)
 
         self.message_queue.put((update, context))
         if not self.message_worker_thread.is_alive():
             if update.effective_message:
-                update.effective_message.reply_text(
+                sync_message(update.effective_message).reply_text(
                     self._(
                         "ETM message worker is not running due to unforeseen reason. This might be a bug. Please see log for details."))
 
@@ -150,10 +152,11 @@ class MasterMessageProcessor(LocaleMixin):
         Process, wrap and dispatch messages from user.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
         assert update.effective_chat
 
-        message: Message = update.effective_message
+        message = sync_message(update.effective_message)
         mid = utils.message_id_to_str(update=update)
 
         self.logger.debug("[%s] Received message from Telegram: %s", mid, message.to_dict())
@@ -194,7 +197,8 @@ class MasterMessageProcessor(LocaleMixin):
                         if topic_id == thread_id:
                             self.logger.debug("[%s] Chat %s is singly-linked to %s in topic %s", mid, message.chat, dest, topic_id)
                             destination = dest
-                            quote = message.reply_to_message.message_id != message.reply_to_message.message_thread_id
+                            reply_to_message = message.reply_to_message
+                            quote = bool(reply_to_message and reply_to_message.message_id != reply_to_message.message_thread_id)
                             if not quote:
                                 message.reply_to_message = None  # type: ignore[assignment]
                             break
@@ -276,12 +280,13 @@ class MasterMessageProcessor(LocaleMixin):
             edited: old message log entry if the message can be edited.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
 
         # Message ID for logging
         message_id = utils.message_id_to_str(update=update)
 
-        message: Message = update.effective_message
+        message = sync_message(update.effective_message)
 
         channel, uid, gid = utils.chat_id_str_to_id(destination)
         if channel not in coordinator.slaves:
@@ -293,7 +298,8 @@ class MasterMessageProcessor(LocaleMixin):
         try:
             m.uid = MessageID(message_id)
             # Store Telegram message type
-            m.type_telegram = mtype = get_msg_type(message)
+            raw_message = message.wrapped_message
+            m.type_telegram = mtype = get_msg_type(raw_message)
 
             if self.TYPE_DICT.get(mtype, None):
                 m.type = self.TYPE_DICT[mtype]
@@ -305,7 +311,7 @@ class MasterMessageProcessor(LocaleMixin):
                     self._("{type_name} messages are not supported by EFB Telegram Master channel.")
                         .format(type_name=mtype.name))
 
-            m.put_telegram_file(message)
+            m.put_telegram_file(raw_message)
             # Chat and author related stuff
             m.chat = self.chat_manager.get_chat(channel, uid, build_dummy=True)
             m.author = m.chat.self or m.chat.add_self()
@@ -313,7 +319,7 @@ class MasterMessageProcessor(LocaleMixin):
             m.deliver_to = coordinator.slaves[channel]
 
             if quote:
-                self.attach_target_message(message, m, channel)
+                self.attach_target_message(raw_message, m, channel)
             # Type specific stuff
             self.logger.debug("[%s] Message type from Telegram: %s", message_id, mtype)
 
@@ -518,7 +524,7 @@ class MasterMessageProcessor(LocaleMixin):
                 dest_name = dest_chat.full_name
             else:
                 dest_name = cached_dest
-            update.effective_message.reply_text(
+            sync_message(update.effective_message).reply_text(
                 self._(
                     "This message is sent to “{dest}” with quick reply feature.\n"
                     "\n"
@@ -541,9 +547,9 @@ class MasterMessageProcessor(LocaleMixin):
         """
         size = getattr(file_obj, "file_size", None)
         if size and not self.channel.flag("local_tdlib_api")\
-                and size > MAX_FILESIZE_DOWNLOAD:
+                and size > FileSizeLimit.FILESIZE_DOWNLOAD:
             size_str = humanize.naturalsize(size)
-            max_size_str = humanize.naturalsize(MAX_FILESIZE_DOWNLOAD)
+            max_size_str = humanize.naturalsize(FileSizeLimit.FILESIZE_DOWNLOAD)
             raise EFBMessageError(
                 self._(
                     "Attachment is too large ({size}). Maximum allowed by Telegram Bot API is {max_size}. (AT01)").format(
@@ -554,14 +560,15 @@ class MasterMessageProcessor(LocaleMixin):
         Triggered by command ``/rm``.
         """
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.message
 
-        message: Message = update.message
+        message = sync_message(update.message)
         if message.reply_to_message is None:
             return self.bot.reply_error(update, self._(
                 "Reply /rm to a message to remove it from its remote chat."
             ))
-        reply: Message = message.reply_to_message
+        reply = sync_message(message.reply_to_message)
         msg_log = self.db.get_msg_log(
             master_msg_id=utils.message_id_to_str(
                 chat_id=TelegramChatID(reply.chat_id),
@@ -606,6 +613,7 @@ class MasterMessageProcessor(LocaleMixin):
 
     def unsupported_message(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)
+        update = sync_update(update)
         assert update.effective_message
 
         message_type = get_msg_type(update.effective_message)

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -7,10 +7,11 @@ from threading import Thread
 from typing import Optional, TYPE_CHECKING, Tuple, Any
 
 import humanize
-from telegram import Update, Message, Chat, TelegramError, Contact, File
+from telegram import Update, Message, Chat, Contact, File
 from telegram.constants import MAX_FILESIZE_DOWNLOAD
-from telegram.ext import MessageHandler, Filters, CallbackContext, CommandHandler
-from telegram.utils.helpers import escape_markdown
+from telegram.error import TelegramError
+from telegram.ext import CallbackContext, filters
+from telegram.helpers import escape_markdown
 
 from ehforwarderbot import coordinator
 from ehforwarderbot.constants import MsgType
@@ -24,6 +25,7 @@ from .chat_destination_cache import ChatDestinationCache
 from .locale_mixin import LocaleMixin
 from .message import ETMMsg
 from .msg_type import TGMsgType, get_msg_type
+from .ptb_compat import CommandHandler, MessageHandler
 from .utils import EFBChannelChatIDStr, TelegramChatID, TelegramMessageID
 
 if TYPE_CHECKING:
@@ -69,15 +71,15 @@ class MasterMessageProcessor(LocaleMixin):
         self.bot.dispatcher.add_handler(CommandHandler("rm", self.delete_message))
 
         self.bot.dispatcher.add_handler(MessageHandler(
-            (Filters.text | Filters.photo | Filters.sticker | Filters.document |
-             Filters.venue | Filters.location | Filters.audio | Filters.voice |
-             Filters.video | Filters.contact | Filters.video_note | Filters.dice) &
-            Filters.update,
+            (filters.TEXT | filters.PHOTO | filters.Sticker.ALL | filters.Document.ALL |
+             filters.VENUE | filters.LOCATION | filters.AUDIO | filters.VOICE |
+             filters.VIDEO | filters.CONTACT | filters.VIDEO_NOTE | filters.Dice.ALL) &
+            filters.UpdateType.MESSAGE,
             self.enqueue_message
         ))
         self.bot.dispatcher.add_handler(MessageHandler(
-            (Filters.passport_data | Filters.invoice | Filters.game | Filters.successful_payment |
-             Filters.poll) & Filters.update,
+            (filters.PASSPORT_DATA | filters.INVOICE | filters.GAME | filters.SUCCESSFUL_PAYMENT |
+             filters.POLL) & filters.UpdateType.MESSAGE,
             self.unsupported_message
         ))
         self.logger: logging.Logger = logging.getLogger(__name__)

--- a/efb_telegram_master/message.py
+++ b/efb_telegram_master/message.py
@@ -18,6 +18,7 @@ from . import utils
 from .chat import ETMChatType, ETMChatMember
 from .chat_object_cache import ChatObjectCacheManager
 from .msg_type import TGMsgType
+from .ptb_compat import run_sync
 
 if TYPE_CHECKING:
     pass
@@ -95,7 +96,7 @@ class ETMMsg(Message):
                 ext = mimetypes.guess_extension(self.mime, strict=False)
                 mime = self.mime
             file = tempfile.NamedTemporaryFile(suffix=ext)
-            file_meta.download(out=file)
+            run_sync(file_meta.download_to_drive(custom_path=file.name))
             file.seek(0)
 
             if not mime:

--- a/efb_telegram_master/ptb_compat.py
+++ b/efb_telegram_master/ptb_compat.py
@@ -1,0 +1,358 @@
+# coding=utf-8
+import asyncio
+import inspect
+import threading
+from functools import wraps
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+
+import telegram
+from telegram.request import HTTPXRequest
+from telegram.ext import (
+    Application,
+    ApplicationBuilder,
+    BaseHandler,
+    CallbackQueryHandler as PTBCallbackQueryHandler,
+    CommandHandler as PTBCommandHandler,
+    ConversationHandler as PTBConversationHandler,
+    MessageHandler as PTBMessageHandler,
+)
+
+
+class SyncTelegramBot:
+    """Synchronous facade for PTB's asyncio-based Bot methods."""
+
+    def __init__(self, bot: telegram.Bot):
+        self._bot = bot
+
+    @property
+    def wrapped_bot(self) -> telegram.Bot:
+        return self._bot
+
+    def __getattr__(self, item: str) -> Any:
+        attr = getattr(self._bot, item)
+        if callable(attr):
+            @wraps(attr)
+            def call(*args, **kwargs):
+                return run_sync(attr(*args, **kwargs))
+
+            return call
+        return attr
+
+
+class SyncApplication:
+    """Expose the PTB v13 dispatcher surface used by this package."""
+
+    def __init__(self, application: Application):
+        self.application = application
+        self.bot = SyncTelegramBot(application.bot)
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def dispatcher(self) -> "SyncApplication":
+        return self
+
+    def add_handler(self, handler: BaseHandler, *args, **kwargs):
+        return self.application.add_handler(handler, *args, **kwargs)
+
+    def add_error_handler(self, callback: Callable, *args, **kwargs):
+        return self.application.add_error_handler(wrap_callback(callback), *args, **kwargs)
+
+    def start_polling(self, *args, **kwargs):
+        kwargs.setdefault("stop_signals", None)
+        return self._start_thread(self.application.run_polling, *args, **kwargs)
+
+    def start_webhook(self, *args, **kwargs):
+        kwargs.setdefault("stop_signals", None)
+        return self._start_thread(self.application.run_webhook, *args, **kwargs)
+
+    def stop(self):
+        stop_running = getattr(self.application, "stop_running", None)
+        if callable(stop_running):
+            try:
+                stop_running()
+            except RuntimeError:
+                pass
+        if getattr(self.application, "running", False):
+            run_sync(self.application.stop())
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=10)
+        return None
+
+    def _start_thread(self, target: Callable, *args, **kwargs):
+        if self._thread is not None and self._thread.is_alive():
+            return None
+
+        def run():
+            target(*args, **kwargs)
+
+        self._thread = threading.Thread(target=run, daemon=True, name="ETM Telegram application")
+        self._thread.start()
+        return None
+
+
+class SyncCallbackQuery:
+    def __init__(self, callback_query: Any, bot: Optional[SyncTelegramBot] = None):
+        self._callback_query = callback_query
+        self._bot = bot
+
+    def __getattr__(self, item: str) -> Any:
+        attr = getattr(self._callback_query, item)
+        if callable(attr):
+            @wraps(attr)
+            def call(*args, **kwargs):
+                return run_sync(attr(*args, **kwargs))
+
+            return call
+        return attr
+
+    @property
+    def __class__(self):
+        return self._callback_query.__class__
+
+    @property
+    def message(self):
+        message = self._callback_query.message
+        if message is None:
+            return None
+        return SyncMessage(message, self._bot)
+
+
+class SyncMessage:
+    def __init__(self, message: Any, bot: Optional[SyncTelegramBot] = None):
+        self._message = message
+        self._bot = bot
+
+    def __getattr__(self, item: str) -> Any:
+        attr = getattr(self._message, item)
+        if callable(attr):
+            @wraps(attr)
+            def call(*args, **kwargs):
+                if item.startswith("reply_") and "quote" in kwargs and "do_quote" not in kwargs:
+                    kwargs["do_quote"] = kwargs.pop("quote")
+                return run_sync(attr(*args, **kwargs))
+
+            return call
+        return attr
+
+    @property
+    def __class__(self):
+        return self._message.__class__
+
+    @property
+    def bot(self):
+        if self._bot is not None:
+            return self._bot
+        bot = getattr(self._message, "bot", None)
+        if bot is None:
+            return None
+        return SyncTelegramBot(bot)
+
+
+class SyncUpdate:
+    def __init__(self, update: Any, bot: Optional[SyncTelegramBot] = None):
+        self._update = update
+        self._bot = bot
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._update, item)
+
+    @property
+    def __class__(self):
+        return self._update.__class__
+
+    @property
+    def callback_query(self):
+        callback_query = self._update.callback_query
+        if callback_query is None:
+            return None
+        return SyncCallbackQuery(callback_query, self._bot)
+
+    def _message(self, attr: str):
+        message = getattr(self._update, attr)
+        if message is None:
+            return None
+        return SyncMessage(message, self._bot)
+
+    @property
+    def message(self):
+        return self._message("message")
+
+    @property
+    def edited_message(self):
+        return self._message("edited_message")
+
+    @property
+    def channel_post(self):
+        return self._message("channel_post")
+
+    @property
+    def edited_channel_post(self):
+        return self._message("edited_channel_post")
+
+    @property
+    def effective_message(self):
+        return self._message("effective_message")
+
+
+SUPPORTED_REQUEST_KWARGS = {
+    "connection_pool_size",
+    "connect_timeout",
+    "http_version",
+    "media_write_timeout",
+    "pool_timeout",
+    "proxy",
+    "read_timeout",
+    "socket_options",
+    "write_timeout",
+}
+
+
+def _proxy_with_auth(proxy: Any, username: Any, password: Any) -> Any:
+    if (
+        username is None
+        or password is None
+        or not isinstance(proxy, str)
+        or "://" not in proxy
+        or "@" in proxy
+    ):
+        return proxy
+    scheme, rest = proxy.split("://", 1)
+    return f"{scheme}://{username}:{password}@{rest}"
+
+
+def build_request_kwargs(request_kwargs: Optional[dict]) -> Dict[str, Any]:
+    if not request_kwargs:
+        return {}
+    kwargs = dict(request_kwargs)
+    if "proxy_url" in kwargs:
+        kwargs["proxy"] = kwargs.pop("proxy_url")
+    username = kwargs.pop("username", None)
+    password = kwargs.pop("password", None)
+    proxy_auth = kwargs.pop("urllib3_proxy_kwargs", None)
+    if proxy_auth:
+        username = proxy_auth.get("username", username)
+        password = proxy_auth.get("password", password)
+    if "proxy" in kwargs:
+        kwargs["proxy"] = _proxy_with_auth(kwargs["proxy"], username, password)
+    return {key: value for key, value in kwargs.items() if key in SUPPORTED_REQUEST_KWARGS}
+
+
+def build_request(request_kwargs: Optional[dict]) -> Optional[HTTPXRequest]:
+    kwargs = build_request_kwargs(request_kwargs)
+    if not kwargs:
+        return None
+    return HTTPXRequest(**kwargs)
+
+
+def build_application(token: str, *, base_url=None, base_file_url=None,
+                      request_kwargs: Optional[dict] = None) -> SyncApplication:
+    builder: ApplicationBuilder = Application.builder().token(token)
+    if base_url:
+        builder = builder.base_url(base_url)
+    if base_file_url:
+        builder = builder.base_file_url(base_file_url)
+    for name, value in build_request_kwargs(request_kwargs).items():
+        setter = getattr(builder, name, None)
+        if callable(setter):
+            builder = setter(value)
+    return SyncApplication(builder.build())
+
+
+def build_bot(token: str, *, base_url=None, base_file_url=None,
+              request_kwargs: Optional[dict] = None) -> SyncTelegramBot:
+    kwargs: Dict[str, Any] = {}
+    if base_url:
+        kwargs["base_url"] = base_url
+    if base_file_url:
+        kwargs["base_file_url"] = base_file_url
+    request = build_request(request_kwargs)
+    if request is not None:
+        kwargs["request"] = request
+    return SyncTelegramBot(telegram.Bot(token=token, **kwargs))
+
+
+def run_sync(value):
+    if not inspect.isawaitable(value):
+        return value
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(value)
+
+    result = {}
+    error = {}
+
+    def runner():
+        try:
+            result["value"] = asyncio.run(value)
+        except BaseException as e:
+            error["value"] = e
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if error:
+        raise error["value"]
+    return result.get("value")
+
+
+def wrap_callback(callback: Callable) -> Callable:
+    if inspect.iscoroutinefunction(callback):
+        return callback
+
+    @wraps(callback)
+    async def wrapped(update, context):
+        sync_update = SyncUpdate(update, SyncTelegramBot(context.bot))
+        return callback(sync_update, context)
+
+    return wrapped
+
+
+def wrap_handler_callback(handler: BaseHandler) -> BaseHandler:
+    callback = getattr(handler, "callback", None)
+    if callable(callback):
+        handler.callback = wrap_callback(callback)
+    return handler
+
+
+def wrap_handler_callbacks(handlers: Iterable[BaseHandler]) -> list:
+    return [wrap_handler_callback(handler) for handler in handlers]
+
+
+def wrap_conversation_state_handlers(states: Mapping[Any, Iterable[BaseHandler]]) -> Dict[Any, list]:
+    return {
+        state: wrap_handler_callbacks(handlers)
+        for state, handlers in states.items()
+    }
+
+
+def CommandHandler(command, callback, *args, **kwargs):
+    return PTBCommandHandler(command, wrap_callback(callback), *args, **kwargs)
+
+
+def CallbackQueryHandler(callback, *args, **kwargs):
+    return PTBCallbackQueryHandler(wrap_callback(callback), *args, **kwargs)
+
+
+def MessageHandler(filters, callback, *args, **kwargs):
+    return PTBMessageHandler(filters, wrap_callback(callback), *args, **kwargs)
+
+
+class ConversationHandler(PTBConversationHandler):
+    def __init__(self, entry_points, states, fallbacks, *args, **kwargs):
+        super().__init__(
+            wrap_handler_callbacks(entry_points),
+            wrap_conversation_state_handlers(states),
+            wrap_handler_callbacks(fallbacks),
+            *args,
+            **kwargs,
+        )
+
+
+def forbidden_errors():
+    return tuple(
+        error for error in (
+            getattr(telegram.error, "Forbidden", None),
+            getattr(telegram.error, "InvalidToken", None),
+        ) if error is not None
+    )

--- a/efb_telegram_master/ptb_compat.py
+++ b/efb_telegram_master/ptb_compat.py
@@ -3,7 +3,7 @@ import asyncio
 import inspect
 import threading
 from functools import wraps
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, TYPE_CHECKING, cast
 
 import telegram
 from telegram.request import HTTPXRequest
@@ -16,6 +16,10 @@ from telegram.ext import (
     ConversationHandler as PTBConversationHandler,
     MessageHandler as PTBMessageHandler,
 )
+
+if TYPE_CHECKING:
+    from telegram import Chat, Message
+    from telegram.ext import CallbackContext
 
 
 class SyncTelegramBot:
@@ -106,11 +110,7 @@ class SyncCallbackQuery:
         return attr
 
     @property
-    def __class__(self):
-        return self._callback_query.__class__
-
-    @property
-    def message(self):
+    def message(self) -> Any:
         message = self._callback_query.message
         if message is None:
             return None
@@ -135,10 +135,6 @@ class SyncMessage:
         return attr
 
     @property
-    def __class__(self):
-        return self._message.__class__
-
-    @property
     def bot(self):
         if self._bot is not None:
             return self._bot
@@ -146,6 +142,10 @@ class SyncMessage:
         if bot is None:
             return None
         return SyncTelegramBot(bot)
+
+    @property
+    def wrapped_message(self) -> Any:
+        return self._message
 
 
 class SyncUpdate:
@@ -157,17 +157,13 @@ class SyncUpdate:
         return getattr(self._update, item)
 
     @property
-    def __class__(self):
-        return self._update.__class__
-
-    @property
-    def callback_query(self):
+    def callback_query(self) -> Any:
         callback_query = self._update.callback_query
         if callback_query is None:
             return None
         return SyncCallbackQuery(callback_query, self._bot)
 
-    def _message(self, attr: str):
+    def _message(self, attr: str) -> Any:
         message = getattr(self._update, attr)
         if message is None:
             return None
@@ -347,6 +343,35 @@ class ConversationHandler(PTBConversationHandler):
             *args,
             **kwargs,
         )
+
+    @property
+    def conversations(self):
+        return self._conversations
+
+
+def conversation_state(handler: PTBConversationHandler) -> Dict[Any, object]:
+    return cast(Dict[Any, object], handler._conversations)
+
+
+def sync_update(update: telegram.Update) -> Any:
+    return cast(Any, update)
+
+
+def sync_message(message: Any) -> Any:
+    return cast(SyncMessage, message)
+
+
+def sync_callback_query(callback_query: Any) -> Any:
+    return cast(SyncCallbackQuery, callback_query)
+
+
+def forwarded_from_chat(message: Any) -> Optional["Chat"]:
+    forward_origin = getattr(message, "forward_origin", None)
+    if forward_origin is not None:
+        origin_chat = getattr(forward_origin, "chat", None)
+        if origin_chat is not None:
+            return cast("Chat", origin_chat)
+    return cast(Optional["Chat"], getattr(message, "forward_from_chat", None))
 
 
 def forbidden_errors():

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -19,8 +19,10 @@ import telegram.error
 import telegram.ext
 from PIL import Image
 from telegram import InputFile, InputMediaPhoto, InputMediaDocument, InputMediaVideo, InputMediaAnimation, \
-    InlineKeyboardMarkup, InlineKeyboardButton, ReplyMarkup, TelegramError, InputMedia
-from telegram.constants import ChatAction
+    InlineKeyboardMarkup, InlineKeyboardButton, InputMedia
+from telegram.constants import ChatAction, FileSizeLimit
+from telegram.error import TelegramError
+from telegram._utils.types import ReplyMarkup
 
 from ehforwarderbot import Message, Status, coordinator
 from ehforwarderbot.chat import ChatNotificationState, SelfChatMember, GroupChat, PrivateChat, SystemChat, Chat
@@ -778,8 +780,8 @@ class SlaveMessageProcessor(LocaleMixin):
             description.append([InlineKeyboardButton(msg.text, callback_data="void")])
         if reactions:
             description.append([InlineKeyboardButton(reactions, callback_data="void")])
-        effective_reply_markup = reply_markup if isinstance(reply_markup, InlineKeyboardMarkup) else InlineKeyboardMarkup([])
-        effective_reply_markup.inline_keyboard = description + effective_reply_markup.inline_keyboard
+        keyboard = [list(row) for row in reply_markup.inline_keyboard] if isinstance(reply_markup, InlineKeyboardMarkup) else []
+        effective_reply_markup = InlineKeyboardMarkup(description + keyboard)
         return effective_reply_markup
 
 
@@ -864,7 +866,7 @@ class SlaveMessageProcessor(LocaleMixin):
                             target_msg_id: Optional[TelegramMessageID] = None,
                             reply_markup: Optional[ReplyMarkup] = None,
                             silent: bool = False) -> telegram.Message:
-        self.bot.send_chat_action(tg_dest, ChatAction.RECORD_AUDIO, message_thread_id=thread_id)
+        self.bot.send_chat_action(tg_dest, ChatAction.RECORD_VOICE, message_thread_id=thread_id)
         if msg.text:
             text = self.html_substitutions(msg)
         else:
@@ -1065,7 +1067,7 @@ class SlaveMessageProcessor(LocaleMixin):
         if attributes.status_type is StatusAttribute.Types.TYPING:
             self.bot.send_chat_action(tg_dest, ChatAction.TYPING, message_thread_id=thread_id)
         elif attributes.status_type is StatusAttribute.Types.UPLOADING_VOICE:
-            self.bot.send_chat_action(tg_dest, ChatAction.RECORD_AUDIO, message_thread_id=thread_id)
+            self.bot.send_chat_action(tg_dest, ChatAction.RECORD_VOICE, message_thread_id=thread_id)
         elif attributes.status_type is StatusAttribute.Types.UPLOADING_IMAGE:
             self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_PHOTO, message_thread_id=thread_id)
         elif attributes.status_type is StatusAttribute.Types.UPLOADING_VIDEO:
@@ -1205,9 +1207,9 @@ class SlaveMessageProcessor(LocaleMixin):
         file.seek(0, 2)
         file_size = file.tell()
         file.seek(0)
-        if not self.channel.flag("local_tdlib_api") and file_size > telegram.constants.MAX_FILESIZE_UPLOAD:
+        if not self.channel.flag("local_tdlib_api") and file_size > FileSizeLimit.FILESIZE_UPLOAD:
             size_str = humanize.naturalsize(file_size)
-            max_size_str = humanize.naturalsize(telegram.constants.MAX_FILESIZE_UPLOAD)
+            max_size_str = humanize.naturalsize(FileSizeLimit.FILESIZE_UPLOAD)
             return self._(
                 "Attachment is too large ({size}). Maximum allowed by Telegram Bot API is {max_size}. (AT02)").format(
                 size=size_str, max_size=max_size_str)

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -18,8 +18,9 @@ import telegram.constants
 import telegram.error
 import telegram.ext
 from PIL import Image
-from telegram import InputFile, ChatAction, InputMediaPhoto, InputMediaDocument, InputMediaVideo, InputMediaAnimation, \
+from telegram import InputFile, InputMediaPhoto, InputMediaDocument, InputMediaVideo, InputMediaAnimation, \
     InlineKeyboardMarkup, InlineKeyboardButton, ReplyMarkup, TelegramError, InputMedia
+from telegram.constants import ChatAction
 
 from ehforwarderbot import Message, Status, coordinator
 from ehforwarderbot.chat import ChatNotificationState, SelfChatMember, GroupChat, PrivateChat, SystemChat, Chat
@@ -1322,4 +1323,3 @@ class SlaveMessageProcessor(LocaleMixin):
             except OSError as e:
                 self.logger.warning("Failed to clean up local API temp file %s: %s", path, e)
         tls.pending_cleanup = []
-

--- a/efb_telegram_master/wizard.py
+++ b/efb_telegram_master/wizard.py
@@ -12,6 +12,7 @@ from ruamel.yaml import YAML
 from telegram import Bot
 from telegram.error import TelegramError
 from telegram.ext import filters
+from telegram.request import HTTPXRequest
 
 from ehforwarderbot import coordinator, utils
 from ehforwarderbot.types import ModuleID
@@ -36,7 +37,7 @@ ngettext = translator.ngettext
 
 class DataModel:
     data: dict
-    request: Optional[Request] = None
+    request: Optional[HTTPXRequest] = None
     building_default = False
 
     def __init__(self, profile: str, instance_id: str):

--- a/efb_telegram_master/wizard.py
+++ b/efb_telegram_master/wizard.py
@@ -9,15 +9,15 @@ from pkg_resources import resource_filename
 
 import cjkwrap
 from ruamel.yaml import YAML
-from telegram import Bot, TelegramError
-from telegram.ext.filters import Filters
-from telegram.ext import MessageHandler, Updater
-from telegram.utils.request import Request
+from telegram import Bot
+from telegram.error import TelegramError
+from telegram.ext import filters
 
 from ehforwarderbot import coordinator, utils
 from ehforwarderbot.types import ModuleID
 
 from . import TelegramChannel
+from .ptb_compat import MessageHandler, build_application, build_request, run_sync
 
 
 def print_wrapped(text):
@@ -184,7 +184,7 @@ def input_bot_token(data: DataModel, default=None):
                 bot_kwargs: dict = {"token": ans}
                 if data.request is not None:
                     bot_kwargs["request"] = data.request
-                Bot(**bot_kwargs).get_me()
+                run_sync(Bot(**bot_kwargs).get_me())
             except TelegramError as e:
                 print_wrapped(str(e))
                 print()
@@ -231,7 +231,7 @@ def setup_proxy(data):
                     "username": username,
                     "password": password
                 }
-        data.request = Request(**data.data['request_kwargs'])
+        data.request = build_request(data.data['request_kwargs'])
 
 
 def setup_telegram_bot(data):
@@ -309,7 +309,7 @@ def setup_telegram_bot_commands_list(data):
         bot_kwargs: dict = {"token": data.data['token']}
         if data.request is not None:
             bot_kwargs["request"] = data.request
-        Bot(**bot_kwargs).set_my_commands(
+        run_sync(Bot(**bot_kwargs).set_my_commands(
             [
                 ("help", _("Show commands list.")),
                 ("link", _("Link a remote chat to a group.")),
@@ -321,7 +321,7 @@ def setup_telegram_bot_commands_list(data):
                 ("react", _("Send a reaction to a message, or show a list of reactors.")),
                 ("rm", _("Remove a message from its remote chat.")),
             ]
-        )
+        ))
 
         print(_("OK"))
         print()
@@ -373,13 +373,11 @@ def setup_admins(data):
         if answer == prompt_yes:
             print(_("Starting ID bot..."), end="", flush=True)
 
-            updater = Updater(token=data.data['token'],
-                              request_kwargs=data.data.get(
-                                  'request_kwargs', None),
-                              use_context=True)
+            updater = build_application(data.data['token'],
+                                        request_kwargs=data.data.get('request_kwargs', None))
             updater.dispatcher.add_handler(
                 MessageHandler(
-                    Filters.all,
+                    filters.ALL,
                     lambda update, context:
                     update.effective_message.reply_text(
                         _("Your Telegram user ID is {id}.").format(

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import sys
 import os
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 10):
     raise Exception(
-        "Python 3.7 or higher is required. Your version is %s." % sys.version)
+        "Python 3.10 or higher is required. Your version is %s." % sys.version)
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                             'efb_telegram_master/__version__.py')
@@ -30,7 +30,7 @@ setup(
     url='https://etm.1a23.studio',
     license='AGPLv3+',
     include_package_data=True,
-    python_requires='>=3.7',
+    python_requires='>=3.10',
     keywords=['ehforwarderbot', 'EH Forwarder Bot', 'EH Forwarder Bot Master Channel', 'Telegram',
               'Telegram Bot', 'chatbot'],
     classifiers=[
@@ -39,9 +39,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: End Users/Desktop",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -54,11 +51,7 @@ setup(
     install_requires=[
         "ehforwarderbot>=2.0.0",
         "setuptools==81.0.0; python_version>='3.9'",
-        "python-telegram-bot~=13.15",
-        "urllib3<2", # used by python-telegram-bot 13.x
-        # Python 3.13 removes the stdlib 'imghdr' module (PEP 594). Some deps
-        # (including python-telegram-bot 13.x) still import it.
-        "standard-imghdr; python_version>='3.13'",
+        "python-telegram-bot~=22.8",
         "audioop-lts; python_version>='3.13'",
         "python-magic",
         "ffmpeg-python",

--- a/tests/integration/test_slave_message_file.py
+++ b/tests/integration/test_slave_message_file.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 from typing import Optional, List, Tuple
 
 from pytest import mark, approx
-from telegram import MAX_FILESIZE_UPLOAD
+from telegram.constants import MAX_FILESIZE_UPLOAD
 from telethon.tl.custom import Message
 from telethon.tl.types import MessageEntityMentionName, MessageEntityCode
 

--- a/tests/unit/test_auxiliary_bot.py
+++ b/tests/unit/test_auxiliary_bot.py
@@ -8,7 +8,7 @@ from efb_telegram_master.auxiliary_bot import AuxiliaryBot
 
 
 def test_initialize_sets_identity():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot") as bot_cls:
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot") as bot_cls:
         bot = bot_cls.return_value
         bot.get_me.return_value = SimpleNamespace(id=123, username="auxbot")
 
@@ -21,8 +21,8 @@ def test_initialize_sets_identity():
 
 
 def test_initialize_disables_bot_on_unauthorized():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot") as bot_cls:
-        bot_cls.return_value.get_me.side_effect = telegram.error.Unauthorized("bad token")
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot") as bot_cls:
+        bot_cls.return_value.get_me.side_effect = telegram.error.Forbidden("bad token")
         aux_bot = AuxiliaryBot("123:token")
 
     assert aux_bot.initialize() is False
@@ -30,7 +30,7 @@ def test_initialize_disables_bot_on_unauthorized():
 
 
 def test_rate_limit_peek_and_reserve():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot"):
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot"):
         aux_bot = AuxiliaryBot("123:token", global_limit=3, global_window=10.0, chat_limit=3, chat_window=10.0)
 
     chat_id = 100
@@ -44,7 +44,7 @@ def test_rate_limit_peek_and_reserve():
 
 
 def test_check_membership_tri_starts_probe_for_unknown():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot"):
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot"):
         aux_bot = AuxiliaryBot("123:token")
 
     with patch.object(aux_bot, "_start_membership_probe") as start_probe:
@@ -54,7 +54,7 @@ def test_check_membership_tri_starts_probe_for_unknown():
 
 
 def test_check_membership_tri_returns_stale_value_while_refreshing():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot"):
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot"):
         aux_bot = AuxiliaryBot("123:token")
 
     with patch("efb_telegram_master.auxiliary_bot.time.time", return_value=1000.0):
@@ -68,7 +68,7 @@ def test_check_membership_tri_returns_stale_value_while_refreshing():
 
 
 def test_check_membership_sync_waits_for_probe_completion():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot"):
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot"):
         aux_bot = AuxiliaryBot("123:token")
 
     state = {"pending": True, "sleep_calls": 0}
@@ -92,7 +92,7 @@ def test_check_membership_sync_waits_for_probe_completion():
 
 
 def test_probe_membership_marks_non_member_on_bad_request():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot") as bot_cls:
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot") as bot_cls:
         bot = bot_cls.return_value
         bot.get_chat_member.side_effect = telegram.error.BadRequest("not found")
         aux_bot = AuxiliaryBot("123:token")
@@ -103,7 +103,7 @@ def test_probe_membership_marks_non_member_on_bad_request():
 
 
 def test_mark_disabled_sets_reason():
-    with patch("efb_telegram_master.auxiliary_bot.telegram.Bot"):
+    with patch("efb_telegram_master.ptb_compat.telegram.Bot"):
         aux_bot = AuxiliaryBot("123:token")
 
     aux_bot.mark_disabled("rate limit")

--- a/tests/unit/test_ptb_compat.py
+++ b/tests/unit/test_ptb_compat.py
@@ -1,7 +1,13 @@
 import asyncio
 from types import SimpleNamespace
 
-from efb_telegram_master.ptb_compat import ConversationHandler, build_request_kwargs, run_sync, wrap_callback
+from efb_telegram_master.ptb_compat import (
+    ConversationHandler,
+    build_request_kwargs,
+    forwarded_from_chat,
+    run_sync,
+    wrap_callback,
+)
 
 
 def test_run_sync_resolves_coroutine():
@@ -64,6 +70,20 @@ def test_build_request_kwargs_maps_socks_proxy_auth():
     assert result == {
         "proxy": "socks5://user:pass@127.0.0.1:1080",
     }
+
+
+def test_forwarded_from_chat_reads_ptb22_forward_origin_chat():
+    chat = SimpleNamespace(id=-100123)
+    message = SimpleNamespace(forward_origin=SimpleNamespace(chat=chat), forward_from_chat=None)
+
+    assert forwarded_from_chat(message) is chat
+
+
+def test_forwarded_from_chat_keeps_legacy_forward_from_chat_fallback():
+    chat = SimpleNamespace(id=-100123)
+    message = SimpleNamespace(forward_from_chat=chat)
+
+    assert forwarded_from_chat(message) is chat
 
 
 def test_wrap_callback_exposes_sync_message_methods():

--- a/tests/unit/test_ptb_compat.py
+++ b/tests/unit/test_ptb_compat.py
@@ -1,0 +1,193 @@
+import asyncio
+from types import SimpleNamespace
+
+from efb_telegram_master.ptb_compat import ConversationHandler, build_request_kwargs, run_sync, wrap_callback
+
+
+def test_run_sync_resolves_coroutine():
+    async def value():
+        return "ok"
+
+    assert run_sync(value()) == "ok"
+
+
+def test_run_sync_resolves_coroutine_from_running_loop():
+    async def value():
+        return "ok"
+
+    async def caller():
+        return run_sync(value())
+
+    assert asyncio.run(caller()) == "ok"
+
+
+def test_build_request_kwargs_maps_ptb13_proxy_names():
+    result = build_request_kwargs({
+        "proxy_url": "socks5://127.0.0.1:1080",
+        "urllib3_proxy_kwargs": {
+            "username": "user",
+            "password": "pass",
+        },
+        "read_timeout": 15,
+    })
+
+    assert result == {
+        "proxy": "socks5://user:pass@127.0.0.1:1080",
+        "read_timeout": 15,
+    }
+
+
+def test_build_request_kwargs_maps_http_proxy_auth_and_drops_unsupported_keys():
+    result = build_request_kwargs({
+        "proxy_url": "http://127.0.0.1:8080/",
+        "username": "user",
+        "password": "pass",
+        "urllib3_proxy_kwargs": {"unused": True},
+        "read_timeout": 15,
+    })
+
+    assert result == {
+        "proxy": "http://user:pass@127.0.0.1:8080/",
+        "read_timeout": 15,
+    }
+
+
+def test_build_request_kwargs_maps_socks_proxy_auth():
+    result = build_request_kwargs({
+        "proxy_url": "socks5://127.0.0.1:1080",
+        "urllib3_proxy_kwargs": {
+            "username": "user",
+            "password": "pass",
+        },
+    })
+
+    assert result == {
+        "proxy": "socks5://user:pass@127.0.0.1:1080",
+    }
+
+
+def test_wrap_callback_exposes_sync_message_methods():
+    calls = []
+
+    class Message:
+        async def reply_text(self, text):
+            calls.append(text)
+
+    class Update:
+        callback_query = None
+        effective_message = Message()
+
+    def callback(update, _context):
+        update.effective_message.reply_text("hello")
+        return "done"
+
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    assert asyncio.run(wrap_callback(callback)(Update(), context)) == "done"
+    assert calls == ["hello"]
+
+
+def test_wrap_callback_exposes_sync_update_message_methods():
+    calls = []
+
+    class Message:
+        def __init__(self, label):
+            self.label = label
+
+        async def reply_text(self, text):
+            calls.append((self.label, text))
+
+    class Update:
+        callback_query = None
+        message = Message("message")
+        edited_message = Message("edited_message")
+        channel_post = Message("channel_post")
+        edited_channel_post = Message("edited_channel_post")
+        effective_message = message
+
+    def callback(update, _context):
+        update.message.reply_text("hello")
+        update.edited_message.reply_text("edited")
+        update.channel_post.reply_text("channel")
+        update.edited_channel_post.reply_text("edited channel")
+        return "done"
+
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    assert asyncio.run(wrap_callback(callback)(Update(), context)) == "done"
+    assert calls == [
+        ("message", "hello"),
+        ("edited_message", "edited"),
+        ("channel_post", "channel"),
+        ("edited_channel_post", "edited channel"),
+    ]
+
+
+def test_wrap_callback_maps_reply_quote_argument():
+    calls = []
+
+    class Message:
+        async def reply_text(self, text, **kwargs):
+            calls.append((text, kwargs))
+
+    class Update:
+        callback_query = None
+        effective_message = Message()
+
+    def callback(update, _context):
+        update.effective_message.reply_text("hello", quote=True)
+
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    asyncio.run(wrap_callback(callback)(Update(), context))
+    assert calls == [("hello", {"do_quote": True})]
+
+
+def test_conversation_handler_wraps_handler_callbacks(monkeypatch):
+    wrapped = []
+    captured = {}
+
+    def entry_callback(_update, _context):
+        return "state"
+
+    def state_callback(_update, _context):
+        return "state"
+
+    def fallback_callback(_update, _context):
+        return "fallback"
+
+    entry_handler = SimpleNamespace(callback=entry_callback)
+    state_handler = SimpleNamespace(callback=state_callback)
+    fallback_handler = SimpleNamespace(callback=fallback_callback)
+
+    def fake_init(self, entry_points, states, fallbacks, **kwargs):
+        captured["entry_points"] = entry_points
+        captured["states"] = states
+        captured["fallbacks"] = fallbacks
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(ConversationHandler.__mro__[1], "__init__", fake_init)
+
+    def fake_wrap(callback):
+        wrapped.append(callback)
+        return SimpleNamespace(wrapped=callback)
+
+    monkeypatch.setattr("efb_telegram_master.ptb_compat.wrap_callback", fake_wrap)
+
+    ConversationHandler(
+        entry_points=[entry_handler],
+        states={"state": [state_handler]},
+        fallbacks=[fallback_handler],
+        per_chat=True,
+    )
+
+    assert captured == {
+        "entry_points": [entry_handler],
+        "states": {"state": [state_handler]},
+        "fallbacks": [fallback_handler],
+        "kwargs": {"per_chat": True},
+    }
+    assert entry_handler.callback.wrapped is entry_callback
+    assert state_handler.callback.wrapped is state_callback
+    assert fallback_handler.callback.wrapped is fallback_callback
+    assert wrapped == [entry_callback, state_callback, fallback_callback]


### PR DESCRIPTION
## Summary

- Upgrade the PTB-only dependency path to `python-telegram-bot~=22.8`.
- Add a synchronous compatibility layer for PTB 22's async bot/application APIs.
- Update PTB imports, filters, constants, request/proxy handling, and focused tests.

## Verification

- Passed: `rtk proxy /tmp/ptb-upgrade-venv/bin/python -m py_compile setup.py efb_telegram_master/ptb_compat.py efb_telegram_master/bot_manager.py efb_telegram_master/auxiliary_bot.py efb_telegram_master/locale_handler.py efb_telegram_master/wizard.py efb_telegram_master/__init__.py efb_telegram_master/commands.py efb_telegram_master/chat_binding.py efb_telegram_master/master_message.py efb_telegram_master/message.py efb_telegram_master/slave_message.py tests/unit/test_ptb_compat.py tests/unit/test_auxiliary_bot.py tests/integration/test_slave_message_file.py`
- Passed: PTB 22.8 import probe in a temp venv printed `22.8` and `imports ok`.
- Passed: removed PTB API static search returned no matches.
- Blocked: focused pytest `tests/unit/test_ptb_compat.py tests/unit/test_auxiliary_bot.py` cannot run in this environment because importing `magic` fails with `ImportError: failed to find libmagic. Check your installation`.
