### PR TITLE
feat: use cleaner topic title for forum topics & fix db migration flow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,22 @@
+name: Sync to Sub-Account
+
+on:
+  push:
+    branches: [ "dev" ] # 当大号的 main 分支有推送时触发
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: '.'
+          destination-github-username: 'onestao'
+          destination-repository-name: 'efb-telegram-master'
+          user-email: 'kettly1266@gmail.com' # 这里填小号的邮箱
+          target-branch: main

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync to Sub-Account
 
 on:
   push:
-    branches: [ "dev" ] # 当大号的 dev 分支有推送时触发
+    branches: [ "dev" ] 
 
 jobs:
   build:
@@ -14,8 +14,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      # 【新增的非常关键的一步】
-      # 删掉大号的 .git 历史和 .github 脚本，留下纯净的代码实体
       - name: Clean up files
         run: |
           rm -rf .git
@@ -31,3 +29,5 @@ jobs:
           destination-repository-name: 'efb-telegram-master'
           user-email: 'kettly1266@gmail.com'
           target-branch: main
+          # 【新增下面这一行】：强制写死提交信息，绝对不带大号的任何痕迹
+          commit-message: 'Auto sync latest code'

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,14 +2,18 @@ name: Sync to Sub-Account
 
 on:
   push:
-    branches: [ "dev" ] # 当大号的 main 分支有推送时触发
+    branches: [ "dev" ] # 当大号的 dev 分支有推送时触发
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          persist-credentials: false # <--- 核心修复：清理大号机器人权限，确保后面使用小号 Token
+
       - name: Pushes to another repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
@@ -18,5 +22,5 @@ jobs:
           source-directory: '.'
           destination-github-username: 'onestao'
           destination-repository-name: 'efb-telegram-master'
-          user-email: 'kettly1266@gmail.com' # 这里填小号的邮箱
-          target-branch: main
+          user-email: 'kettly1266@gmail.com' # 小号的邮箱
+          target-branch: main # 推送到小号的 main 分支

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,7 +12,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          persist-credentials: false # <--- 核心修复：清理大号机器人权限，确保后面使用小号 Token
+          persist-credentials: false
+
+      # 【新增的非常关键的一步】
+      # 删掉大号的 .git 历史和 .github 脚本，留下纯净的代码实体
+      - name: Clean up files
+        run: |
+          rm -rf .git
+          rm -rf .github
 
       - name: Pushes to another repository
         uses: cpina/github-action-push-to-another-repository@main
@@ -22,5 +29,5 @@ jobs:
           source-directory: '.'
           destination-github-username: 'onestao'
           destination-repository-name: 'efb-telegram-master'
-          user-email: 'kettly1266@gmail.com' # 小号的邮箱
-          target-branch: main # 推送到小号的 main 分支
+          user-email: 'kettly1266@gmail.com'
+          target-branch: main

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ CLAUDE.md
 .claude/settings.local.json
 
 .venv/
+.codegraph/
+efb.db

--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -4,6 +4,9 @@ import html
 import logging
 import mimetypes
 import time
+import warnings
+
+warnings.filterwarnings("ignore", message=".*_id_attrs.*")
 from gettext import NullTranslations, translation
 from typing import Optional, List, Callable
 from xmlrpc.server import SimpleXMLRPCServer

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -96,7 +96,7 @@ class TelegramBotManager(LocaleMixin):
     @classmethod
     def _format_affix(cls, prefix: str = '', suffix: str = '', parse_mode=None) -> Tuple[str, str]:
         if cls._is_html_parse_mode(parse_mode):
-            prefix = (prefix and (f"<pre>{html.escape(prefix.strip())}</pre>\n")) or prefix
+            prefix = (prefix and (f"<b>{html.escape(prefix.strip())}</b>\n")) or prefix
             suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
         else:
             prefix = (prefix and (prefix.rstrip() + "\n")) or prefix

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -57,6 +57,36 @@ def _has_callback_keyboard(reply_markup) -> bool:
     return False
 
 
+def _freeze_delayed_file_arg(value):
+    """Copy open file-like arguments so delayed sends do not read closed files."""
+    if isinstance(value, (str, bytes, os.PathLike)):
+        return value
+    if not hasattr(value, 'read'):
+        return value
+
+    try:
+        if getattr(value, 'closed', False):
+            return value
+        original_pos = value.tell() if hasattr(value, 'tell') else None
+        if hasattr(value, 'seek'):
+            value.seek(0)
+        frozen = io.BytesIO(value.read())
+        frozen.name = getattr(value, 'name', None)
+        if original_pos is not None and hasattr(value, 'seek'):
+            value.seek(original_pos)
+        frozen.seek(0)
+        return frozen
+    except (OSError, ValueError):
+        return value
+
+
+def _freeze_delayed_task_arguments(args: tuple, kwargs: dict) -> Tuple[tuple, dict]:
+    """Snapshot delayed task arguments that may become invalid before execution."""
+    return tuple(_freeze_delayed_file_arg(arg) for arg in args), {
+        key: _freeze_delayed_file_arg(value) for key, value in kwargs.items()
+    }
+
+
 class TelegramBotManager(LocaleMixin):
     """
     This is a wrapper of Telegram's message sending and editing methods.
@@ -207,14 +237,15 @@ class TelegramBotManager(LocaleMixin):
                         # Grab any pending cleanup files before scheduling
                         cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]  # pylint: disable=protected-access
                         self._cleanup_tls.pending_cleanup = []  # pylint: disable=protected-access
+                        delayed_args, delayed_kwargs = _freeze_delayed_task_arguments(args, kwargs)
 
                         # Schedule the delayed execution using the new system
                         task_id = self._schedule_delayed_task(  # pylint: disable=protected-access
                             chat_id=chat_id,
                             delay_time=delay_time,
                             function=fn,
-                            args=(self,) + args,
-                            kwargs=kwargs,
+                            args=(self,) + delayed_args,
+                            kwargs=delayed_kwargs,
                             cleanup_files=cleanup_files
                         )
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -96,7 +96,7 @@ class TelegramBotManager(LocaleMixin):
     @classmethod
     def _format_affix(cls, prefix: str = '', suffix: str = '', parse_mode=None) -> Tuple[str, str]:
         if cls._is_html_parse_mode(parse_mode):
-            prefix = (prefix and (f"<code>{html.escape(prefix.strip())}</code>\n")) or prefix
+            prefix = (prefix and (f"<pre>{html.escape(prefix.strip())}</pre>\n")) or prefix
             suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
         else:
             prefix = (prefix and (prefix.rstrip() + "\n")) or prefix

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -89,6 +89,29 @@ class TelegramBotManager(LocaleMixin):
     _chat_timestamps: 'defaultdict[int, Deque[float]]'
     _aux_recent_use: dict[int, float]
 
+    @staticmethod
+    def _is_html_parse_mode(parse_mode) -> bool:
+        return str(parse_mode or '').lower() == "html"
+
+    @classmethod
+    def _format_affix(cls, prefix: str = '', suffix: str = '', parse_mode=None) -> Tuple[str, str]:
+        if cls._is_html_parse_mode(parse_mode):
+            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
+            suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
+        else:
+            prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
+            suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
+        return prefix, suffix
+
+    @classmethod
+    def _message_file_buffer(cls, text: str, parse_mode=None) -> io.BytesIO:
+        if cls._is_html_parse_mode(parse_mode):
+            text = (
+                "<html><head><meta charset='utf-8'></head>"
+                "<body><pre style='white-space:pre-wrap'>" + text + "</pre></body></html>"
+            )
+        return io.BytesIO(text.encode('utf-8'))
+
     class Decorators:
         logger = logging.getLogger(__name__)
 
@@ -331,12 +354,7 @@ class TelegramBotManager(LocaleMixin):
                     if is_empty:
                         return is_empty
 
-                if str(kwargs.get('parse_mode', '')).lower() == "html":
-                    prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
-                    suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
-                else:
-                    prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
-                    suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
+                prefix, suffix = self._format_affix(prefix, suffix, kwargs.get('parse_mode', ''))
 
                 if len(prefix + text + suffix) >= telegram.constants.MAX_CAPTION_LENGTH:
                     full_message = io.StringIO(prefix + text + suffix)
@@ -887,12 +905,7 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        if str(kwargs.get('parse_mode', '')).lower() == "html":
-            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
-            suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
-        else:
-            prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
-            suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
+        prefix, suffix = self._format_affix(prefix, suffix, kwargs.get('parse_mode', ''))
         text: str
         if args[1:]:
             text = args[1]
@@ -900,7 +913,7 @@ class TelegramBotManager(LocaleMixin):
             text = kwargs.pop('text')
         args = args[:1]
         if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
-            full_message = io.BytesIO((prefix + text + suffix).encode('utf-8'))
+            full_message = self._message_file_buffer(prefix + text + suffix, kwargs.get('parse_mode', ''))
             truncated = prefix + text[:100] + "\n...\n" + text[-100:] + suffix
             msg = self._bot_send_message_fallback(args[0], text=truncated, **kwargs)
             filename = "%s_%s" % (args[0], msg.message_id)
@@ -908,15 +921,8 @@ class TelegramBotManager(LocaleMixin):
                 filename += ".txt"
             elif kwargs.get('parse_mode', '').lower() == 'markdown':
                 filename += ".md"
-            elif kwargs.get('parse_mode', '').lower() == 'html':
+            elif self._is_html_parse_mode(kwargs.get('parse_mode', '')):
                 filename += ".html"
-                full_message_html = (
-                    "<html><head><meta charset='utf-8'></head>"
-                    "<body><pre style='white-space:pre-wrap'>" + (prefix + text + suffix) + "</pre></body></html>"
-                )
-                # Replace the attachment payload with HTML-wrapped content.
-                # (Previous logic did seek(0) then truncate(), which empties the buffer.)
-                full_message = io.BytesIO(full_message_html.encode('utf-8'))
             else:
                 filename += ".txt"
             self._active_bot.send_document(args[0], full_message, filename=filename,
@@ -945,21 +951,16 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        if str(kwargs.get('parse_mode', '')).lower() == "html":
-            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
-            suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
-        else:
-            prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
-            suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
+        prefix, suffix = self._format_affix(prefix, suffix, kwargs.get('parse_mode', ''))
         text = kwargs.pop('text', '')
         if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
-            full_message = io.BytesIO((prefix + text + suffix).encode())
+            full_message = self._message_file_buffer(prefix + text + suffix, kwargs.get('parse_mode', ''))
             truncated = prefix + text[:100] + "\n...\n" + text[-100:] + suffix
             msg = self._bot_edit_message_text_fallback(text=truncated, **kwargs)
             filename = "%s_%s" % (kwargs['chat_id'], msg.message_id)
             if kwargs.get('parse_mode', '').lower() == 'markdown':
                 filename += ".md"
-            elif kwargs.get('parse_mode', '').lower() == 'html':
+            elif self._is_html_parse_mode(kwargs.get('parse_mode', '')):
                 filename += ".html"
             else:
                 filename += ".txt"

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -331,12 +331,12 @@ class TelegramBotManager(LocaleMixin):
                     if is_empty:
                         return is_empty
 
-                prefix = (prefix and (prefix + "\n")) or prefix
-                suffix = (suffix and ("\n" + suffix)) or suffix
-
                 if str(kwargs.get('parse_mode', '')).lower() == "html":
-                    prefix = html.escape(prefix)
-                    suffix = html.escape(suffix)
+                    prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
+                    suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
+                else:
+                    prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
+                    suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
 
                 if len(prefix + text + suffix) >= telegram.constants.MAX_CAPTION_LENGTH:
                     full_message = io.StringIO(prefix + text + suffix)
@@ -887,11 +887,12 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        prefix = (prefix and (prefix + "\n")) or prefix
-        suffix = (suffix and ("\n" + suffix)) or suffix
         if str(kwargs.get('parse_mode', '')).lower() == "html":
-            prefix = html.escape(prefix)
-            suffix = html.escape(suffix)
+            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
+            suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
+        else:
+            prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
+            suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
         text: str
         if args[1:]:
             text = args[1]
@@ -944,11 +945,12 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
-        prefix = (prefix and (prefix + "\n")) or prefix
-        suffix = (suffix and ("\n" + suffix)) or suffix
         if str(kwargs.get('parse_mode', '')).lower() == "html":
-            prefix = html.escape(prefix)
-            suffix = html.escape(suffix)
+            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
+            suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
+        else:
+            prefix = (prefix and (prefix.rstrip() + "\n")) or prefix
+            suffix = (suffix and ("\n" + suffix.lstrip())) or suffix
         text = kwargs.pop('text', '')
         if len(prefix + text + suffix) >= telegram.constants.MAX_MESSAGE_LENGTH:
             full_message = io.BytesIO((prefix + text + suffix).encode())

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -96,7 +96,7 @@ class TelegramBotManager(LocaleMixin):
     @classmethod
     def _format_affix(cls, prefix: str = '', suffix: str = '', parse_mode=None) -> Tuple[str, str]:
         if cls._is_html_parse_mode(parse_mode):
-            prefix = (prefix and (f"<blockquote>{html.escape(prefix.strip())}</blockquote>\n")) or prefix
+            prefix = (prefix and (f"<code>{html.escape(prefix.strip())}</code>\n")) or prefix
             suffix = (suffix and ("\n" + html.escape(suffix.strip()))) or suffix
         else:
             prefix = (prefix and (prefix.rstrip() + "\n")) or prefix

--- a/efb_telegram_master/chat.py
+++ b/efb_telegram_master/chat.py
@@ -204,6 +204,17 @@ class ETMChatMixin(ETMBaseChatMixin, Chat, ABC):
                f"{self.display_name}"
 
     @property
+    def topic_title(self) -> str:
+        """Chat title used for forum topic names in topic_group.
+
+        Same as chat_title but without channel_emoji and chat_type_emoji
+        prefixes, so that Telegram auto-generates a cleaner topic icon
+        from the first character of the actual chat name.
+        """
+        non_default_instance_flag = "*" if "#" in self.module_id else ""
+        return f"{non_default_instance_flag}{self.display_name}"
+
+    @property
     def last_message_time(self) -> datetime:
         """Time of the last recorded message from this chat.
         Returns ``datetime.min`` when no recorded message is found.

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -1190,7 +1190,9 @@ class ChatBindingManager(LocaleMixin):
                 self.bot.edit_forum_topic(
                     chat_id=tg_chat_id,
                     message_thread_id=thread_id,
-                    name=self.truncate_ellipsis(chat.chat_title, self.MAX_LEN_CHAT_TITLE),
+                    name=self.truncate_ellipsis(
+                        chat.topic_title if tg_chat_id == self.channel.topic_group else chat.chat_title,
+                        self.MAX_LEN_CHAT_TITLE),
                     icon_custom_emoji_id=""
                 )
             except TelegramError as e:
@@ -1295,7 +1297,9 @@ class ChatBindingManager(LocaleMixin):
             self.bot.edit_forum_topic(
                 chat_id=update.effective_chat.id,
                 message_thread_id=thread_id,
-                name=self.truncate_ellipsis(etm_chat.chat_title, self.MAX_LEN_CHAT_TITLE),
+                name=self.truncate_ellipsis(
+                    etm_chat.topic_title if TelegramChatID(update.effective_chat.id) == self.channel.topic_group else etm_chat.chat_title,
+                    self.MAX_LEN_CHAT_TITLE),
                 icon_custom_emoji_id=""  # param required by telegram
             )
             update.effective_message.reply_text(self._('Chat details updated.'))
@@ -1338,9 +1342,10 @@ class ChatBindingManager(LocaleMixin):
                     channel_id, chat_id, _ = utils.chat_id_str_to_id(slave_uid)
                     chat: ETMChatType = self.chat_manager.get_chat(channel_id, chat_id, build_dummy=True)
                     try:
+                        topic_name = chat.topic_title if telegram_chat_id == self.channel.topic_group else chat.chat_title
                         topic = self.bot.create_forum_topic(
                             chat_id=telegram_chat_id,
-                            name=chat.chat_title
+                            name=topic_name
                         )
                         thread_id = topic.message_thread_id
                         self.db.add_topic_assoc(

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -1191,7 +1191,7 @@ class ChatBindingManager(LocaleMixin):
                     chat_id=tg_chat_id,
                     message_thread_id=thread_id,
                     name=self.truncate_ellipsis(
-                        chat.topic_title if tg_chat_id == self.channel.topic_group else chat.chat_title,
+                        chat.topic_title,
                         self.MAX_LEN_CHAT_TITLE),
                     icon_custom_emoji_id=""
                 )
@@ -1298,7 +1298,7 @@ class ChatBindingManager(LocaleMixin):
                 chat_id=update.effective_chat.id,
                 message_thread_id=thread_id,
                 name=self.truncate_ellipsis(
-                    etm_chat.topic_title if TelegramChatID(update.effective_chat.id) == self.channel.topic_group else etm_chat.chat_title,
+                    etm_chat.topic_title,
                     self.MAX_LEN_CHAT_TITLE),
                 icon_custom_emoji_id=""  # param required by telegram
             )
@@ -1342,7 +1342,7 @@ class ChatBindingManager(LocaleMixin):
                     channel_id, chat_id, _ = utils.chat_id_str_to_id(slave_uid)
                     chat: ETMChatType = self.chat_manager.get_chat(channel_id, chat_id, build_dummy=True)
                     try:
-                        topic_name = chat.topic_title if telegram_chat_id == self.channel.topic_group else chat.chat_title
+                        topic_name = chat.topic_title
                         topic = self.bot.create_forum_topic(
                             chat_id=telegram_chat_id,
                             name=topic_name

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -755,6 +755,41 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def find_msg_by_media_type(slave_origin_uid: 'EFBChannelChatIDStr',
+                               media_types: 'List[str]',
+                               slave_member_uid: 'Optional[str]' = None,
+                               limit: int = 200) -> 'List[MsgLog]':
+        """Find recent media messages by type and optionally by sender.
+
+        Used for matching WeChat media quote blocks (e.g. [图片], [视频])
+        where text-based fuzzy matching is unreliable.
+
+        Args:
+            slave_origin_uid: The slave chat identifier string to scope the search.
+            media_types: List of TGMsgType values to filter by (e.g. ["Photo", "Video"]).
+            slave_member_uid: Optional sender UID to further filter results.
+            limit: Maximum number of recent messages to search (default 200).
+
+        Returns:
+            List[MsgLog]: Matching message log entries, ordered by time desc.
+        """
+        try:
+            query = (MsgLog.select()
+                     .where(
+                         (MsgLog.slave_origin_uid == slave_origin_uid) &
+                         (MsgLog.media_type.in_(media_types))
+                     )
+                     .order_by(MsgLog.time.desc())
+                     .limit(limit))
+
+            if slave_member_uid:
+                query = query.where(MsgLog.slave_member_uid == slave_member_uid)
+
+            return list(query)
+        except Exception:
+            return []
+
+    @staticmethod
     def delete_msg_log(master_msg_id: Optional[TgChatMsgIDStr] = None,
                        slave_msg_id: Optional[EFBChannelChatIDStr] = None,
                        slave_origin_uid: Optional[EFBChannelChatIDStr] = None):

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -687,35 +687,67 @@ class DatabaseManager:
                                limit: int = 200) -> Optional['MsgLog']:
         """Find a message in the database by matching quoted text content.
 
-        Searches the most recent `limit` messages from the same slave chat
-        whose `text` field starts with or contains the given quote_text.
+        Uses a 3-layer matching strategy on a single DB query result:
+        1. Strip "Name：" or "Name:" prefix from quote_text, then check
+           if the remaining body is contained in candidate.text (forward match).
+        2. Reverse match: check if candidate.text is contained in the
+           full quote_text (handles cases where DB text is a substring).
+        3. Normalized fuzzy match: strip all whitespace and CJK/ASCII
+           punctuation from both sides, then check containment.
 
         Args:
             slave_origin_uid: The slave chat identifier string to scope the search.
-            quote_text: The quoted text extracted from the WeChat「」format.
+            quote_text: The quoted text extracted from the WeChat「」format,
+                        typically in the form "SenderName：original content".
             limit: Maximum number of recent messages to search (default 200).
 
         Returns:
             Optional[MsgLog]: The best matching message log entry, or None.
         """
+        import re as _re
+
         if not quote_text or not quote_text.strip():
             return None
 
-        # Strip HTML entities that may have been escaped
-        clean_text = quote_text.strip()
+        full_quote = quote_text.strip()
+
+        # Layer 1 prep: strip "SenderName：" or "SenderName:" prefix
+        # Match everything before the first full-width or half-width colon
+        colon_match = _re.match(r'^[^：:]+[：:](.+)$', full_quote, flags=_re.DOTALL)
+        quote_body = colon_match.group(1).strip() if colon_match else full_quote
+
+        # Layer 3 prep: normalize helper — remove whitespace + common punctuation
+        _punct_re = _re.compile(r'[\s，。！？、；：\u201c\u201d\u2018\u2019（）《》【】…—.,!?\';:\"()\[\]{}<>~`@#$%^&*_+=|/\\-]+')
+
+        def _normalize(s: str) -> str:
+            return _punct_re.sub('', s)
+
+        norm_body = _normalize(quote_body)
+        norm_full = _normalize(full_quote)
 
         try:
-            # Search recent messages from the same slave chat,
-            # ordered by time descending (most recent first).
-            # We use LIKE with the quote text to find messages whose text
-            # starts with the quoted content.
             candidates = (MsgLog.select()
                           .where(MsgLog.slave_origin_uid == slave_origin_uid)
                           .order_by(MsgLog.time.desc())
                           .limit(limit))
 
             for candidate in candidates:
-                if candidate.text and clean_text in candidate.text:
+                ct = candidate.text
+                if not ct:
+                    continue
+
+                # Layer 1: forward match (stripped body in DB text)
+                if quote_body and quote_body in ct:
+                    return candidate
+
+                # Layer 2: reverse match (DB text in full quote)
+                if ct.strip() in full_quote:
+                    return candidate
+
+                # Layer 3: normalized fuzzy match
+                norm_ct = _normalize(ct)
+                if norm_ct and (norm_body and norm_body in norm_ct
+                                or norm_ct in norm_full):
                     return candidate
 
             return None

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -231,13 +231,12 @@ class DatabaseManager:
                 else:
                     self._create()
             else:
-                self._check_and_run_migrations()
+                self._create()  # create_tables is safe for existing tables
+            self._check_and_run_migrations()
         else:
             # SQLite backend: original logic
-            if not ChatAssoc.table_exists() or not TopicAssoc.table_exists():
-                self._create()
-            else:
-                self._check_and_run_migrations()
+            self._create()  # create_tables is safe for existing tables
+            self._check_and_run_migrations()
         self.logger.debug("Database migration finished...")
 
     def stop_worker(self):

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import pickle
+import re
 import time
 from contextlib import suppress
 from functools import partial
@@ -169,6 +170,20 @@ class MsgLog(BaseModel):
         return msg
 
 
+class MsgAlias(BaseModel):
+    slave_origin_uid = TextField()
+    slave_message_id = TextField()
+    master_msg_id = TextField()
+    time = DateTimeField(default=datetime.datetime.now, null=True)
+
+    class Meta:
+        database = database
+        indexes = (
+            (("slave_origin_uid", "slave_message_id"), False),
+            (("time",), False),
+        )
+
+
 class SlaveChatInfo(BaseModel):
     slave_channel_id = TextField()
     slave_channel_emoji = CharField()
@@ -249,7 +264,7 @@ class DatabaseManager:
         """
         Initializing tables.
         """
-        database.create_tables([ChatAssoc, MsgLog, SlaveChatInfo, TopicAssoc])
+        database.create_tables([ChatAssoc, MsgLog, MsgAlias, SlaveChatInfo, TopicAssoc])
 
     def _migrate_from_sqlite(self, sqlite_path: Path):
         """Migrate data from existing SQLite database to PostgreSQL on first use."""
@@ -636,6 +651,7 @@ class DatabaseManager:
         row.text = msg.text
         row.slave_origin_uid = chat_id_to_str(chat=msg.chat)
         row.slave_member_uid = chat_id_to_str(chat=msg.author)
+        row.slave_member_display_name = getattr(msg.author, 'alias', None) or getattr(msg.author, 'name', None)
         row.msg_type = msg.type.name
         row.sent_to = msg.deliver_to.channel_id
         row.slave_message_id = msg.uid or f"{self.FAIL_FLAG}.{time.time()}"
@@ -650,6 +666,32 @@ class DatabaseManager:
 
         result = save()
         self.logger.debug("[%s] Database insert/update outcome: %s", master_msg_id, result)
+
+    @staticmethod
+    def prune_msg_aliases(max_age_hours: int = 24):
+        cutoff = datetime.datetime.now() - datetime.timedelta(hours=max_age_hours)
+        return MsgAlias.delete().where(MsgAlias.time < cutoff).execute()
+
+    @staticmethod
+    def add_msg_alias(slave_origin_uid: EFBChannelChatIDStr,
+                      slave_msg_id: MessageID,
+                      master_msg_id: TgChatMsgIDStr) -> MsgAlias:
+        DatabaseManager.prune_msg_aliases()
+        alias = MsgAlias.get_or_none(
+            (MsgAlias.slave_origin_uid == slave_origin_uid) &
+            (MsgAlias.slave_message_id == slave_msg_id)
+        )
+        if alias is None:
+            alias = MsgAlias()
+            force_insert = True
+        else:
+            force_insert = False
+        alias.slave_origin_uid = slave_origin_uid
+        alias.slave_message_id = slave_msg_id
+        alias.master_msg_id = master_msg_id
+        alias.time = datetime.datetime.now()
+        alias.save(force_insert=force_insert)
+        return alias
 
     @staticmethod
     def get_msg_log(master_msg_id: Optional[TgChatMsgIDStr] = None,
@@ -675,18 +717,42 @@ class DatabaseManager:
                 return MsgLog.select().where(MsgLog.master_msg_id == master_msg_id) \
                     .order_by(MsgLog.time.desc()).first()
             else:
-                return MsgLog.select().where((MsgLog.slave_message_id == slave_msg_id) &
-                                             (MsgLog.slave_origin_uid == slave_origin_uid)
-                                             ).order_by(MsgLog.time.desc()).first()
+                log = MsgLog.select().where((MsgLog.slave_message_id == slave_msg_id) &
+                                            (MsgLog.slave_origin_uid == slave_origin_uid)
+                                            ).order_by(MsgLog.time.desc()).first()
+                if log:
+                    return log
+
+                cutoff = datetime.datetime.now() - datetime.timedelta(hours=24)
+                alias = MsgAlias.select().where(
+                    (MsgAlias.slave_message_id == slave_msg_id) &
+                    (MsgAlias.slave_origin_uid == slave_origin_uid) &
+                    (MsgAlias.time >= cutoff)
+                ).order_by(MsgAlias.time.desc()).first()
+                if alias:
+                    return MsgLog.select().where(MsgLog.master_msg_id == alias.master_msg_id) \
+                        .order_by(MsgLog.time.desc()).first()
+                return None
         except DoesNotExist:
             return None
 
     @staticmethod
-    def find_msg_by_quote_text(slave_origin_uid: 'EFBChannelChatIDStr',
-                               quote_text: str,
-                               limit: int = 200,
-                               slave_member_uid: 'Optional[str]' = None) -> Optional['MsgLog']:
-        """Find a message in the database by matching quoted text content.
+    def _normalize_quote_text(text: str) -> str:
+        punct_re = re.compile(r'[\s，。！？、；：\u201c\u201d\u2018\u2019（）《》【】…—.,!?\';:\"()\[\]{}<>~`@#$%^&*_+=|/\\-]+')
+        return punct_re.sub('', text)
+
+    @staticmethod
+    def _strip_quote_sender(quote_text: str) -> str:
+        full_quote = quote_text.strip()
+        colon_match = re.match(r'^[^：:]+[：:](.+)$', full_quote, flags=re.DOTALL)
+        return colon_match.group(1).strip() if colon_match else full_quote
+
+    @staticmethod
+    def find_msgs_by_quote_text(slave_origin_uid: 'EFBChannelChatIDStr',
+                                quote_text: str,
+                                limit: int = 200,
+                                slave_member_uid: 'Optional[str]' = None) -> 'List[MsgLog]':
+        """Find candidate messages by matching quoted text content.
 
         Uses a 3-layer matching strategy on a single DB query result:
         1. Strip "Name：" or "Name:" prefix from quote_text, then check
@@ -705,28 +771,15 @@ class DatabaseManager:
                               Useful for short quotes where text alone is too ambiguous.
 
         Returns:
-            Optional[MsgLog]: The best matching message log entry, or None.
+            List[MsgLog]: Matching message log entries, ordered by time desc.
         """
-        import re as _re
-
         if not quote_text or not quote_text.strip():
-            return None
+            return []
 
         full_quote = quote_text.strip()
-
-        # Layer 1 prep: strip "SenderName：" or "SenderName:" prefix
-        # Match everything before the first full-width or half-width colon
-        colon_match = _re.match(r'^[^：:]+[：:](.+)$', full_quote, flags=_re.DOTALL)
-        quote_body = colon_match.group(1).strip() if colon_match else full_quote
-
-        # Layer 3 prep: normalize helper — remove whitespace + common punctuation
-        _punct_re = _re.compile(r'[\s，。！？、；：\u201c\u201d\u2018\u2019（）《》【】…—.,!?\';:\"()\[\]{}<>~`@#$%^&*_+=|/\\-]+')
-
-        def _normalize(s: str) -> str:
-            return _punct_re.sub('', s)
-
-        norm_body = _normalize(quote_body)
-        norm_full = _normalize(full_quote)
+        quote_body = DatabaseManager._strip_quote_sender(full_quote)
+        norm_body = DatabaseManager._normalize_quote_text(quote_body)
+        norm_full = DatabaseManager._normalize_quote_text(full_quote)
 
         try:
             query = (MsgLog.select()
@@ -737,30 +790,82 @@ class DatabaseManager:
             if slave_member_uid:
                 query = query.where(MsgLog.slave_member_uid == slave_member_uid)
 
-            candidates = query
+            matches = []
 
-            for candidate in candidates:
+            for candidate in query:
                 ct = candidate.text
                 if not ct:
                     continue
 
                 # Layer 1: forward match (stripped body in DB text)
                 if quote_body and quote_body in ct:
-                    return candidate
+                    matches.append(candidate)
+                    continue
 
                 # Layer 2: reverse match (DB text in full quote)
                 if ct.strip() in full_quote:
-                    return candidate
+                    matches.append(candidate)
+                    continue
 
                 # Layer 3: normalized fuzzy match
-                norm_ct = _normalize(ct)
+                norm_ct = DatabaseManager._normalize_quote_text(ct)
                 if norm_ct and (norm_body and norm_body in norm_ct
                                 or norm_ct in norm_full):
-                    return candidate
+                    matches.append(candidate)
 
-            return None
+            return matches
         except Exception:
-            return None
+            return []
+
+    @staticmethod
+    def find_msg_by_quote_text(slave_origin_uid: 'EFBChannelChatIDStr',
+                               quote_text: str,
+                               limit: int = 200,
+                               slave_member_uid: 'Optional[str]' = None) -> Optional['MsgLog']:
+        """Find the most recent message matching quoted text content."""
+        candidates = DatabaseManager.find_msgs_by_quote_text(
+            slave_origin_uid=slave_origin_uid,
+            quote_text=quote_text,
+            limit=limit,
+            slave_member_uid=slave_member_uid,
+        )
+        if candidates:
+            return candidates[0]
+        return None
+
+    @staticmethod
+    def find_member_uids_by_display_name(slave_origin_uid: 'EFBChannelChatIDStr',
+                                         display_name: str,
+                                         limit: int = 500) -> 'List[str]':
+        """Find member UIDs whose logged display name matches a quoted sender name."""
+        if not display_name or not display_name.strip():
+            return []
+
+        name = display_name.strip()
+        norm_name = DatabaseManager._normalize_quote_text(name)
+        try:
+            rows = (MsgLog.select(MsgLog.slave_member_uid, MsgLog.slave_member_display_name)
+                    .where(MsgLog.slave_origin_uid == slave_origin_uid)
+                    .order_by(MsgLog.time.desc())
+                    .limit(limit))
+
+            matched_uids = []
+            seen_uids = set()
+            for row in rows:
+                uid = row.slave_member_uid
+                display = (row.slave_member_display_name or '').strip()
+                if not uid or uid in seen_uids or not display:
+                    continue
+                norm_display = DatabaseManager._normalize_quote_text(display)
+                if name == display or name in display or display in name \
+                        or (norm_name and norm_display and (norm_name == norm_display
+                                                            or norm_name in norm_display
+                                                            or norm_display in norm_name)):
+                    matched_uids.append(uid)
+                    seen_uids.add(uid)
+            return matched_uids
+        except Exception:
+            return []
 
     @staticmethod
     def find_msg_by_media_type(slave_origin_uid: 'EFBChannelChatIDStr',
@@ -944,6 +1049,17 @@ class DatabaseManager:
             if limit > 0:
                 query = query.limit(limit)
 
+            return list(query)
+        except DoesNotExist:
+            return []
+
+    @staticmethod
+    def get_recent_text_messages(slave_chat_id: EFBChannelChatIDStr, limit: int = 30) -> List[MsgLog]:
+        try:
+            query = MsgLog.select().where(
+                (MsgLog.slave_origin_uid == slave_chat_id) &
+                (MsgLog.msg_type == MsgType.Text.name)
+            ).order_by(MsgLog.time.desc()).limit(limit)
             return list(query)
         except DoesNotExist:
             return []

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -648,6 +648,7 @@ class DatabaseManager:
 
         row.master_msg_id = master_msg_id
         row.master_msg_id_alt = master_msg_id_alt
+        row.time = datetime.datetime.now()
         row.text = msg.text
         row.slave_origin_uid = chat_id_to_str(chat=msg.chat)
         row.slave_member_uid = chat_id_to_str(chat=msg.author)
@@ -1059,6 +1060,25 @@ class DatabaseManager:
             query = MsgLog.select().where(
                 (MsgLog.slave_origin_uid == slave_chat_id) &
                 (MsgLog.msg_type == MsgType.Text.name)
+            ).order_by(MsgLog.time.desc()).limit(limit)
+            return list(query)
+        except DoesNotExist:
+            return []
+
+    @staticmethod
+    def get_recent_solitaire_messages(
+        slave_chat_id: EFBChannelChatIDStr,
+        limit: int = 5,
+        max_age_hours: int = 72,
+    ) -> List[MsgLog]:
+        """Query recent solitaire messages directly with SQL LIKE filter."""
+        cutoff = datetime.datetime.now() - datetime.timedelta(hours=max_age_hours)
+        try:
+            query = MsgLog.select().where(
+                (MsgLog.slave_origin_uid == slave_chat_id) &
+                (MsgLog.msg_type == MsgType.Text.name) &
+                (MsgLog.time >= cutoff) &
+                (MsgLog.text.startswith('#接龙') | MsgLog.text.startswith('#接龍'))
             ).order_by(MsgLog.time.desc()).limit(limit)
             return list(query)
         except DoesNotExist:

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -682,6 +682,47 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def find_msg_by_quote_text(slave_origin_uid: 'EFBChannelChatIDStr',
+                               quote_text: str,
+                               limit: int = 200) -> Optional['MsgLog']:
+        """Find a message in the database by matching quoted text content.
+
+        Searches the most recent `limit` messages from the same slave chat
+        whose `text` field starts with or contains the given quote_text.
+
+        Args:
+            slave_origin_uid: The slave chat identifier string to scope the search.
+            quote_text: The quoted text extracted from the WeChat「」format.
+            limit: Maximum number of recent messages to search (default 200).
+
+        Returns:
+            Optional[MsgLog]: The best matching message log entry, or None.
+        """
+        if not quote_text or not quote_text.strip():
+            return None
+
+        # Strip HTML entities that may have been escaped
+        clean_text = quote_text.strip()
+
+        try:
+            # Search recent messages from the same slave chat,
+            # ordered by time descending (most recent first).
+            # We use LIKE with the quote text to find messages whose text
+            # starts with the quoted content.
+            candidates = (MsgLog.select()
+                          .where(MsgLog.slave_origin_uid == slave_origin_uid)
+                          .order_by(MsgLog.time.desc())
+                          .limit(limit))
+
+            for candidate in candidates:
+                if candidate.text and clean_text in candidate.text:
+                    return candidate
+
+            return None
+        except Exception:
+            return None
+
+    @staticmethod
     def delete_msg_log(master_msg_id: Optional[TgChatMsgIDStr] = None,
                        slave_msg_id: Optional[EFBChannelChatIDStr] = None,
                        slave_origin_uid: Optional[EFBChannelChatIDStr] = None):

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -1078,7 +1078,7 @@ class DatabaseManager:
                 (MsgLog.slave_origin_uid == slave_chat_id) &
                 (MsgLog.msg_type == MsgType.Text.name) &
                 (MsgLog.time >= cutoff) &
-                (MsgLog.text.startswith('#接龙') | MsgLog.text.startswith('#接龍'))
+                (MsgLog.text.contains('#接龙') | MsgLog.text.contains('#接龍'))
             ).order_by(MsgLog.time.desc()).limit(limit)
             return list(query)
         except DoesNotExist:

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -684,7 +684,8 @@ class DatabaseManager:
     @staticmethod
     def find_msg_by_quote_text(slave_origin_uid: 'EFBChannelChatIDStr',
                                quote_text: str,
-                               limit: int = 200) -> Optional['MsgLog']:
+                               limit: int = 200,
+                               slave_member_uid: 'Optional[str]' = None) -> Optional['MsgLog']:
         """Find a message in the database by matching quoted text content.
 
         Uses a 3-layer matching strategy on a single DB query result:
@@ -700,6 +701,8 @@ class DatabaseManager:
             quote_text: The quoted text extracted from the WeChat「」format,
                         typically in the form "SenderName：original content".
             limit: Maximum number of recent messages to search (default 200).
+            slave_member_uid: Optional sender UID to narrow the search.
+                              Useful for short quotes where text alone is too ambiguous.
 
         Returns:
             Optional[MsgLog]: The best matching message log entry, or None.
@@ -726,10 +729,15 @@ class DatabaseManager:
         norm_full = _normalize(full_quote)
 
         try:
-            candidates = (MsgLog.select()
-                          .where(MsgLog.slave_origin_uid == slave_origin_uid)
-                          .order_by(MsgLog.time.desc())
-                          .limit(limit))
+            query = (MsgLog.select()
+                     .where(MsgLog.slave_origin_uid == slave_origin_uid)
+                     .order_by(MsgLog.time.desc())
+                     .limit(limit))
+
+            if slave_member_uid:
+                query = query.where(MsgLog.slave_member_uid == slave_member_uid)
+
+            candidates = query
 
             for candidate in candidates:
                 ct = candidate.text
@@ -758,7 +766,8 @@ class DatabaseManager:
     def find_msg_by_media_type(slave_origin_uid: 'EFBChannelChatIDStr',
                                media_types: 'List[str]',
                                slave_member_uid: 'Optional[str]' = None,
-                               limit: int = 200) -> 'List[MsgLog]':
+                               limit: int = 200,
+                               max_age_hours: int = 48) -> 'List[MsgLog]':
         """Find recent media messages by type and optionally by sender.
 
         Used for matching WeChat media quote blocks (e.g. [图片], [视频])
@@ -769,15 +778,21 @@ class DatabaseManager:
             media_types: List of TGMsgType values to filter by (e.g. ["Photo", "Video"]).
             slave_member_uid: Optional sender UID to further filter results.
             limit: Maximum number of recent messages to search (default 200).
+            max_age_hours: Maximum age of messages to consider in hours (default 48).
+                           Prevents matching very old messages that are unlikely
+                           to be the intended quote target.
 
         Returns:
             List[MsgLog]: Matching message log entries, ordered by time desc.
         """
+        import datetime as _dt
         try:
+            cutoff = _dt.datetime.now() - _dt.timedelta(hours=max_age_hours)
             query = (MsgLog.select()
                      .where(
                          (MsgLog.slave_origin_uid == slave_origin_uid) &
-                         (MsgLog.media_type.in_(media_types))
+                         (MsgLog.media_type.in_(media_types)) &
+                         (MsgLog.time >= cutoff)
                      )
                      .order_by(MsgLog.time.desc())
                      .limit(limit))

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -351,9 +351,9 @@ class MasterMessageProcessor(LocaleMixin):
                         try:
                             message.delete()
                         except TelegramError:
-                            message.reply_text(self._("Message is removed in remote chat."))
+                            message.reply_text(f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>", parse_mode="HTML")
                     else:
-                        message.reply_text(self._("Message is removed in remote chat."))
+                        message.reply_text(f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>", parse_mode="HTML")
                     log_message = False
                     return
                 self.logger.debug('[%s] Message is edited (%s)', m.uid, m.edit)
@@ -598,9 +598,9 @@ class MasterMessageProcessor(LocaleMixin):
             try:
                 reply.delete()
             except TelegramError:
-                reply.reply_text(self._("Message is removed in remote chat."))
+                reply.reply_text(f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>", parse_mode="HTML")
         else:
-            reply.reply_text(self._("Message is removed in remote chat."))
+            reply.reply_text(f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>", parse_mode="HTML")
 
     def unsupported_message(self, update: Update, context: CallbackContext):
         assert isinstance(update, Update)

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -230,10 +230,10 @@ class SlaveMessageProcessor(LocaleMixin):
                     target_msg = utils.message_id_str_to_id(log.master_msg_id)
                     if target_msg and target_msg[0] == int(tg_dest):
                         target_msg_id = TelegramMessageID(target_msg[1])
-                        # Strip the quote block from msg.text so that
-                        # html_substitutions won't render a duplicate <blockquote>.
-                        # The native Telegram reply header already shows the quoted content.
-                        msg.text = msg.text[quote_match.end():]
+                        # Flag the message so html_substitutions renders
+                        # the quote as a collapsed (expandable) blockquote,
+                        # avoiding visual duplication with the native reply header.
+                        msg._expandable_quote = True
                         self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
                                           msg.uid, target_msg_id)
                     else:
@@ -430,7 +430,11 @@ class SlaveMessageProcessor(LocaleMixin):
             import re
             quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n(.*)$', t, flags=re.DOTALL)
             if quote_match:
-                t = f"<blockquote>{quote_match.group(1)}</blockquote>\n{quote_match.group(2)}"
+                # Use expandable (collapsed) blockquote when a native reply-to
+                # header is present, so the quote doesn't visually duplicate.
+                # Falls back to a regular visible blockquote otherwise.
+                bq_tag = "blockquote expandable" if getattr(msg, '_expandable_quote', False) else "blockquote"
+                t = f"<{bq_tag}>{quote_match.group(1)}</blockquote>\n{quote_match.group(2)}"
         return t
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -513,14 +513,13 @@ class SlaveMessageProcessor(LocaleMixin):
         candidates = [i for i in candidates if i is not None]
 
         command_base = None
-        if (msg.text or "").startswith(self.flag("solitaire_command")) and isinstance(msg.target, Message) \
-                and has_solitaire_header(msg.target.text):
+        if (msg.text or "").startswith(self.flag("solitaire_command")) and isinstance(msg.target, Message):
             target_log = self.db.get_msg_log(
                 slave_msg_id=msg.target.uid,
                 slave_origin_uid=utils.chat_id_to_str(chat=msg.target.chat)
             )
-            if target_log:
-                command_base = self._build_solitaire_candidate(target_log, text=msg.target.text)
+            if target_log and has_solitaire_header(target_log.text):
+                command_base = self._build_solitaire_candidate(target_log)
 
         return resolve_solitaire_action(
             msg.text or "",

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -218,29 +218,131 @@ class SlaveMessageProcessor(LocaleMixin):
             quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n', msg.text, flags=re.DOTALL)
             if quote_match:
                 quoted_text = quote_match.group(1)
+
+                # Extract sender name and quote body from "SenderName：content"
+                colon_split = re.match(r'^(.+?)[：:](.+)$', quoted_text, flags=re.DOTALL)
+                sender_name = colon_split.group(1).strip() if colon_split else None
+                quote_body = colon_split.group(2).strip() if colon_split else quoted_text.strip()
+
+                # Determine if the quote body is a media placeholder
+                _MEDIA_MAP = {
+                    # Chinese placeholders
+                    r'(?:\[图片\]|查看图片)': ['Photo'],
+                    r'(?:\[视频\]|查看视频|收到一条视频消息)': ['Video', 'Animation'],
+                    r'\[文件\]': ['Document'],
+                    r'\[语音\]': ['Voice', 'Audio'],
+                    r'(?:\[表情\]|\[动画表情\])': ['Sticker', 'AnimatedSticker', 'VideoSticker'],
+                    r'\[名片\]': ['Contact'],
+                    r'\[位置\]': ['Location', 'Venue'],
+                    # English placeholders
+                    r'\[(?:Image|Photo)\]': ['Photo'],
+                    r'\[Video\]': ['Video', 'Animation'],
+                    r'\[File\]': ['Document'],
+                    r'\[Voice\]': ['Voice', 'Audio'],
+                    r'\[Sticker\]': ['Sticker', 'AnimatedSticker', 'VideoSticker'],
+                    # Filename patterns (images/videos/docs)
+                    r'\S+\.(?:jpg|jpeg|png|gif|bmp|webp|heic|heif)': ['Photo', 'Document'],
+                    r'\S+\.(?:mp4|avi|mov|mkv|wmv|flv|3gp)': ['Video', 'Animation', 'Document'],
+                    r'\S+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|7z|apk|exe|txt|csv)': ['Document'],
+                    r'Image_\d+.*': ['Photo', 'Document'],
+                }
+
+                matched_media_types = None
+                for pattern, media_types in _MEDIA_MAP.items():
+                    if re.match(r'^\s*' + pattern + r'\s*$', quote_body, re.IGNORECASE):
+                        matched_media_types = media_types
+                        break
+
                 slave_chat_uid = utils.chat_id_to_str(chat=msg.chat)
-                self.logger.debug("[%s] Text quote block detected, attempting fuzzy match: '%.50s...'",
-                                  msg.uid, quoted_text)
-                log = self.db.find_msg_by_quote_text(
-                    slave_origin_uid=slave_chat_uid,
-                    quote_text=quoted_text,
-                    limit=200
-                )
-                if log:
-                    target_msg = utils.message_id_str_to_id(log.master_msg_id)
-                    if target_msg and target_msg[0] == int(tg_dest):
-                        target_msg_id = TelegramMessageID(target_msg[1])
-                        # Flag the message so html_substitutions renders
-                        # the quote as a collapsed (expandable) blockquote,
-                        # avoiding visual duplication with the native reply header.
-                        msg._expandable_quote = True
-                        self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
-                                          msg.uid, target_msg_id)
+
+                if matched_media_types:
+                    # --- Media quote path: match by media_type + sender name ---
+                    self.logger.debug("[%s] Media quote detected (types=%s, sender='%s'), attempting media match.",
+                                      msg.uid, matched_media_types, sender_name)
+
+                    # First, try to resolve sender name to slave_member_uid
+                    # by looking through recent messages from this chat and
+                    # checking display names via chat_manager.
+                    resolved_member_uid = None
+                    if sender_name:
+                        # Search recent candidates with matching media type
+                        candidates = self.db.find_msg_by_media_type(
+                            slave_origin_uid=slave_chat_uid,
+                            media_types=matched_media_types,
+                            limit=200
+                        )
+                        for candidate in candidates:
+                            if not candidate.slave_member_uid:
+                                continue
+                            try:
+                                member_channel_id, member_id, _ = utils.chat_id_str_to_id(candidate.slave_member_uid)
+                                chat_channel_id, chat_id, _ = utils.chat_id_str_to_id(slave_chat_uid)
+                                member = self.chat_manager.get_chat_member(
+                                    member_channel_id, chat_id, member_id, build_dummy=False
+                                )
+                                if member:
+                                    member_display = member.alias or member.name or ''
+                                    if sender_name in member_display or member_display in sender_name:
+                                        resolved_member_uid = candidate.slave_member_uid
+                                        break
+                            except Exception:
+                                continue
+
+                    # Now query with resolved sender UID for precision
+                    if resolved_member_uid:
+                        results = self.db.find_msg_by_media_type(
+                            slave_origin_uid=slave_chat_uid,
+                            media_types=matched_media_types,
+                            slave_member_uid=resolved_member_uid,
+                            limit=50
+                        )
                     else:
-                        self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
-                                          msg.uid)
+                        # Fallback: no sender resolution, just use media type
+                        results = self.db.find_msg_by_media_type(
+                            slave_origin_uid=slave_chat_uid,
+                            media_types=matched_media_types,
+                            limit=50
+                        )
+
+                    if results:
+                        # Take the most recent matching media message
+                        log = results[0]
+                        target_msg_result = utils.message_id_str_to_id(log.master_msg_id)
+                        if target_msg_result and target_msg_result[0] == int(tg_dest):
+                            target_msg_id = TelegramMessageID(target_msg_result[1])
+                            msg._expandable_quote = True
+                            self.logger.debug("[%s] Media quote match found: tg_msg_id=%s (sender_uid=%s)",
+                                              msg.uid, target_msg_id, resolved_member_uid)
+                        else:
+                            self.logger.debug("[%s] Media quote match found but in different chat, skipping.",
+                                              msg.uid)
+                    else:
+                        self.logger.debug("[%s] No media quote match found in database.", msg.uid)
+
+                elif len(quote_body) >= 4:
+                    # --- Text quote path: multi-layer fuzzy text matching ---
+                    self.logger.debug("[%s] Text quote block detected, attempting fuzzy match: '%.50s...'",
+                                      msg.uid, quoted_text)
+                    log = self.db.find_msg_by_quote_text(
+                        slave_origin_uid=slave_chat_uid,
+                        quote_text=quoted_text,
+                        limit=200
+                    )
+                    if log:
+                        target_msg = utils.message_id_str_to_id(log.master_msg_id)
+                        if target_msg and target_msg[0] == int(tg_dest):
+                            target_msg_id = TelegramMessageID(target_msg[1])
+                            msg._expandable_quote = True
+                            self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
+                                              msg.uid, target_msg_id)
+                        else:
+                            self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
+                                              msg.uid)
+                    else:
+                        self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
                 else:
-                    self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
+                    self.logger.debug("[%s] Quote body too short (%d chars), skipping: '%s'",
+                                      msg.uid, len(quote_body), quote_body)
 
         # Generate basic reply markup
         commands: Optional[List[MessageCommand]] = None

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1107,6 +1107,14 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.logger.debug("Found message to delete in Telegram: %s.%s",
                                   *old_msg_id)
                 try:
+                    # Get sender name from DB to preserve it in the edited message
+                    sender_prefix = ""
+                    try:
+                        etm_msg = old_msg.build_etm_msg(self.chat_manager)
+                        sender_prefix = f"{etm_msg.author.long_name}:"
+                    except Exception:
+                        pass
+
                     original_text = html.escape(old_msg.text or '')
                     new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
                     
@@ -1115,6 +1123,7 @@ class SlaveMessageProcessor(LocaleMixin):
                             chat_id=old_msg_id[0], 
                             message_id=old_msg_id[1], 
                             caption=new_text,
+                            prefix=sender_prefix,
                             parse_mode="HTML"
                         )
                     else:
@@ -1122,6 +1131,7 @@ class SlaveMessageProcessor(LocaleMixin):
                             chat_id=old_msg_id[0], 
                             message_id=old_msg_id[1], 
                             text=new_text,
+                            prefix=sender_prefix,
                             parse_mode="HTML"
                         )
                     return

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -210,6 +210,34 @@ class SlaveMessageProcessor(LocaleMixin):
                 else:
                     target_msg_id = target_msg[1]
 
+        # Fallback: If msg.target was not set (no EFB-level reply), but the message
+        # text contains a WeChat-style quote block (「...」\n---\n...), try to find
+        # the original message in the database by fuzzy-matching the quoted text.
+        if target_msg_id is None and not isinstance(msg.target, Message) and msg.text:
+            import re
+            quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n', msg.text, flags=re.DOTALL)
+            if quote_match:
+                quoted_text = quote_match.group(1)
+                slave_chat_uid = utils.chat_id_to_str(chat=msg.chat)
+                self.logger.debug("[%s] Text quote block detected, attempting fuzzy match: '%.50s...'",
+                                  msg.uid, quoted_text)
+                log = self.db.find_msg_by_quote_text(
+                    slave_origin_uid=slave_chat_uid,
+                    quote_text=quoted_text,
+                    limit=200
+                )
+                if log:
+                    target_msg = utils.message_id_str_to_id(log.master_msg_id)
+                    if target_msg and target_msg[0] == int(tg_dest):
+                        target_msg_id = TelegramMessageID(target_msg[1])
+                        self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
+                                          msg.uid, target_msg_id)
+                    else:
+                        self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
+                                          msg.uid)
+                else:
+                    self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
+
         # Generate basic reply markup
         commands: Optional[List[MessageCommand]] = None
         reply_markup: Optional[InlineKeyboardMarkup] = None

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -368,10 +368,17 @@ class SlaveMessageProcessor(LocaleMixin):
                     t += '</code>'
                 prev = i[1]
             t += html.escape(text[prev:])
-            return t
         elif text:
-            return html.escape(text)
-        return text
+            t = html.escape(text)
+        else:
+            t = text
+
+        if t:
+            import re
+            quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n(.*)$', t, flags=re.DOTALL)
+            if quote_match:
+                t = f"<blockquote>{quote_match.group(1)}</blockquote>\n{quote_match.group(2)}"
+        return t
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
                            thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -377,7 +377,7 @@ class SlaveMessageProcessor(LocaleMixin):
             import re
             quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n(.*)$', t, flags=re.DOTALL)
             if quote_match:
-                t = f"<blockquote>{quote_match.group(1)}</blockquote>\n{quote_match.group(2)}"
+                t = f"💬 <code>{quote_match.group(1)}</code>\n{quote_match.group(2)}"
         return t
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1108,7 +1108,8 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.warning("Failed to delete message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
                     pass
                 self.bot.send_message(chat_id=old_msg_id[0],
-                                      text=self._("Message is removed in remote chat."),
+                                      text=f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>",
+                                      parse_mode="HTML",
                                       reply_to_message_id=old_msg_id[1],
                                       disable_notification=True)  # Probably silent notification
             else:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -377,7 +377,7 @@ class SlaveMessageProcessor(LocaleMixin):
             import re
             quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n(.*)$', t, flags=re.DOTALL)
             if quote_match:
-                t = f"💬 <code>{quote_match.group(1)}</code>\n{quote_match.group(2)}"
+                t = f"<blockquote>{quote_match.group(1)}</blockquote>\n{quote_match.group(2)}"
         return t
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -230,6 +230,10 @@ class SlaveMessageProcessor(LocaleMixin):
                     target_msg = utils.message_id_str_to_id(log.master_msg_id)
                     if target_msg and target_msg[0] == int(tg_dest):
                         target_msg_id = TelegramMessageID(target_msg[1])
+                        # Strip the quote block from msg.text so that
+                        # html_substitutions won't render a duplicate <blockquote>.
+                        # The native Telegram reply header already shows the quoted content.
+                        msg.text = msg.text[quote_match.end():]
                         self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
                                           msg.uid, target_msg_id)
                     else:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1108,11 +1108,40 @@ class SlaveMessageProcessor(LocaleMixin):
                                   *old_msg_id)
                 try:
                     if not self.channel.flag('prevent_message_removal'):
-                        self.bot.delete_message(*old_msg_id,
-                                                _sender_bot_id=old_msg.sender_bot_id)
-                        return
+                        try:
+                            import html
+                            etm_msg = old_msg.build_etm_msg(self.chat_manager)
+                            slave_uid = utils.chat_id_to_str(chat=etm_msg.chat)
+                            singly_linked = len(self.db.get_chat_assoc(slave_uid=slave_uid)) == 1
+                            msg_template = self.generate_message_template(etm_msg, singly_linked)
+                            
+                            original_text = html.escape(old_msg.text or '')
+                            new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
+                            
+                            if old_msg.media_type and old_msg.media_type != 'text':
+                                self.bot.edit_message_caption(
+                                    chat_id=old_msg_id[0], 
+                                    message_id=old_msg_id[1], 
+                                    caption=new_text,
+                                    prefix=msg_template,
+                                    parse_mode="HTML"
+                                )
+                            else:
+                                self.bot.edit_message_text(
+                                    chat_id=old_msg_id[0], 
+                                    message_id=old_msg_id[1], 
+                                    text=new_text,
+                                    prefix=msg_template,
+                                    parse_mode="HTML"
+                                )
+                            return
+                        except Exception as e:
+                            self.logger.debug("Failed to edit message %s.%s as recalled: %s. Falling back to delete.", *old_msg_id, e)
+                            self.bot.delete_message(*old_msg_id,
+                                                    _sender_bot_id=old_msg.sender_bot_id)
+                            return
                 except TelegramError as e:
-                    self.logger.warning("Failed to delete message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
+                    self.logger.warning("Failed to delete/edit message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
                     pass
                 self.bot.send_message(chat_id=old_msg_id[0],
                                       text=f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>",

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -255,54 +255,55 @@ class SlaveMessageProcessor(LocaleMixin):
 
                 slave_chat_uid = utils.chat_id_to_str(chat=msg.chat)
 
-                if matched_media_types:
-                    # --- Media quote path: match by media_type + sender name ---
-                    self.logger.debug("[%s] Media quote detected (types=%s, sender='%s'), attempting media match.",
-                                      msg.uid, matched_media_types, sender_name)
-
-                    # First, try to resolve sender name to slave_member_uid
-                    # by looking through recent messages from this chat and
+                # --- Shared: resolve sender name to slave_member_uid ---
+                resolved_member_uid = None
+                if sender_name:
+                    # Look through recent messages from this chat,
                     # checking display names via chat_manager.
-                    resolved_member_uid = None
-                    if sender_name:
-                        # Search recent candidates with matching media type
-                        candidates = self.db.find_msg_by_media_type(
-                            slave_origin_uid=slave_chat_uid,
-                            media_types=matched_media_types,
-                            limit=200
-                        )
-                        for candidate in candidates:
-                            if not candidate.slave_member_uid:
+                    # We use a broad query (no media_type filter) to maximize
+                    # the chance of finding a name match.
+                    try:
+                        from .db import MsgLog
+                        seen_uids = set()
+                        recent_msgs = (MsgLog.select(MsgLog.slave_member_uid)
+                                       .where(MsgLog.slave_origin_uid == slave_chat_uid)
+                                       .order_by(MsgLog.time.desc())
+                                       .limit(500))
+                        for row in recent_msgs:
+                            uid = row.slave_member_uid
+                            if not uid or uid in seen_uids:
                                 continue
+                            seen_uids.add(uid)
                             try:
-                                member_channel_id, member_id, _ = utils.chat_id_str_to_id(candidate.slave_member_uid)
-                                chat_channel_id, chat_id, _ = utils.chat_id_str_to_id(slave_chat_uid)
+                                member_channel_id, member_id, _ = utils.chat_id_str_to_id(uid)
+                                _, chat_id, _ = utils.chat_id_str_to_id(slave_chat_uid)
                                 member = self.chat_manager.get_chat_member(
                                     member_channel_id, chat_id, member_id, build_dummy=False
                                 )
                                 if member:
                                     member_display = member.alias or member.name or ''
                                     if sender_name in member_display or member_display in sender_name:
-                                        resolved_member_uid = candidate.slave_member_uid
+                                        resolved_member_uid = uid
+                                        self.logger.debug("[%s] Sender '%s' resolved to uid=%s (display='%s')",
+                                                          msg.uid, sender_name, uid, member_display)
                                         break
                             except Exception:
                                 continue
+                    except Exception:
+                        pass
 
-                    # Now query with resolved sender UID for precision
-                    if resolved_member_uid:
-                        results = self.db.find_msg_by_media_type(
-                            slave_origin_uid=slave_chat_uid,
-                            media_types=matched_media_types,
-                            slave_member_uid=resolved_member_uid,
-                            limit=50
-                        )
-                    else:
-                        # Fallback: no sender resolution, just use media type
-                        results = self.db.find_msg_by_media_type(
-                            slave_origin_uid=slave_chat_uid,
-                            media_types=matched_media_types,
-                            limit=50
-                        )
+                if matched_media_types:
+                    # --- Media quote path: match by media_type + sender + time window ---
+                    self.logger.debug("[%s] Media quote detected (types=%s, sender='%s'), attempting media match.",
+                                      msg.uid, matched_media_types, sender_name)
+
+                    results = self.db.find_msg_by_media_type(
+                        slave_origin_uid=slave_chat_uid,
+                        media_types=matched_media_types,
+                        slave_member_uid=resolved_member_uid,
+                        limit=50,
+                        max_age_hours=48
+                    )
 
                     if results:
                         # Take the most recent matching media message
@@ -319,30 +320,34 @@ class SlaveMessageProcessor(LocaleMixin):
                     else:
                         self.logger.debug("[%s] No media quote match found in database.", msg.uid)
 
-                elif len(quote_body) >= 4:
-                    # --- Text quote path: multi-layer fuzzy text matching ---
-                    self.logger.debug("[%s] Text quote block detected, attempting fuzzy match: '%.50s...'",
-                                      msg.uid, quoted_text)
-                    log = self.db.find_msg_by_quote_text(
-                        slave_origin_uid=slave_chat_uid,
-                        quote_text=quoted_text,
-                        limit=200
-                    )
-                    if log:
-                        target_msg = utils.message_id_str_to_id(log.master_msg_id)
-                        if target_msg and target_msg[0] == int(tg_dest):
-                            target_msg_id = TelegramMessageID(target_msg[1])
-                            msg._expandable_quote = True
-                            self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
-                                              msg.uid, target_msg_id)
-                        else:
-                            self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
-                                              msg.uid)
-                    else:
-                        self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
                 else:
-                    self.logger.debug("[%s] Quote body too short (%d chars), skipping: '%s'",
-                                      msg.uid, len(quote_body), quote_body)
+                    # --- Text quote path: multi-layer fuzzy text matching ---
+                    # For short quotes (<4 chars), require sender filtering for accuracy.
+                    # For longer quotes, sender filtering is optional (improves precision).
+                    if len(quote_body) < 4 and not resolved_member_uid:
+                        self.logger.debug("[%s] Quote body too short (%d chars) and no sender resolved, skipping: '%s'",
+                                          msg.uid, len(quote_body), quote_body)
+                    else:
+                        self.logger.debug("[%s] Text quote block detected (len=%d, sender_uid=%s), attempting fuzzy match: '%.50s...'",
+                                          msg.uid, len(quote_body), resolved_member_uid, quoted_text)
+                        log = self.db.find_msg_by_quote_text(
+                            slave_origin_uid=slave_chat_uid,
+                            quote_text=quoted_text,
+                            limit=200,
+                            slave_member_uid=resolved_member_uid
+                        )
+                        if log:
+                            target_msg = utils.message_id_str_to_id(log.master_msg_id)
+                            if target_msg and target_msg[0] == int(tg_dest):
+                                target_msg_id = TelegramMessageID(target_msg[1])
+                                msg._expandable_quote = True
+                                self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
+                                                  msg.uid, target_msg_id)
+                            else:
+                                self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
+                                                  msg.uid)
+                        else:
+                            self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
 
         # Generate basic reply markup
         commands: Optional[List[MessageCommand]] = None

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -139,19 +139,40 @@ class SlaveMessageProcessor(LocaleMixin):
 
             self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
         except Exception as e:
-            if isinstance(e, telegram.error.BadRequest) and e.message:
-                if "Topic" in e.message:
-                    try:
-                        self.bot.reopen_forum_topic(
-                            chat_id=tg_dest,
-                            message_thread_id=thread_id
-                        )
-                    except telegram.error.BadRequest as reopen_err:
-                        self.logger.error('Failed to reopen topic, Reason: %s', reopen_err)
-                        self.db.remove_topic_assoc(
-                            topic_chat_id=tg_dest,
-                            message_thread_id=thread_id,
-                        )
+            if isinstance(e, telegram.error.BadRequest) and e.message and \
+                    ("Topic" in e.message or "thread" in e.message.lower()):
+                # Topic might be closed or deleted. Try to reopen first (works for closed topics).
+                topic_recovered = False
+                try:
+                    self.bot.reopen_forum_topic(
+                        chat_id=tg_dest,
+                        message_thread_id=thread_id
+                    )
+                    topic_recovered = True
+                except telegram.error.BadRequest as reopen_err:
+                    # Reopen failed — topic was deleted, not just closed.
+                    # Remove the stale DB record so a new topic can be created.
+                    self.logger.warning('Topic %s in chat %s was deleted. Removing stale association and retrying. '
+                                        'Reopen error: %s', thread_id, tg_dest, reopen_err)
+                    self.db.remove_topic_assoc(
+                        topic_chat_id=tg_dest,
+                        message_thread_id=thread_id,
+                    )
+
+                # Retry: either the topic was reopened, or the stale record was removed
+                # so get_slave_msg_dest will create a fresh topic.
+                try:
+                    if topic_recovered:
+                        # Topic was merely closed and is now reopened — retry with the same thread_id
+                        self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
+                    else:
+                        # Topic was deleted — re-resolve destination (will auto-create a new topic)
+                        msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(msg)
+                        if tg_dest is not None:
+                            self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
+                except Exception as retry_err:
+                    self.logger.error("Failed to deliver message after topic recovery.\nMessage: %s\n%s\n%s",
+                                      repr(msg), repr(retry_err), traceback.format_exc())
             else:
                 self.logger.error("Error occurred while processing message from slave channel.\nMessage: %s\n%s\n%s",
                               repr(msg), repr(e), traceback.format_exc())

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -4,6 +4,7 @@ import html
 import itertools
 import logging
 import os
+import re
 import tempfile
 import traceback
 import urllib.parse
@@ -35,6 +36,7 @@ from .constants import Emoji
 from .locale_mixin import LocaleMixin
 from .message import ETMMsg
 from .msg_type import get_msg_type
+from .solitaire import ActionPlan, SolitaireCandidate, has_solitaire_header, resolve_solitaire_action
 from .utils import TelegramChatID, TelegramTopicID, TelegramMessageID, OldMsgID
 
 if TYPE_CHECKING:
@@ -45,6 +47,26 @@ if TYPE_CHECKING:
 
 class SlaveMessageProcessor(LocaleMixin):
     """Process messages as Message objects from slave channels."""
+
+    _WECHAT_QUOTE_RE = re.compile(r'「(.+?)」\n-[\- ]{10,80}\n', flags=re.DOTALL)
+    _MEDIA_QUOTE_PATTERNS = (
+        (r'(?:\[图片\]|查看图片)', ['Photo']),
+        (r'(?:\[视频\]|查看视频|收到一条视频消息)', ['Video', 'Animation']),
+        (r'\[文件\]', ['Document']),
+        (r'\[语音\]', ['Voice', 'Audio']),
+        (r'(?:\[表情\]|\[动画表情\])', ['Sticker', 'AnimatedSticker', 'VideoSticker']),
+        (r'\[名片\]', ['Contact']),
+        (r'\[位置\]', ['Location', 'Venue']),
+        (r'\[(?:Image|Photo)\]', ['Photo']),
+        (r'\[Video\]', ['Video', 'Animation']),
+        (r'\[File\]', ['Document']),
+        (r'\[Voice\]', ['Voice', 'Audio']),
+        (r'\[Sticker\]', ['Sticker', 'AnimatedSticker', 'VideoSticker']),
+        (r'\S+\.(?:jpg|jpeg|png|gif|bmp|webp|heic|heif)', ['Photo', 'Document']),
+        (r'\S+\.(?:mp4|avi|mov|mkv|wmv|flv|3gp)', ['Video', 'Animation', 'Document']),
+        (r'\S+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|7z|apk|exe|txt|csv)', ['Document']),
+        (r'Image_\d+.*', ['Photo', 'Document']),
+    )
 
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
@@ -178,6 +200,123 @@ class SlaveMessageProcessor(LocaleMixin):
                               repr(msg), repr(e), traceback.format_exc())
         return msg
 
+    @classmethod
+    def _parse_wechat_quote(cls, text: str) -> Optional[Tuple[str, Optional[str], str]]:
+        quote_match = next(cls._WECHAT_QUOTE_RE.finditer(text), None)
+        if not quote_match:
+            return None
+
+        quoted_text = quote_match.group(1)
+        colon_split = re.match(r'^(.+?)[：:](.+)$', quoted_text, flags=re.DOTALL)
+        sender_name = colon_split.group(1).strip() if colon_split else None
+        quote_body = colon_split.group(2).strip() if colon_split else quoted_text.strip()
+        return quoted_text, sender_name, quote_body
+
+    @classmethod
+    def _match_media_quote_types(cls, quote_body: str) -> Optional[List[str]]:
+        for pattern, media_types in cls._MEDIA_QUOTE_PATTERNS:
+            if re.match(r'^\s*' + pattern + r'\s*$', quote_body, re.IGNORECASE):
+                return media_types
+        return None
+
+    def _resolve_quoted_sender_uid(self, slave_chat_uid: str, sender_name: Optional[str]) -> Optional[str]:
+        if not sender_name:
+            return None
+
+        matched_uids = self.db.find_member_uids_by_display_name(slave_chat_uid, sender_name)
+        if len(matched_uids) == 1:
+            return matched_uids[0]
+        if len(matched_uids) > 1:
+            self.logger.debug("Quoted sender '%s' matches multiple logged members: %s", sender_name, matched_uids)
+            return None
+
+        try:
+            from .db import MsgLog
+            seen_uids = set()
+            recent_msgs = (MsgLog.select(MsgLog.slave_member_uid)
+                           .where(MsgLog.slave_origin_uid == slave_chat_uid)
+                           .order_by(MsgLog.time.desc())
+                           .limit(500))
+            for row in recent_msgs:
+                uid = row.slave_member_uid
+                if not uid or uid in seen_uids:
+                    continue
+                seen_uids.add(uid)
+                try:
+                    member_channel_id, member_id, _ = utils.chat_id_str_to_id(uid)
+                    _, chat_id, _ = utils.chat_id_str_to_id(slave_chat_uid)
+                    member = self.chat_manager.get_chat_member(
+                        member_channel_id, chat_id, member_id, build_dummy=False
+                    )
+                    if member:
+                        member_display = member.alias or member.name or ''
+                        if sender_name in member_display or member_display in sender_name:
+                            matched_uids.append(uid)
+                except Exception:
+                    continue
+        except Exception:
+            return None
+
+        unique_uids = list(dict.fromkeys(matched_uids))
+        if len(unique_uids) == 1:
+            return unique_uids[0]
+        if len(unique_uids) > 1:
+            self.logger.debug("Quoted sender '%s' matches multiple cached members: %s", sender_name, unique_uids)
+        return None
+
+    @staticmethod
+    def _telegram_msg_id_from_log(log, tg_dest: TelegramChatID) -> Optional[TelegramMessageID]:
+        target_msg = utils.message_id_str_to_id(log.master_msg_id)
+        if target_msg and target_msg[0] == int(tg_dest):
+            return TelegramMessageID(target_msg[1])
+        return None
+
+    def _find_wechat_quote_target(self, msg: Message, tg_dest: TelegramChatID) -> Optional[TelegramMessageID]:
+        parsed_quote = self._parse_wechat_quote(msg.text or "")
+        if not parsed_quote:
+            return None
+
+        quoted_text, sender_name, quote_body = parsed_quote
+        slave_chat_uid = utils.chat_id_to_str(chat=msg.chat)
+        resolved_member_uid = self._resolve_quoted_sender_uid(slave_chat_uid, sender_name)
+        if not resolved_member_uid:
+            self.logger.debug("[%s] Quoted sender '%s' cannot be resolved uniquely; skipping quote target.",
+                              msg.uid, sender_name)
+            return None
+
+        matched_media_types = self._match_media_quote_types(quote_body)
+        if matched_media_types:
+            self.logger.debug("[%s] Media quote detected (types=%s, sender='%s'), requiring unique match.",
+                              msg.uid, matched_media_types, sender_name)
+            candidates = self.db.find_msg_by_media_type(
+                slave_origin_uid=slave_chat_uid,
+                media_types=matched_media_types,
+                slave_member_uid=resolved_member_uid,
+                limit=50,
+                max_age_hours=48,
+            )
+        else:
+            self.logger.debug("[%s] Text quote detected (len=%d, sender_uid=%s), requiring unique match: '%.50s...'",
+                              msg.uid, len(quote_body), resolved_member_uid, quoted_text)
+            candidates = self.db.find_msgs_by_quote_text(
+                slave_origin_uid=slave_chat_uid,
+                quote_text=quoted_text,
+                limit=200,
+                slave_member_uid=resolved_member_uid,
+            )
+
+        candidates = [i for i in candidates if self._telegram_msg_id_from_log(i, tg_dest) is not None]
+        if len(candidates) != 1:
+            self.logger.debug("[%s] Quote target has %d high-confidence candidates; skipping reply target.",
+                              msg.uid, len(candidates))
+            return None
+
+        target_msg_id = self._telegram_msg_id_from_log(candidates[0], tg_dest)
+        if target_msg_id is not None:
+            msg._expandable_quote = True
+            self.logger.debug("[%s] Quote target resolved uniquely: tg_msg_id=%s", msg.uid, target_msg_id)
+        return target_msg_id
+
     def dispatch_message(self, msg: Message, msg_template: str,
                          old_msg_id: Optional[OldMsgID],
                          tg_dest: TelegramChatID,
@@ -186,6 +325,10 @@ class SlaveMessageProcessor(LocaleMixin):
         """Dispatch with header, destination and Telegram message ID and destinations."""
 
         xid = msg.uid
+        db_old_msg_id = old_msg_id
+        solitaire_alias_master_msg_id: Optional[str] = None
+        solitaire_edit = False
+        solitaire_edit_success = False
 
         # When targeting a message (reply to)
         target_msg_id: Optional[TelegramMessageID] = None
@@ -211,143 +354,30 @@ class SlaveMessageProcessor(LocaleMixin):
                     target_msg_id = target_msg[1]
 
         # Fallback: If msg.target was not set (no EFB-level reply), but the message
-        # text contains a WeChat-style quote block (「...」\n---\n...), try to find
-        # the original message in the database by fuzzy-matching the quoted text.
+        # text contains a WeChat-style quote block (「...」\n---\n...), attach a
+        # Telegram reply only when the quoted sender and target are uniquely resolved.
         if target_msg_id is None and not isinstance(msg.target, Message) and msg.text:
-            import re
-            quote_match = re.match(r'^「(.+?)」\n-[\- ]{10,40}\n', msg.text, flags=re.DOTALL)
-            if quote_match:
-                quoted_text = quote_match.group(1)
+            target_msg_id = self._find_wechat_quote_target(msg, tg_dest)
 
-                # Extract sender name and quote body from "SenderName：content"
-                colon_split = re.match(r'^(.+?)[：:](.+)$', quoted_text, flags=re.DOTALL)
-                sender_name = colon_split.group(1).strip() if colon_split else None
-                quote_body = colon_split.group(2).strip() if colon_split else quoted_text.strip()
-
-                # Determine if the quote body is a media placeholder
-                _MEDIA_MAP = {
-                    # Chinese placeholders
-                    r'(?:\[图片\]|查看图片)': ['Photo'],
-                    r'(?:\[视频\]|查看视频|收到一条视频消息)': ['Video', 'Animation'],
-                    r'\[文件\]': ['Document'],
-                    r'\[语音\]': ['Voice', 'Audio'],
-                    r'(?:\[表情\]|\[动画表情\])': ['Sticker', 'AnimatedSticker', 'VideoSticker'],
-                    r'\[名片\]': ['Contact'],
-                    r'\[位置\]': ['Location', 'Venue'],
-                    # English placeholders
-                    r'\[(?:Image|Photo)\]': ['Photo'],
-                    r'\[Video\]': ['Video', 'Animation'],
-                    r'\[File\]': ['Document'],
-                    r'\[Voice\]': ['Voice', 'Audio'],
-                    r'\[Sticker\]': ['Sticker', 'AnimatedSticker', 'VideoSticker'],
-                    # Filename patterns (images/videos/docs)
-                    r'\S+\.(?:jpg|jpeg|png|gif|bmp|webp|heic|heif)': ['Photo', 'Document'],
-                    r'\S+\.(?:mp4|avi|mov|mkv|wmv|flv|3gp)': ['Video', 'Animation', 'Document'],
-                    r'\S+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|7z|apk|exe|txt|csv)': ['Document'],
-                    r'Image_\d+.*': ['Photo', 'Document'],
-                }
-
-                matched_media_types = None
-                for pattern, media_types in _MEDIA_MAP.items():
-                    if re.match(r'^\s*' + pattern + r'\s*$', quote_body, re.IGNORECASE):
-                        matched_media_types = media_types
-                        break
-
-                slave_chat_uid = utils.chat_id_to_str(chat=msg.chat)
-
-                # --- Shared: resolve sender name to slave_member_uid ---
-                resolved_member_uid = None
-                if sender_name:
-                    # Look through recent messages from this chat,
-                    # checking display names via chat_manager.
-                    # We use a broad query (no media_type filter) to maximize
-                    # the chance of finding a name match.
-                    try:
-                        from .db import MsgLog
-                        seen_uids = set()
-                        recent_msgs = (MsgLog.select(MsgLog.slave_member_uid)
-                                       .where(MsgLog.slave_origin_uid == slave_chat_uid)
-                                       .order_by(MsgLog.time.desc())
-                                       .limit(500))
-                        for row in recent_msgs:
-                            uid = row.slave_member_uid
-                            if not uid or uid in seen_uids:
-                                continue
-                            seen_uids.add(uid)
-                            try:
-                                member_channel_id, member_id, _ = utils.chat_id_str_to_id(uid)
-                                _, chat_id, _ = utils.chat_id_str_to_id(slave_chat_uid)
-                                member = self.chat_manager.get_chat_member(
-                                    member_channel_id, chat_id, member_id, build_dummy=False
-                                )
-                                if member:
-                                    member_display = member.alias or member.name or ''
-                                    if sender_name in member_display or member_display in sender_name:
-                                        resolved_member_uid = uid
-                                        self.logger.debug("[%s] Sender '%s' resolved to uid=%s (display='%s')",
-                                                          msg.uid, sender_name, uid, member_display)
-                                        break
-                            except Exception:
-                                continue
-                    except Exception:
-                        pass
-
-                if matched_media_types:
-                    # --- Media quote path: match by media_type + sender + time window ---
-                    self.logger.debug("[%s] Media quote detected (types=%s, sender='%s'), attempting media match.",
-                                      msg.uid, matched_media_types, sender_name)
-
-                    results = self.db.find_msg_by_media_type(
-                        slave_origin_uid=slave_chat_uid,
-                        media_types=matched_media_types,
-                        slave_member_uid=resolved_member_uid,
-                        limit=50,
-                        max_age_hours=48
-                    )
-
-                    if results:
-                        # Take the most recent matching media message
-                        log = results[0]
-                        target_msg_result = utils.message_id_str_to_id(log.master_msg_id)
-                        if target_msg_result and target_msg_result[0] == int(tg_dest):
-                            target_msg_id = TelegramMessageID(target_msg_result[1])
-                            msg._expandable_quote = True
-                            self.logger.debug("[%s] Media quote match found: tg_msg_id=%s (sender_uid=%s)",
-                                              msg.uid, target_msg_id, resolved_member_uid)
-                        else:
-                            self.logger.debug("[%s] Media quote match found but in different chat, skipping.",
-                                              msg.uid)
+        if self._should_resolve_solitaire(msg):
+            action_plan = self._resolve_solitaire_action(msg)
+            self.logger.debug("[%s] Solitaire resolver action: %s", msg.uid, action_plan)
+            if action_plan.action_type == "DROP":
+                return
+            if action_plan.action_type == "EDIT":
+                if action_plan.replacement_text is not None:
+                    msg.text = action_plan.replacement_text
+                if action_plan.editable_master_msg_id and action_plan.canonical_master_msg_id:
+                    editable_msg_id = utils.message_id_str_to_id(action_plan.editable_master_msg_id)
+                    canonical_msg_id = utils.message_id_str_to_id(action_plan.canonical_master_msg_id)
+                    if editable_msg_id and canonical_msg_id:
+                        old_msg_id = editable_msg_id
+                        db_old_msg_id = canonical_msg_id
+                        solitaire_alias_master_msg_id = action_plan.canonical_master_msg_id
+                        solitaire_edit = True
                     else:
-                        self.logger.debug("[%s] No media quote match found in database.", msg.uid)
-
-                else:
-                    # --- Text quote path: multi-layer fuzzy text matching ---
-                    # For short quotes (<4 chars), require sender filtering for accuracy.
-                    # For longer quotes, sender filtering is optional (improves precision).
-                    if len(quote_body) < 4 and not resolved_member_uid:
-                        self.logger.debug("[%s] Quote body too short (%d chars) and no sender resolved, skipping: '%s'",
-                                          msg.uid, len(quote_body), quote_body)
-                    else:
-                        self.logger.debug("[%s] Text quote block detected (len=%d, sender_uid=%s), attempting fuzzy match: '%.50s...'",
-                                          msg.uid, len(quote_body), resolved_member_uid, quoted_text)
-                        log = self.db.find_msg_by_quote_text(
-                            slave_origin_uid=slave_chat_uid,
-                            quote_text=quoted_text,
-                            limit=200,
-                            slave_member_uid=resolved_member_uid
-                        )
-                        if log:
-                            target_msg = utils.message_id_str_to_id(log.master_msg_id)
-                            if target_msg and target_msg[0] == int(tg_dest):
-                                target_msg_id = TelegramMessageID(target_msg[1])
-                                msg._expandable_quote = True
-                                self.logger.debug("[%s] Fuzzy quote match found: tg_msg_id=%s",
-                                                  msg.uid, target_msg_id)
-                            else:
-                                self.logger.debug("[%s] Fuzzy quote match found but in different chat, skipping.",
-                                                  msg.uid)
-                        else:
-                            self.logger.debug("[%s] No fuzzy quote match found in database.", msg.uid)
+                        self.logger.warning("[%s] Solitaire resolver returned invalid target: %s",
+                                            msg.uid, action_plan)
 
         # Generate basic reply markup
         commands: Optional[List[MessageCommand]] = None
@@ -366,8 +396,21 @@ class SlaveMessageProcessor(LocaleMixin):
 
         # Type dispatching
         if msg.type == MsgType.Text:
-            tg_msg = self.slave_message_text(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                             reply_markup, silent)
+            try:
+                tg_msg = self.slave_message_text(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id,
+                                                 target_msg_id, reply_markup, silent)
+                solitaire_edit_success = solitaire_edit
+            except TelegramError as e:
+                if not solitaire_edit:
+                    raise
+                self.logger.warning("[%s] Failed to edit solitaire message %s; sending as a new message instead: %s",
+                                    msg.uid, old_msg_id, e)
+                old_msg_id = None
+                db_old_msg_id = None
+                solitaire_alias_master_msg_id = None
+                solitaire_edit = False
+                tg_msg = self.slave_message_text(msg, tg_dest, thread_id, msg_template, reactions, None,
+                                                 target_msg_id, reply_markup, silent)
         elif msg.type == MsgType.Link:
             tg_msg = self.slave_message_link(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
                                              reply_markup, silent)
@@ -432,7 +475,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
             # Register the delayed database update
             if hasattr(tg_msg, 'task_id'):
-                self.bot.register_delayed_database_update(tg_msg.task_id, etm_msg, old_msg_id)
+                self.bot.register_delayed_database_update(tg_msg.task_id, etm_msg, db_old_msg_id)
             else:
                 self.logger.warning("[%s] Delayed message missing task_id, cannot register database update", xid)
         else:
@@ -447,9 +490,59 @@ class SlaveMessageProcessor(LocaleMixin):
             # Capture sender_bot_id annotated by rate_limit_decorator
             sender_bot_id = getattr(tg_msg, '_sender_bot_id', None)
 
-            self.db.add_or_update_message_log(etm_msg, tg_msg, old_msg_id,
+            self.db.add_or_update_message_log(etm_msg, tg_msg, db_old_msg_id,
                                               sender_bot_id=sender_bot_id)
+            if solitaire_edit_success and solitaire_alias_master_msg_id and msg.uid:
+                self.db.add_msg_alias(utils.chat_id_to_str(chat=msg.chat), msg.uid, solitaire_alias_master_msg_id)
             # self.logger.debug("[%s] Message inserted/updated to the database.", xid)
+
+    def _should_resolve_solitaire(self, msg: Message) -> bool:
+        if not self.flag("solitaire_auto_merge"):
+            return False
+        if msg.edit or msg.type != MsgType.Text or not isinstance(msg.chat, GroupChat):
+            return False
+        text = msg.text or ""
+        return text.startswith(self.flag("solitaire_command")) or has_solitaire_header(text)
+
+    def _resolve_solitaire_action(self, msg: Message) -> ActionPlan:
+        chat_uid = utils.chat_id_to_str(chat=msg.chat)
+        candidates = [
+            self._build_solitaire_candidate(row)
+            for row in self.db.get_recent_text_messages(chat_uid, limit=30)
+            if has_solitaire_header(row.text)
+        ]
+        candidates = [i for i in candidates if i is not None]
+
+        command_base = None
+        if (msg.text or "").startswith(self.flag("solitaire_command")) and isinstance(msg.target, Message) \
+                and has_solitaire_header(msg.target.text):
+            target_log = self.db.get_msg_log(
+                slave_msg_id=msg.target.uid,
+                slave_origin_uid=utils.chat_id_to_str(chat=msg.target.chat)
+            )
+            if target_log:
+                command_base = self._build_solitaire_candidate(target_log, text=msg.target.text)
+
+        return resolve_solitaire_action(
+            msg.text or "",
+            str(msg.uid) if msg.uid is not None else None,
+            candidates,
+            command=self.flag("solitaire_command"),
+            command_base=command_base,
+        )
+
+    @staticmethod
+    def _build_solitaire_candidate(row, text: Optional[str] = None) -> Optional[SolitaireCandidate]:
+        canonical_master_msg_id = row.master_msg_id
+        editable_master_msg_id = row.master_msg_id_alt or row.master_msg_id
+        if not canonical_master_msg_id or not editable_master_msg_id:
+            return None
+        return SolitaireCandidate(
+            slave_message_id=str(row.slave_message_id),
+            canonical_master_msg_id=canonical_master_msg_id,
+            editable_master_msg_id=editable_master_msg_id,
+            text=text if text is not None else row.text,
+        )
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:
         """Get the Telegram destination of a message with its header.

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1107,12 +1107,6 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.logger.debug("Found message to delete in Telegram: %s.%s",
                                   *old_msg_id)
                 try:
-                    import html
-                    etm_msg = old_msg.build_etm_msg(self.chat_manager)
-                    slave_uid = utils.chat_id_to_str(chat=etm_msg.chat)
-                    singly_linked = len(self.db.get_chat_assoc(slave_uid=slave_uid)) == 1
-                    msg_template = self.generate_message_template(etm_msg, singly_linked)
-                    
                     original_text = html.escape(old_msg.text or '')
                     new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
                     
@@ -1121,7 +1115,6 @@ class SlaveMessageProcessor(LocaleMixin):
                             chat_id=old_msg_id[0], 
                             message_id=old_msg_id[1], 
                             caption=new_text,
-                            prefix=msg_template,
                             parse_mode="HTML"
                         )
                     else:
@@ -1129,7 +1122,6 @@ class SlaveMessageProcessor(LocaleMixin):
                             chat_id=old_msg_id[0], 
                             message_id=old_msg_id[1], 
                             text=new_text,
-                            prefix=msg_template,
                             parse_mode="HTML"
                         )
                     return

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -508,8 +508,7 @@ class SlaveMessageProcessor(LocaleMixin):
         chat_uid = utils.chat_id_to_str(chat=msg.chat)
         candidates = [
             self._build_solitaire_candidate(row)
-            for row in self.db.get_recent_text_messages(chat_uid, limit=30)
-            if has_solitaire_header(row.text)
+            for row in self.db.get_recent_solitaire_messages(chat_uid)
         ]
         candidates = [i for i in candidates if i is not None]
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1116,7 +1116,7 @@ class SlaveMessageProcessor(LocaleMixin):
                     original_text = html.escape(old_msg.text or '')
                     new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
                     
-                    if old_msg.media_type and old_msg.media_type != 'text':
+                    if old_msg.media_type and old_msg.media_type not in ('Text', 'text'):
                         self.bot.edit_message_caption(
                             chat_id=old_msg_id[0], 
                             message_id=old_msg_id[1], 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -375,6 +375,9 @@ class SlaveMessageProcessor(LocaleMixin):
                         db_old_msg_id = canonical_msg_id
                         solitaire_alias_master_msg_id = action_plan.canonical_master_msg_id
                         solitaire_edit = True
+                        if action_plan.sender_bot_id:
+                            msg.vendor_specific = msg.vendor_specific or {}
+                            msg.vendor_specific['_sender_bot_id'] = action_plan.sender_bot_id
                     else:
                         self.logger.warning("[%s] Solitaire resolver returned invalid target: %s",
                                             msg.uid, action_plan)
@@ -540,6 +543,7 @@ class SlaveMessageProcessor(LocaleMixin):
             canonical_master_msg_id=canonical_master_msg_id,
             editable_master_msg_id=editable_master_msg_id,
             text=text if text is not None else row.text,
+            sender_bot_id=getattr(row, 'sender_bot_id', None),
         )
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -1107,42 +1107,44 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.logger.debug("Found message to delete in Telegram: %s.%s",
                                   *old_msg_id)
                 try:
-                    if not self.channel.flag('prevent_message_removal'):
-                        try:
-                            import html
-                            etm_msg = old_msg.build_etm_msg(self.chat_manager)
-                            slave_uid = utils.chat_id_to_str(chat=etm_msg.chat)
-                            singly_linked = len(self.db.get_chat_assoc(slave_uid=slave_uid)) == 1
-                            msg_template = self.generate_message_template(etm_msg, singly_linked)
-                            
-                            original_text = html.escape(old_msg.text or '')
-                            new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
-                            
-                            if old_msg.media_type and old_msg.media_type != 'text':
-                                self.bot.edit_message_caption(
-                                    chat_id=old_msg_id[0], 
-                                    message_id=old_msg_id[1], 
-                                    caption=new_text,
-                                    prefix=msg_template,
-                                    parse_mode="HTML"
-                                )
-                            else:
-                                self.bot.edit_message_text(
-                                    chat_id=old_msg_id[0], 
-                                    message_id=old_msg_id[1], 
-                                    text=new_text,
-                                    prefix=msg_template,
-                                    parse_mode="HTML"
-                                )
-                            return
-                        except Exception as e:
-                            self.logger.debug("Failed to edit message %s.%s as recalled: %s. Falling back to delete.", *old_msg_id, e)
-                            self.bot.delete_message(*old_msg_id,
-                                                    _sender_bot_id=old_msg.sender_bot_id)
-                            return
-                except TelegramError as e:
-                    self.logger.warning("Failed to delete/edit message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
+                    import html
+                    etm_msg = old_msg.build_etm_msg(self.chat_manager)
+                    slave_uid = utils.chat_id_to_str(chat=etm_msg.chat)
+                    singly_linked = len(self.db.get_chat_assoc(slave_uid=slave_uid)) == 1
+                    msg_template = self.generate_message_template(etm_msg, singly_linked)
+                    
+                    original_text = html.escape(old_msg.text or '')
+                    new_text = f"<del>{original_text}</del>\n[已撤回]" if original_text else "[已撤回]"
+                    
+                    if old_msg.media_type and old_msg.media_type != 'text':
+                        self.bot.edit_message_caption(
+                            chat_id=old_msg_id[0], 
+                            message_id=old_msg_id[1], 
+                            caption=new_text,
+                            prefix=msg_template,
+                            parse_mode="HTML"
+                        )
+                    else:
+                        self.bot.edit_message_text(
+                            chat_id=old_msg_id[0], 
+                            message_id=old_msg_id[1], 
+                            text=new_text,
+                            prefix=msg_template,
+                            parse_mode="HTML"
+                        )
+                    return
+                except Exception as e:
+                    self.logger.debug("Failed to edit message %s.%s as recalled: %s. Falling back to delete/notify.", *old_msg_id, e)
                     pass
+
+                try:
+                    if not self.channel.flag('prevent_message_removal'):
+                        self.bot.delete_message(*old_msg_id, _sender_bot_id=old_msg.sender_bot_id)
+                        return
+                except TelegramError as e:
+                    self.logger.warning("Failed to delete message %s.%s: %s. Sending notification instead.", *old_msg_id, e)
+                    pass
+                
                 self.bot.send_message(chat_id=old_msg_id[0],
                                       text=f"<blockquote>🚫 {self._('Message is removed in remote chat.')}</blockquote>",
                                       parse_mode="HTML",

--- a/efb_telegram_master/solitaire.py
+++ b/efb_telegram_master/solitaire.py
@@ -18,6 +18,7 @@ class ActionPlan:
     editable_master_msg_id: Optional[str] = None
     replacement_text: Optional[str] = None
     reason: str = ""
+    sender_bot_id: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ class SolitaireCandidate:
     canonical_master_msg_id: str
     editable_master_msg_id: str
     text: str
+    sender_bot_id: Optional[str] = None
 
 
 _HEADER_VALUES = ("#接龙", "#接龍")
@@ -112,6 +114,7 @@ def resolve_solitaire_action(
             canonical_master_msg_id=base.canonical_master_msg_id,
             editable_master_msg_id=base.editable_master_msg_id,
             replacement_text=replacement,
+            sender_bot_id=base.sender_bot_id,
             reason="command_append",
         )
 
@@ -141,6 +144,7 @@ def resolve_solitaire_action(
             "EDIT",
             canonical_master_msg_id=best_candidate.canonical_master_msg_id,
             editable_master_msg_id=best_candidate.editable_master_msg_id,
+            sender_bot_id=best_candidate.sender_bot_id,
             reason=reason,
         )
     return ActionPlan("SEND", reason="ambiguous_match")
@@ -158,7 +162,10 @@ def _score_match(old: SolitaireParse, new: SolitaireParse) -> Tuple[float, str]:
             return 0.0, "continuation_prefix_changed"
         if len(new_items) - len(old_items) > 20:
             return 0.0, "continuation_growth_too_large"
-        return max(0.9, 1.0 - changed * 0.05), "continuation"
+        # Prefer the most complete prior snapshot when several missed candidates
+        # all match the same continuation chain.
+        coverage = len(old_items) / len(new_items)
+        return max(0.9, 1.0 + coverage - changed * 0.05), "continuation"
 
     if len(new_items) == len(old_items):
         if len(old_items) < 5:

--- a/efb_telegram_master/solitaire.py
+++ b/efb_telegram_master/solitaire.py
@@ -1,0 +1,193 @@
+# coding=utf-8
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+import re
+from typing import List, Optional, Sequence, Tuple
+
+from typing_extensions import Literal
+
+
+ActionType = Literal["EDIT", "SEND", "DROP"]
+
+
+@dataclass(frozen=True)
+class ActionPlan:
+    action_type: ActionType
+    canonical_master_msg_id: Optional[str] = None
+    editable_master_msg_id: Optional[str] = None
+    replacement_text: Optional[str] = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SolitaireItem:
+    index: int
+    content: str
+
+
+@dataclass(frozen=True)
+class SolitaireParse:
+    layout: str
+    items: Tuple[SolitaireItem, ...]
+
+
+@dataclass(frozen=True)
+class SolitaireCandidate:
+    slave_message_id: str
+    canonical_master_msg_id: str
+    editable_master_msg_id: str
+    text: str
+
+
+_HEADER_VALUES = ("#接龙", "#接龍")
+_ITEM_RE = re.compile(r"^\s*(\d+)([.])\s+(.+?)\s*$")
+
+
+def has_solitaire_header(text: Optional[str]) -> bool:
+    if not text:
+        return False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        return stripped in _HEADER_VALUES
+    return False
+
+
+def parse_solitaire(text: Optional[str]) -> Optional[SolitaireParse]:
+    if not has_solitaire_header(text):
+        return None
+    assert text is not None
+
+    items: List[SolitaireItem] = []
+    layout: Optional[str] = None
+    for line in text.splitlines():
+        match = _ITEM_RE.match(line)
+        if not match:
+            continue
+        item_layout = match.group(2)
+        if layout is None:
+            layout = item_layout
+        elif item_layout != layout:
+            return None
+        items.append(SolitaireItem(int(match.group(1)), match.group(3).rstrip()))
+
+    if not items:
+        return None
+    if [i.index for i in items] != list(range(1, len(items) + 1)):
+        return None
+    return SolitaireParse(layout=layout or ".", items=tuple(items))
+
+
+def build_command_text(base_text: str, payload: str) -> Optional[str]:
+    parsed = parse_solitaire(base_text)
+    payload = payload.strip()
+    if parsed is None or not payload:
+        return None
+
+    replacement = base_text.rstrip() + f"\n{len(parsed.items) + 1}. {payload}"
+    if parse_solitaire(replacement) is None:
+        return None
+    return replacement
+
+
+def resolve_solitaire_action(
+        text: str,
+        msg_uid: Optional[str],
+        candidates: Sequence[SolitaireCandidate],
+        *,
+        command: str = "jl`",
+        command_base: Optional[SolitaireCandidate] = None,
+) -> ActionPlan:
+    if text.startswith(command):
+        base = command_base or next(iter(candidates), None)
+        if base is None:
+            return ActionPlan("DROP", reason="command_without_candidate")
+        replacement = build_command_text(base.text, text[len(command):])
+        if replacement is None:
+            return ActionPlan("DROP", reason="invalid_command_append")
+        return ActionPlan(
+            "EDIT",
+            canonical_master_msg_id=base.canonical_master_msg_id,
+            editable_master_msg_id=base.editable_master_msg_id,
+            replacement_text=replacement,
+            reason="command_append",
+        )
+
+    new_parsed = parse_solitaire(text)
+    if new_parsed is None:
+        return ActionPlan("SEND", reason="not_solitaire")
+
+    scored: List[Tuple[float, SolitaireCandidate, str]] = []
+    for candidate in candidates:
+        if msg_uid and candidate.slave_message_id == msg_uid:
+            continue
+        old_parsed = parse_solitaire(candidate.text)
+        if old_parsed is None or old_parsed.layout != new_parsed.layout:
+            continue
+        score, reason = _score_match(old_parsed, new_parsed)
+        if score > 0:
+            scored.append((score, candidate, reason))
+
+    if not scored:
+        return ActionPlan("SEND", reason="no_match")
+
+    scored.sort(key=lambda i: i[0], reverse=True)
+    best_score, best_candidate, reason = scored[0]
+    second_score = scored[1][0] if len(scored) > 1 else 0.0
+    if best_score >= 0.9 and best_score - second_score >= 0.15:
+        return ActionPlan(
+            "EDIT",
+            canonical_master_msg_id=best_candidate.canonical_master_msg_id,
+            editable_master_msg_id=best_candidate.editable_master_msg_id,
+            reason=reason,
+        )
+    return ActionPlan("SEND", reason="ambiguous_match")
+
+
+def _score_match(old: SolitaireParse, new: SolitaireParse) -> Tuple[float, str]:
+    old_items = [i.content for i in old.items]
+    new_items = [i.content for i in new.items]
+
+    if len(new_items) > len(old_items):
+        changed = _changed_count(old_items, new_items[:len(old_items)])
+        if len(old_items) < 5 and changed > 0:
+            return 0.0, "continuation_prefix_changed_short"
+        if len(old_items) >= 5 and changed > 1:
+            return 0.0, "continuation_prefix_changed"
+        if len(new_items) - len(old_items) > 20:
+            return 0.0, "continuation_growth_too_large"
+        return max(0.9, 1.0 - changed * 0.05), "continuation"
+
+    if len(new_items) == len(old_items):
+        if len(old_items) < 5:
+            return 0.0, "correction_too_short"
+        changed = _changed_count(old_items, new_items)
+        if changed <= 2:
+            return 0.96 - changed * 0.02, "correction"
+        return 0.0, "correction_too_many_changes"
+
+    if len(old_items) >= 3 and len(new_items) == len(old_items) - 1:
+        if _is_single_deletion(old_items, new_items):
+            return 0.94, "deletion"
+        return 0.0, "deletion_with_changes"
+
+    return 0.0, "unsupported_change"
+
+
+def _changed_count(old_items: Sequence[str], new_items: Sequence[str]) -> int:
+    return sum(1 for old, new in zip(old_items, new_items) if old != new)
+
+
+def _is_single_deletion(old_items: Sequence[str], new_items: Sequence[str]) -> bool:
+    matcher = SequenceMatcher(a=list(old_items), b=list(new_items), autojunk=False)
+    deleted = 0
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        if tag == "delete" and (i2 - i1) == 1 and j1 == j2:
+            deleted += 1
+            continue
+        return False
+    return deleted == 1

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -57,7 +57,7 @@ class ExperimentalFlagsManager(LocaleMixin):
         "api_base_file_url": None,
         "local_tdlib_api": False,
         "topic_group": None,
-        "solitaire_auto_merge": False,
+        "solitaire_auto_merge": True,
         "solitaire_command": "jl`",
     }
 

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -57,6 +57,8 @@ class ExperimentalFlagsManager(LocaleMixin):
         "api_base_file_url": None,
         "local_tdlib_api": False,
         "topic_group": None,
+        "solitaire_auto_merge": False,
+        "solitaire_command": "jl`",
     }
 
     @staticmethod
@@ -273,55 +275,79 @@ if os.name == "nt":
 
     def gif_conversion(file: IO[bytes], channel_id: str) -> IO[bytes]:
         """Convert Telegram GIF to real GIF, the NT way."""
-        gif_file = NamedTemporaryFile(suffix='.gif')
         file.seek(0)
 
         # Use custom ffprobe command to read from stream
         metadata = ffprobe(file)
 
-        # Set input/output of ffmpeg to stream
-        stream = ffmpeg.input("pipe:")
-        if channel_id.startswith("blueset.wechat") and metadata.get('width', 0) > 600:
-            # Workaround: Compress GIF for slave channel `blueset.wechat`
-            # TODO: Move this logic to `blueset.wechat` in the future
-            stream = stream.filter("scale", 600, -2)
-        # Need to specify file format here as no extension hint presents.
-        args = stream.output("pipe:", format="gif").compile()
-        file.seek(0)
+        for attempt in range(2):
+            gif_file = NamedTemporaryFile(suffix='.gif')
+            file.seek(0)
 
-        # subprocess.Popen would still try to access the file handle instead of
-        # using standard IO interface. Not sure if that would work on Windows.
-        # Using the most classic buffer and copy via IO interface just to play
-        # safe.
-        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        assert p.stdin
-        copyfileobj(file, p.stdin)
-        p.stdin.close()
+            # Set input/output of ffmpeg to stream
+            stream = ffmpeg.input("pipe:")
+            if attempt == 1:
+                stream = stream.filter("fps", fps=12)
 
-        # Raise exception if error occurs, just like ffmpeg-python.
-        if p.returncode != 0 and p.stderr:
-            err = p.stderr.read().decode()
-            print(err, file=sys.stderr)
-            raise ffmpeg.Error('ffmpeg', "", err)
+            if channel_id.startswith("blueset.wechat") and metadata.get('width', 0) > 600:
+                # Workaround: Compress GIF for slave channel `blueset.wechat`
+                # TODO: Move this logic to `blueset.wechat` in the future
+                stream = stream.filter("scale", 600, -2)
+            # Need to specify file format here as no extension hint presents.
+            args = stream.output("pipe:", format="gif").compile()
 
-        assert p.stdout
-        copyfileobj(p.stdout, gif_file)
+            # subprocess.Popen would still try to access the file handle instead of
+            # using standard IO interface. Not sure if that would work on Windows.
+            # Using the most classic buffer and copy via IO interface just to play
+            # safe.
+            p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            assert p.stdin
+            copyfileobj(file, p.stdin)
+            p.stdin.close()
+
+            assert p.stdout
+            copyfileobj(p.stdout, gif_file)
+            p.wait()
+
+            # Raise exception if error occurs, just like ffmpeg-python.
+            if p.returncode != 0:
+                err = p.stderr.read().decode() if p.stderr else ""
+                print(err, file=sys.stderr)
+                raise ffmpeg.Error('ffmpeg', "", err)
+
+            gif_file.seek(0)
+            if attempt == 0 and os.path.getsize(gif_file.name) > 1000000:
+                gif_file.close()
+                continue
+            break
+
         file.close()
-        gif_file.seek(0)
         return gif_file
 
 else:
     def gif_conversion(file: IO[bytes], channel_id: str) -> IO[bytes]:
         """Convert Telegram GIF to real GIF, the non-NT way."""
-        gif_file = NamedTemporaryFile(suffix='.gif')
-        file.seek(0)
         metadata = ffmpeg.probe(file.name)
-        stream = ffmpeg.input(file.name)
-        if channel_id.startswith("blueset.wechat") and metadata.get('width', 0) > 600:
-            # Workaround: Compress GIF for slave channel `blueset.wechat`
-            # TODO: Move this logic to `blueset.wechat` in the future
-            stream = stream.filter("scale", 600, -2)
-        stream.output(gif_file.name).overwrite_output().run()
+
+        for attempt in range(2):
+            gif_file = NamedTemporaryFile(suffix='.gif')
+            file.seek(0)
+
+            stream = ffmpeg.input(file.name)
+            if attempt == 1:
+                stream = stream.filter("fps", fps=12)
+
+            if channel_id.startswith("blueset.wechat") and metadata.get('width', 0) > 600:
+                # Workaround: Compress GIF for slave channel `blueset.wechat`
+                # TODO: Move this logic to `blueset.wechat` in the future
+                stream = stream.filter("scale", 600, -2)
+            stream.output(gif_file.name).overwrite_output().run()
+
+            gif_file.seek(0)
+            if attempt == 0 and os.path.getsize(gif_file.name) > 1000000:
+                gif_file.close()
+                continue
+            break
+
         file.close()
-        gif_file.seek(0)
         return gif_file

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -42,6 +42,40 @@ def test_caption_prefix_suffix(channel, bot_admin, image):
     assert edited.caption == "Edited prefix\nEdited text\nEdited suffix"
 
 
+def test_html_affix_prefix_uses_blockquote():
+    prefix, suffix = TelegramBotManager._format_affix(
+        prefix='Speaker <A&B>', suffix='Seen <ok> & noted', parse_mode='html'
+    )
+
+    assert prefix == '<blockquote>Speaker &lt;A&amp;B&gt;</blockquote>\n'
+    assert suffix == '\nSeen &lt;ok&gt; &amp; noted'
+
+
+def test_html_caption_affix_decorator_uses_blockquote():
+    def fake_send(self, *args, **kwargs):
+        return SimpleNamespace(caption=kwargs['caption'])
+
+    manager = SimpleNamespace(
+        _detect_empty_file=Mock(return_value=None),
+        _format_affix=TelegramBotManager._format_affix,
+    )
+    decorated = TelegramBotManager.Decorators.caption_affix_decorator(fake_send)
+
+    message = decorated(
+        manager,
+        12345,
+        caption='Body',
+        prefix='Speaker <A&B>',
+        suffix='Seen <ok> & noted',
+        parse_mode='html',
+    )
+
+    assert message.caption == (
+        '<blockquote>Speaker &lt;A&amp;B&gt;</blockquote>\n'
+        'Body\nSeen &lt;ok&gt; &amp; noted'
+    )
+
+
 def test_message_truncation(channel, bot_admin):
     msg_body = ''.join(random.choice(string.ascii_letters) for _ in range(100000))
     with patch('telegram.Bot.send_document') as mock_send_document:

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1,3 +1,4 @@
+import io
 import string
 import random
 import threading
@@ -228,6 +229,29 @@ def test_rate_limit_decorator_schedules_delayed_task_when_main_bot_is_limited():
     assert result.is_delayed is True
     manager._schedule_delayed_task.assert_called_once()
     manager._create_delayed_message_placeholder.assert_called_once_with(123, 5.0, "task-1")
+
+
+def test_rate_limit_decorator_freezes_file_for_delayed_task():
+    decorated = TelegramBotManager.Decorators.rate_limit_decorator(
+        lambda self, chat_id, sticker: SimpleNamespace(chat_id=chat_id, sticker=sticker.read())
+    )
+    manager = SimpleNamespace(
+        _delayed_worker_stop=threading.Event(),
+        bot_pool=None,
+        _calculate_rate_limit_delay=Mock(return_value=(5.0, 1, 1)),
+        _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
+        _schedule_delayed_task=Mock(return_value="task-1"),
+        _create_delayed_message_placeholder=Mock(return_value=SimpleNamespace(is_delayed=True, task_id="task-1")),
+        logger=Mock(),
+    )
+    source_file = io.BytesIO(b"sticker-bytes")
+
+    decorated(manager, 123, source_file)
+    source_file.close()
+
+    scheduled_args = manager._schedule_delayed_task.call_args.kwargs["args"]
+    frozen_file = scheduled_args[2]
+    assert frozen_file.read() == b"sticker-bytes"
 
 
 def test_handle_rate_limit_error_retries_retry_after_even_when_generic_retry_disabled():

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -10,7 +10,7 @@ from ehforwarderbot import Message, MsgType
 from ehforwarderbot.types import MessageID
 
 from efb_telegram_master import utils
-from efb_telegram_master.db import MsgLog, TopicAssoc
+from efb_telegram_master.db import MsgAlias, MsgLog, TopicAssoc
 from efb_telegram_master.message import ETMMsg
 from efb_telegram_master.msg_type import TGMsgType
 from efb_telegram_master.utils import TelegramChatID, TelegramMessageID, TelegramTopicID
@@ -22,6 +22,14 @@ def test_msglog_schema_has_sender_bot_id(channel):
         from efb_telegram_master.db import database
         columns = {column.name for column in database.get_columns("msglog")}
     assert "sender_bot_id" in columns
+
+
+def test_msgalias_table_exists(channel):
+    tables = channel.db.database.get_tables() if hasattr(channel.db, "database") else None
+    if tables is None:
+        from efb_telegram_master.db import database
+        tables = database.get_tables()
+    assert "msgalias" in tables
 
 
 def test_topic_assoc_table_exists_and_round_trips(channel, slave):
@@ -57,6 +65,32 @@ def test_add_or_update_message_log_persists_sender_bot_id(channel, slave):
     assert stored is not None
     assert stored.sender_bot_id == "777"
 
+    stored.delete_instance()
+
+
+def test_msg_alias_resolves_recent_slave_uid(channel, slave):
+    chat = slave.chat_with_alias
+    author = chat.self
+    etm_msg = ETMMsg(
+        uid=MessageID("canonical-message"),
+        chat=channel.chat_manager.update_chat_obj(chat),
+        author=channel.chat_manager.get_or_enrol_member(chat, author),
+        text="canonical text",
+        type=MsgType.Text,
+        type_telegram=TGMsgType.Text,
+        deliver_to=channel,
+    )
+    master_message = SimpleNamespace(chat_id=3333, message_id=4444)
+    channel.db.add_or_update_message_log(etm_msg, master_message)
+
+    slave_uid = utils.chat_id_to_str(chat=chat)
+    channel.db.add_msg_alias(slave_uid, MessageID("alias-message"), "3333.4444")
+
+    stored = channel.db.get_msg_log(slave_msg_id=MessageID("alias-message"), slave_origin_uid=slave_uid)
+    assert stored is not None
+    assert stored.master_msg_id == "3333.4444"
+
+    MsgAlias.delete().where(MsgAlias.slave_message_id == "alias-message").execute()
     stored.delete_instance()
 
 

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,10 +1,18 @@
+from datetime import datetime
+from types import SimpleNamespace
+
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 
-from ehforwarderbot import Message, Chat
+from ehforwarderbot import Message, Chat, MsgType
+from ehforwarderbot.types import MessageID
+from efb_telegram_master import utils
 from ehforwarderbot.types import ReactionName
 from efb_telegram_master.constants import Emoji
+from efb_telegram_master.message import ETMMsg
+from efb_telegram_master.msg_type import TGMsgType
 from efb_telegram_master.slave_message import SlaveMessageProcessor
+from efb_telegram_master.utils import TelegramChatID
 
 
 def test_slave_message_reaction_footer(slave):
@@ -184,3 +192,134 @@ def test_build_inline_keyboard_existing_buttons(build_inline_keyboard, private):
     assert "__text__" in seq
     assert "__template__" in seq
     assert "__reactions__" in seq
+
+
+def _log_message(channel, chat, author, *, text, master_msg_id, slave_msg_id, msg_type=MsgType.Text,
+                 tg_msg_type=TGMsgType.Text):
+    cached_chat = channel.chat_manager.update_chat_obj(chat, full_update=True)
+    etm_msg = ETMMsg(
+        uid=MessageID(slave_msg_id),
+        chat=cached_chat,
+        author=channel.chat_manager.get_or_enrol_member(cached_chat, author),
+        text=text,
+        type=msg_type,
+        type_telegram=tg_msg_type,
+        deliver_to=channel,
+    )
+    chat_id, message_id = master_msg_id.split(".")
+    channel.db.add_or_update_message_log(
+        etm_msg,
+        SimpleNamespace(chat_id=int(chat_id), message_id=int(message_id)),
+    )
+    row = channel.db.get_msg_log(master_msg_id=master_msg_id)
+    row.time = datetime.now()
+    row.save()
+    return row
+
+
+def test_wechat_text_quote_resolves_unique_sender_target(channel, slave):
+    processor = SlaveMessageProcessor(channel)
+    chat = slave.group
+    quoted_author = chat.members[0]
+    reply_author = chat.members[1]
+    original = _log_message(
+        channel,
+        chat,
+        quoted_author,
+        text="这边1点半上班",
+        master_msg_id="12345.10",
+        slave_msg_id="quoted-text",
+    )
+    try:
+        msg = Message(
+            uid=MessageID("reply-text"),
+            chat=chat,
+            author=reply_author,
+            text=f"{reply_author.alias or reply_author.name}:\n"
+                 f"「{quoted_author.alias or quoted_author.name}：这边1点半上班」\n"
+                 "- - - - - - - - - - - - - - -\n"
+                 "中间休息时间短，应该下班时间早吧",
+            type=MsgType.Text,
+        )
+
+        target = processor._find_wechat_quote_target(msg, TelegramChatID(12345))
+
+        assert target == 10
+        assert getattr(msg, "_expandable_quote", False) is True
+    finally:
+        original.delete_instance()
+
+
+def test_wechat_short_text_quote_requires_unique_candidate(channel, slave):
+    processor = SlaveMessageProcessor(channel)
+    chat = slave.group
+    quoted_author = chat.members[0]
+    rows = [
+        _log_message(channel, chat, quoted_author, text="测试一下", master_msg_id="12345.20", slave_msg_id="short-1"),
+        _log_message(channel, chat, quoted_author, text="测试", master_msg_id="12345.21", slave_msg_id="short-2"),
+    ]
+    try:
+        msg = Message(
+            uid=MessageID("reply-short"),
+            chat=chat,
+            author=chat.members[1],
+            text=f"「{quoted_author.alias or quoted_author.name}：测试」\n"
+                 "- - - - - - - - - - - - - - -\n"
+                 "回复",
+            type=MsgType.Text,
+        )
+
+        assert processor._find_wechat_quote_target(msg, TelegramChatID(12345)) is None
+        assert not getattr(msg, "_expandable_quote", False)
+    finally:
+        for row in rows:
+            row.delete_instance()
+
+
+def test_wechat_media_quote_requires_unique_candidate(channel, slave):
+    processor = SlaveMessageProcessor(channel)
+    chat = slave.group
+    quoted_author = chat.members[0]
+    rows = [
+        _log_message(channel, chat, quoted_author, text="first image", master_msg_id="12345.30",
+                     slave_msg_id="image-1", msg_type=MsgType.Image, tg_msg_type=TGMsgType.Photo),
+        _log_message(channel, chat, quoted_author, text="second image", master_msg_id="12345.31",
+                     slave_msg_id="image-2", msg_type=MsgType.Image, tg_msg_type=TGMsgType.Photo),
+    ]
+    try:
+        msg = Message(
+            uid=MessageID("reply-image"),
+            chat=chat,
+            author=chat.members[1],
+            text=f"「{quoted_author.alias or quoted_author.name}：[图片]」\n"
+                 "- - - - - - - - - - - - - - -\n"
+                 "感觉",
+            type=MsgType.Text,
+        )
+
+        assert processor._find_wechat_quote_target(msg, TelegramChatID(12345)) is None
+        assert not getattr(msg, "_expandable_quote", False)
+    finally:
+        for row in rows:
+            row.delete_instance()
+
+
+def test_add_or_update_message_log_persists_member_display_name(channel, slave):
+    chat = slave.group
+    author = chat.members[0]
+    row = _log_message(
+        channel,
+        chat,
+        author,
+        text="display name",
+        master_msg_id="12345.40",
+        slave_msg_id="display-name",
+    )
+    try:
+        assert row.slave_member_display_name == (author.alias or author.name)
+        assert utils.chat_id_to_str(chat=author) in channel.db.find_member_uids_by_display_name(
+            utils.chat_id_to_str(chat=chat),
+            author.alias or author.name,
+        )
+    finally:
+        row.delete_instance()

--- a/tests/unit/test_solitaire.py
+++ b/tests/unit/test_solitaire.py
@@ -7,12 +7,13 @@ from efb_telegram_master.solitaire import (
 )
 
 
-def candidate(uid, master_id, text):
+def candidate(uid, master_id, text, sender_bot_id=None):
     return SolitaireCandidate(
         slave_message_id=uid,
         canonical_master_msg_id=master_id,
         editable_master_msg_id=master_id,
         text=text,
+        sender_bot_id=sender_bot_id,
     )
 
 
@@ -131,6 +132,38 @@ def test_ambiguous_candidates_fall_back_to_send():
 
     assert plan.action_type == "SEND"
     assert plan.reason == "ambiguous_match"
+
+
+def test_continuation_prefers_latest_snapshot_when_previous_merges_were_missed():
+    one = solitaire("A材料学院水果美食团购", note="下午5.3左右到")
+    two = solitaire("A材料学院水果美食团购", "Laine. 半个西瓜，西北", note="下午5.3左右到")
+    three = solitaire(
+        "A材料学院水果美食团购",
+        "Laine. 半个西瓜，西北",
+        "朝夕。 蟠桃1斤 脆桃2斤",
+        note="下午5.3左右到",
+    )
+    four = solitaire(
+        "A材料学院水果美食团购",
+        "Laine. 半个西瓜，西北",
+        "朝夕。 蟠桃1斤 脆桃2斤",
+        "fantasy 西瓜果切两盒",
+        note="下午5.3左右到",
+    )
+
+    plan = resolve_solitaire_action(
+        four,
+        "new",
+        [
+            candidate("one", "1.10", one),
+            candidate("two", "1.11", two),
+            candidate("three", "1.12", three, sender_bot_id="777"),
+        ],
+    )
+
+    assert plan.action_type == "EDIT"
+    assert plan.canonical_master_msg_id == "1.12"
+    assert plan.sender_bot_id == "777"
 
 
 def test_command_appends_to_base_candidate():

--- a/tests/unit/test_solitaire.py
+++ b/tests/unit/test_solitaire.py
@@ -1,0 +1,154 @@
+from efb_telegram_master.solitaire import (
+    SolitaireCandidate,
+    build_command_text,
+    has_solitaire_header,
+    parse_solitaire,
+    resolve_solitaire_action,
+)
+
+
+def candidate(uid, master_id, text):
+    return SolitaireCandidate(
+        slave_message_id=uid,
+        canonical_master_msg_id=master_id,
+        editable_master_msg_id=master_id,
+        text=text,
+    )
+
+
+def solitaire(*items, header="#接龙", note="下午5.30左右到"):
+    lines = [header, note, ""]
+    lines.extend(f"{i}. {item}" for i, item in enumerate(items, start=1))
+    return "\n".join(lines)
+
+
+def test_solitaire_header_must_be_first_non_empty_line():
+    assert has_solitaire_header("\n#接龙\n1. A")
+    assert has_solitaire_header("#接龍\n1. A")
+    assert not has_solitaire_header("hello\n#接龙\n1. A")
+    assert not has_solitaire_header("我们来 #接龙 吧\n1. A")
+
+
+def test_parse_wechat_solitaire_format():
+    parsed = parse_solitaire(solitaire("A材料学院水果美食团购", "abc 火龙果4个"))
+
+    assert parsed is not None
+    assert parsed.layout == "."
+    assert [i.index for i in parsed.items] == [1, 2]
+    assert parsed.items[0].content == "A材料学院水果美食团购"
+
+
+def test_parse_rejects_non_continuous_indices():
+    assert parse_solitaire("#接龙\n\n1. A\n3. C") is None
+
+
+def test_continuation_edits_when_prefix_is_inherited():
+    old = solitaire("A", "B", "C")
+    new = solitaire("A", "B", "C", "D")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "EDIT"
+    assert plan.canonical_master_msg_id == "1.10"
+    assert plan.reason == "continuation"
+
+
+def test_short_continuation_rejects_prefix_change():
+    old = solitaire("A", "B", "C")
+    new = solitaire("A", "B edited", "C", "D")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "SEND"
+
+
+def test_long_continuation_allows_one_prefix_change():
+    old = solitaire("A", "B", "C", "D", "E")
+    new = solitaire("A", "B edited", "C", "D", "E", "F")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "EDIT"
+
+
+def test_correction_allows_two_item_changes_for_long_solitaire():
+    old = solitaire("A", "B", "C", "D", "E", "F")
+    new = solitaire("A", "B edited", "C", "D edited", "E", "F")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "EDIT"
+    assert plan.reason == "correction"
+
+
+def test_short_correction_is_rejected():
+    old = solitaire("A", "B", "C", "D")
+    new = solitaire("A", "B edited", "C", "D")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "SEND"
+
+
+def test_single_deletion_edits_when_remaining_items_match():
+    old = solitaire("茄子QieZhi", "茄子QieZhi 2", "估计", "66")
+    new = solitaire("茄子QieZhi", "估计", "66")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "EDIT"
+    assert plan.reason == "deletion"
+
+
+def test_deletion_plus_item_change_is_rejected():
+    old = solitaire("A", "B", "C", "D")
+    new = solitaire("A", "C edited", "D")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "SEND"
+
+
+def test_item_spacing_and_punctuation_changes_count_as_edits():
+    old = solitaire("A", "西瓜果切2盒，西北", "C", "D", "E")
+    new = solitaire("A", "西瓜果切 2盒 西北", "C", "D", "E")
+
+    plan = resolve_solitaire_action(new, "new", [candidate("old", "1.10", old)])
+
+    assert plan.action_type == "EDIT"
+    assert plan.reason == "correction"
+
+
+def test_ambiguous_candidates_fall_back_to_send():
+    old = solitaire("A", "B", "C")
+    new = solitaire("A", "B", "C", "D")
+
+    plan = resolve_solitaire_action(
+        new,
+        "new",
+        [candidate("old-a", "1.10", old), candidate("old-b", "1.11", old)],
+    )
+
+    assert plan.action_type == "SEND"
+    assert plan.reason == "ambiguous_match"
+
+
+def test_command_appends_to_base_candidate():
+    base = solitaire("A", "B")
+
+    plan = resolve_solitaire_action("cmd 张三", "new", [candidate("old", "1.10", base)], command="cmd")
+
+    assert plan.action_type == "EDIT"
+    assert plan.replacement_text == base + "\n3. 张三"
+
+
+def test_command_without_candidate_is_dropped():
+    plan = resolve_solitaire_action("cmd 张三", "new", [], command="cmd")
+
+    assert plan.action_type == "DROP"
+
+
+def test_build_command_text_revalidates_result():
+    assert build_command_text(solitaire("A"), "张三") == solitaire("A") + "\n2. 张三"
+    assert build_command_text("not solitaire", "张三") is None
+    assert build_command_text(solitaire("A"), "   ") is None


### PR DESCRIPTION
This PR introduces:
- A new \	opic_title\ property in the chat model to clean up emoji prefixes for forum topic names in Telegram topic groups.
- Updates to \chat_binding\ to use \	opic_title\ instead of \chat_title\ for topic groups.
- A fix to the SQLite and PostgreSQL database initialization sequence to ensure migrations run sequentially and successfully.