### PR TITLE
Support remote image URLs from slave channels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -826,6 +826,11 @@ Development notes (CI and tooling)
   ETM can copy files into a shared directory derived from ``api_base_file_url``
   (when it is a ``file://`` URL) for better container/shared-filesystem
   compatibility.
+- **Remote image URLs from slave channels**: for Telegram-specific delivery,
+  slave channels may set ``msg.vendor_specific["blueset.telegram.image_url"]``
+  on ``MsgType.Image`` messages to an HTTP(S) image URL. ETM will pass the URL
+  to Telegram for server-side download instead of requiring ``msg.file`` and
+  ``msg.path``.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -830,7 +830,9 @@ Development notes (CI and tooling)
   slave channels may set ``msg.vendor_specific["blueset.telegram.image_url"]``
   on ``MsgType.Image`` messages to an HTTP(S) image URL. ETM will pass the URL
   to Telegram for server-side download instead of requiring ``msg.file`` and
-  ``msg.path``.
+  ``msg.path``. If Telegram cannot download the URL on first send, ETM sends
+  an editable placeholder media message so a later media edit can replace it
+  with a reachable URL.
 
 License
 -------

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -2472,8 +2472,12 @@ class TelegramBotManager(LocaleMixin):
     def _detect_empty_file(self, file, chat, caption, prefix, suffix, message_thread_id=None):
         empty = True
         if isinstance(file, str):
-            stat_path = url2pathname(urlparse(file).path) if file.startswith('file://') else file
-            empty = os.stat(stat_path).st_size == 0
+            parsed = urlparse(file)
+            if parsed.scheme in {'http', 'https'}:
+                empty = False
+            else:
+                stat_path = url2pathname(parsed.path) if parsed.scheme == 'file' else file
+                empty = os.stat(stat_path).st_size == 0
         elif hasattr(file, "seekable"):
             try:
                 if hasattr(file, 'closed') and file.closed:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -2215,9 +2215,12 @@ class TelegramBotManager(LocaleMixin):
         Returns:
             telegram.Message
         """
+        fallback_to_document = kwargs.pop('_fallback_to_document', True)
         try:
             return self._active_bot.send_photo(*args, **kwargs)
         except telegram.error.BadRequest:
+            if not fallback_to_document:
+                raise
             return self._active_bot.send_document(*args, **kwargs)
 
     @Decorators.skip_on_rate_limit

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -660,6 +660,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
+                                           _fallback_to_document=False,
                                            _send_mode="blocking")
             except telegram.error.BadRequest as e:
                 self.logger.warning('[%s] Failed to send remote image URL, sending editable placeholder. Reason: %s',

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -50,6 +50,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
     REACTION_DB_WAIT_TIMEOUT = 2.0
     REACTION_DB_WAIT_INTERVAL = 0.05
+    REMOTE_IMAGE_URL_VENDOR_KEY = "blueset.telegram.image_url"
 
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
@@ -381,6 +382,26 @@ class SlaveMessageProcessor(LocaleMixin):
             return 'blocking'
         return 'eventual'
 
+    @classmethod
+    def _remote_image_url(cls, msg: Message) -> Optional[str]:
+        url = (msg.vendor_specific or {}).get(cls.REMOTE_IMAGE_URL_VENDOR_KEY)
+        if not isinstance(url, str):
+            return None
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            return url
+        return None
+
+    @staticmethod
+    def _remote_image_filename(msg: Message, remote_image_url: str) -> str:
+        if msg.filename:
+            return msg.filename
+        parsed = urllib.parse.urlparse(remote_image_url)
+        parsed_path = parsed.path
+        if parsed.params:
+            parsed_path = f"{parsed_path};{parsed.params}"
+        return urllib.parse.unquote(os.path.basename(parsed_path)) or "image"
+
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
                            thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
                            old_msg_id: Optional[OldMsgID] = None,
@@ -489,7 +510,9 @@ class SlaveMessageProcessor(LocaleMixin):
                             target_msg_id: Optional[TelegramMessageID] = None,
                             reply_markup: Optional[ReplyMarkup] = None,
                             silent: bool = False) -> telegram.Message:
-        assert msg.file
+        remote_image_url = self._remote_image_url(msg)
+        if not remote_image_url:
+            assert msg.file
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_PHOTO, message_thread_id=thread_id)
         self.logger.debug("[%s] Message is of %s type; Path: %s; MIME: %s", msg.uid, msg.type, msg.path, msg.mime)
         if msg.path:
@@ -507,6 +530,51 @@ class SlaveMessageProcessor(LocaleMixin):
                 text = ""
         else:
             text = ""
+
+        if remote_image_url:
+            if old_msg_id:
+                try:
+                    edit_kwargs = self._get_edit_kwargs(msg)
+                    if msg.edit_media:
+                        res = self.bot.edit_message_media(
+                            chat_id=old_msg_id[0],
+                            message_id=old_msg_id[1],
+                            media=InputMediaPhoto(remote_image_url),
+                            reply_markup=reply_markup,
+                            **edit_kwargs
+                        )
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text,
+                                                         parse_mode="HTML", **edit_kwargs)
+                except telegram.error.BadRequest as e:
+                    self.logger.warning("[%s] Failed to edit remote image/caption (BadRequest: %s). "
+                                        "Sending new message instead.", msg.uid, e)
+                    if old_msg_id[0] == tg_dest:
+                        target_msg_id = target_msg_id or old_msg_id[1]
+
+            try:
+                return self.bot.send_photo(tg_dest, remote_image_url, prefix=msg_template, suffix=reactions,
+                                           caption=text, parse_mode="HTML",
+                                           reply_to_message_id=target_msg_id,
+                                           message_thread_id=thread_id,
+                                           reply_markup=reply_markup,
+                                           disable_notification=silent,
+                                           _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+            except telegram.error.BadRequest as e:
+                self.logger.error('[%s] Failed to send remote image, sending as document. Reason: %s',
+                                  msg.uid, e)
+                file_name = self._remote_image_filename(msg, remote_image_url).replace(';', ' ')
+                return self.bot.send_document(tg_dest, remote_image_url, prefix=msg_template, suffix=reactions,
+                                              caption=text, parse_mode="HTML", filename=file_name,
+                                              reply_to_message_id=target_msg_id,
+                                              message_thread_id=thread_id,
+                                              reply_markup=reply_markup,
+                                              disable_notification=silent,
+                                              _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+
         try:
             # Avoid Telegram compression of pictures by sending high definition image messages as files
             # Code adopted from wolfsilver's fork:
@@ -798,7 +866,10 @@ class SlaveMessageProcessor(LocaleMixin):
                            silent: bool = False) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_DOCUMENT, message_thread_id=thread_id)
 
-        if msg.filename is None and msg.path is not None:
+        remote_image_url = self._remote_image_url(msg) if msg.type == MsgType.Image else None
+        if remote_image_url:
+            file_name = self._remote_image_filename(msg, remote_image_url)
+        elif msg.filename is None and msg.path is not None:
             file_name = os.path.basename(msg.path)
         else:
             assert msg.filename is not None  # mypy compliance
@@ -823,6 +894,31 @@ class SlaveMessageProcessor(LocaleMixin):
             text = ""
 
         try:
+            if remote_image_url:
+                if old_msg_id:
+                    edit_kwargs = self._get_edit_kwargs(msg)
+                    if msg.edit_media:
+                        res = self.bot.edit_message_media(
+                            chat_id=old_msg_id[0],
+                            message_id=old_msg_id[1],
+                            media=InputMediaDocument(remote_image_url),
+                            **edit_kwargs
+                        )
+                        if not text:
+                            return res
+                    return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
+                                                         reply_markup=reply_markup,
+                                                         prefix=msg_template, suffix=reactions, caption=text,
+                                                         parse_mode="HTML", **edit_kwargs)
+                return self.bot.send_document(tg_dest, remote_image_url,
+                                              prefix=msg_template, suffix=reactions,
+                                              caption=text, parse_mode="HTML", filename=file_name,
+                                              reply_to_message_id=target_msg_id,
+                                              message_thread_id=thread_id,
+                                              reply_markup=reply_markup,
+                                              disable_notification=silent,
+                                              _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+
             file_too_large = self.check_file_size(msg.file)
             edit_media = msg.edit_media
             if file_too_large:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -611,6 +611,8 @@ class SlaveMessageProcessor(LocaleMixin):
                 return self._send_remote_image_placeholder(tg_dest, thread_id, msg_template, reactions, text,
                                                            target_msg_id, reply_markup, silent)
 
+        msg_file = msg.file
+        assert msg_file is not None
         try:
             # Avoid Telegram compression of pictures by sending high definition image messages as files
             # Code adopted from wolfsilver's fork:
@@ -646,7 +648,7 @@ class SlaveMessageProcessor(LocaleMixin):
             except IOError:  # Ignore when the image cannot be properly identified.
                 send_as_file = False
 
-            file_too_large = self.check_file_size(msg.file)
+            file_too_large = self.check_file_size(msg_file)
             edit_media = msg.edit_media
             if file_too_large:
                 if old_msg_id:
@@ -667,7 +669,7 @@ class SlaveMessageProcessor(LocaleMixin):
                     if edit_media:
                         assert msg.path
                         media: InputMedia
-                        file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                        file = self.process_file_obj(msg_file, msg.path, msg.filename)
                         if send_as_file:
                             media = InputMediaDocument(file)
                         else:
@@ -684,11 +686,11 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.warning("[%s] Failed to edit media/caption (BadRequest: %s). Sending new message instead.", msg.uid, e)
                     if old_msg_id[0] == tg_dest:
                         target_msg_id = target_msg_id or old_msg_id[1]
-                    msg.file.seek(0)
+                    msg_file.seek(0)
 
             if send_as_file:
                 assert msg.path
-                file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                file = self.process_file_obj(msg_file, msg.path, msg.filename)
                 return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
                                               caption=text, parse_mode="HTML", filename=msg.filename,
                                               reply_to_message_id=target_msg_id,
@@ -699,7 +701,7 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 try:
                     assert msg.path
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                    file = self.process_file_obj(msg_file, msg.path, msg.filename)
                     return self.bot.send_photo(tg_dest, file, prefix=msg_template, suffix=reactions,
                                                caption=text, parse_mode="HTML",
                                                reply_to_message_id=target_msg_id,
@@ -711,8 +713,8 @@ class SlaveMessageProcessor(LocaleMixin):
                     self.logger.error('[%s] Failed to send it as image, sending as document. Reason: %s',
                                       msg.uid, e)
                     assert msg.path
-                    msg.file.seek(0)
-                    file = self.process_file_obj(msg.file, msg.path, msg.filename)
+                    msg_file.seek(0)
+                    file = self.process_file_obj(msg_file, msg.path, msg.filename)
                     return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
                                                   caption=text, parse_mode="HTML", filename=msg.filename,
                                                   reply_to_message_id=target_msg_id,
@@ -721,8 +723,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   disable_notification=silent,
                                                   _send_mode=self._send_mode(msg, old_msg_id, thread_id))
         finally:
-            if msg.file:
-                msg.file.close()
+            msg_file.close()
             self._cleanup_pending_local_api_files()
 
     def slave_message_animation(self, msg: Message, tg_dest: TelegramChatID,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -402,6 +402,48 @@ class SlaveMessageProcessor(LocaleMixin):
             parsed_path = f"{parsed_path};{parsed.params}"
         return urllib.parse.unquote(os.path.basename(parsed_path)) or "image"
 
+    def _remote_image_placeholder(self) -> IO[bytes]:
+        placeholder = tempfile.NamedTemporaryFile(
+            suffix=".png",
+            dir=utils.ExperimentalFlagsManager.get_temp_dir(self.channel),
+        )
+        Image.new("RGB", (64, 64), (245, 245, 245)).save(placeholder, "PNG")
+        placeholder.seek(0)
+        return placeholder
+
+    def _send_remote_image_placeholder(self, tg_dest: TelegramChatID,
+                                       thread_id: Optional[TelegramTopicID],
+                                       msg_template: str,
+                                       reactions: str,
+                                       text: str,
+                                       target_msg_id: Optional[TelegramMessageID],
+                                       reply_markup: Optional[ReplyMarkup],
+                                       silent: bool,
+                                       *,
+                                       as_document: bool = False) -> telegram.Message:
+        placeholder = self._remote_image_placeholder()
+        filename = "remote-image-placeholder.png"
+        try:
+            file = self.process_file_obj(placeholder, placeholder.name, filename)
+            if as_document:
+                return self.bot.send_document(tg_dest, file, prefix=msg_template, suffix=reactions,
+                                              caption=text, parse_mode="HTML", filename=filename,
+                                              reply_to_message_id=target_msg_id,
+                                              message_thread_id=thread_id,
+                                              reply_markup=reply_markup,
+                                              disable_notification=silent,
+                                              _send_mode="blocking")
+            return self.bot.send_photo(tg_dest, file, prefix=msg_template, suffix=reactions,
+                                       caption=text, parse_mode="HTML",
+                                       reply_to_message_id=target_msg_id,
+                                       message_thread_id=thread_id,
+                                       reply_markup=reply_markup,
+                                       disable_notification=silent,
+                                       _send_mode="blocking")
+        finally:
+            placeholder.close()
+            self._cleanup_pending_local_api_files()
+
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
                            thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
                            old_msg_id: Optional[OldMsgID] = None,
@@ -562,18 +604,12 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                           _send_mode="blocking")
             except telegram.error.BadRequest as e:
-                self.logger.error('[%s] Failed to send remote image, sending as document. Reason: %s',
-                                  msg.uid, e)
-                file_name = self._remote_image_filename(msg, remote_image_url).replace(';', ' ')
-                return self.bot.send_document(tg_dest, remote_image_url, prefix=msg_template, suffix=reactions,
-                                              caption=text, parse_mode="HTML", filename=file_name,
-                                              reply_to_message_id=target_msg_id,
-                                              message_thread_id=thread_id,
-                                              reply_markup=reply_markup,
-                                              disable_notification=silent,
-                                              _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                self.logger.warning('[%s] Failed to send remote image URL, sending editable placeholder. Reason: %s',
+                                    msg.uid, e)
+                return self._send_remote_image_placeholder(tg_dest, thread_id, msg_template, reactions, text,
+                                                           target_msg_id, reply_markup, silent)
 
         try:
             # Avoid Telegram compression of pictures by sending high definition image messages as files
@@ -910,14 +946,20 @@ class SlaveMessageProcessor(LocaleMixin):
                                                          reply_markup=reply_markup,
                                                          prefix=msg_template, suffix=reactions, caption=text,
                                                          parse_mode="HTML", **edit_kwargs)
-                return self.bot.send_document(tg_dest, remote_image_url,
-                                              prefix=msg_template, suffix=reactions,
-                                              caption=text, parse_mode="HTML", filename=file_name,
-                                              reply_to_message_id=target_msg_id,
-                                              message_thread_id=thread_id,
-                                              reply_markup=reply_markup,
-                                              disable_notification=silent,
-                                              _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                try:
+                    return self.bot.send_document(tg_dest, remote_image_url,
+                                                  prefix=msg_template, suffix=reactions,
+                                                  caption=text, parse_mode="HTML", filename=file_name,
+                                                  reply_to_message_id=target_msg_id,
+                                                  message_thread_id=thread_id,
+                                                  reply_markup=reply_markup,
+                                                  disable_notification=silent,
+                                                  _send_mode="blocking")
+                except telegram.error.BadRequest as e:
+                    self.logger.warning('[%s] Failed to send remote image URL as document, sending editable placeholder. '
+                                        'Reason: %s', msg.uid, e)
+                    return self._send_remote_image_placeholder(tg_dest, thread_id, msg_template, reactions, text,
+                                                               target_msg_id, reply_markup, silent, as_document=True)
 
             file_too_large = self.check_file_size(msg.file)
             edit_media = msg.edit_media

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -117,6 +117,22 @@ def test_malformed_html_caption(channel, bot_admin, image):
     )
 
 
+def test_empty_file_detection_skips_http_url():
+    manager = SimpleNamespace(send_message=Mock(), _=lambda text: text)
+
+    result = TelegramBotManager._detect_empty_file(
+        manager,
+        "https://example.com/images/photo.jpg",
+        100,
+        "",
+        "",
+        "",
+    )
+
+    assert result is None
+    manager.send_message.assert_not_called()
+
+
 def test_rate_limit_decorator_forced_routes_to_sender_bot():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     aux_bot = SimpleNamespace(bot=object(), bot_id=777, disabled=False, reserve_slot=Mock(return_value=0.0))

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -133,6 +133,21 @@ def test_empty_file_detection_skips_http_url():
     manager.send_message.assert_not_called()
 
 
+def test_send_photo_can_disable_document_fallback_for_remote_url():
+    manager = _make_lightweight_bot_manager()
+    manager._bot.send_photo.side_effect = telegram.error.BadRequest("failed to get HTTP URL content")
+
+    with pytest.raises(telegram.error.BadRequest):
+        manager.send_photo(
+            123,
+            "https://example.com/images/photo.jpg",
+            caption="caption",
+            _fallback_to_document=False,
+        )
+
+    manager._bot.send_document.assert_not_called()
+
+
 def test_rate_limit_decorator_forced_routes_to_sender_bot():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     aux_bot = SimpleNamespace(bot=object(), bot_id=777, disabled=False, reserve_slot=Mock(return_value=0.0))

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -323,6 +323,7 @@ def test_slave_message_image_sends_remote_image_url():
         message_thread_id=200,
         reply_markup=None,
         disable_notification=True,
+        _fallback_to_document=False,
         _send_mode="blocking",
     )
     processor.bot.send_document.assert_not_called()
@@ -342,6 +343,7 @@ def test_slave_message_image_sends_placeholder_when_remote_image_url_fails():
     assert processor.bot.send_photo.call_count == 2
     first_call, second_call = processor.bot.send_photo.call_args_list
     assert first_call.args[1] == REMOTE_IMAGE_URL
+    assert first_call.kwargs["_fallback_to_document"] is False
     assert hasattr(second_call.args[1], "read")
     assert second_call.kwargs["caption"] == "remote &lt;image&gt;"
     assert second_call.kwargs["_send_mode"] == "blocking"

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,13 +1,15 @@
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton, InputMediaPhoto
 from telegram.error import BadRequest
+from typing import cast
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 from ehforwarderbot import Message, Chat
 from ehforwarderbot.constants import MsgType
 from ehforwarderbot.chat import ChatMember
-from ehforwarderbot.types import ReactionName
+from ehforwarderbot.types import MessageID, ReactionName
+from efb_telegram_master import TelegramChannel
 from efb_telegram_master.constants import Emoji
 from efb_telegram_master.slave_message import SlaveMessageProcessor
 
@@ -74,7 +76,7 @@ REMOTE_IMAGE_URL = "https://example.com/images/photo.jpg"
 
 def build_remote_image_message(remote_image_url: str = REMOTE_IMAGE_URL) -> Message:
     message = Message()
-    message.uid = "__remote_image_msg__"
+    message.uid = MessageID("__remote_image_msg__")
     message.type = MsgType.Image
     message.text = "remote <image>"
     message.file = None
@@ -96,7 +98,7 @@ def build_slave_message_processor() -> SlaveMessageProcessor:
     processor.bot._cleanup_tls = SimpleNamespace(pending_cleanup=[])
     processor.flag = Mock(side_effect=lambda flag_name: "emoji" if flag_name == "default_media_prompt" else False)
     processor.logger = Mock()
-    processor.channel = SimpleNamespace(config={"admins": [1]}, flag=processor.flag)
+    processor.channel = cast(TelegramChannel, SimpleNamespace(config={"admins": [1]}, flag=processor.flag))
     return processor
 
 

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,5 +1,6 @@
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton, InputMediaPhoto
+from telegram.error import BadRequest
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -93,9 +94,9 @@ def build_slave_message_processor() -> SlaveMessageProcessor:
     processor = object.__new__(SlaveMessageProcessor)
     processor.bot = Mock()
     processor.bot._cleanup_tls = SimpleNamespace(pending_cleanup=[])
-    processor.flag = Mock(return_value="emoji")
+    processor.flag = Mock(side_effect=lambda flag_name: "emoji" if flag_name == "default_media_prompt" else False)
     processor.logger = Mock()
-    processor.channel = SimpleNamespace(config={"admins": [1]})
+    processor.channel = SimpleNamespace(config={"admins": [1]}, flag=processor.flag)
     return processor
 
 
@@ -243,8 +244,28 @@ def test_slave_message_image_sends_remote_image_url():
         message_thread_id=200,
         reply_markup=None,
         disable_notification=True,
-        _send_mode="eventual",
+        _send_mode="blocking",
     )
+    processor.bot.send_document.assert_not_called()
+
+
+def test_slave_message_image_sends_placeholder_when_remote_image_url_fails():
+    processor = build_slave_message_processor()
+    processor.bot.send_photo.side_effect = [
+        BadRequest("failed to get HTTP URL content"),
+        "__placeholder_message__",
+    ]
+    msg = build_remote_image_message()
+
+    result = processor.slave_message_image(msg, 100, None, "__template__", "__reactions__")
+
+    assert result == "__placeholder_message__"
+    assert processor.bot.send_photo.call_count == 2
+    first_call, second_call = processor.bot.send_photo.call_args_list
+    assert first_call.args[1] == REMOTE_IMAGE_URL
+    assert hasattr(second_call.args[1], "read")
+    assert second_call.kwargs["caption"] == "remote &lt;image&gt;"
+    assert second_call.kwargs["_send_mode"] == "blocking"
     processor.bot.send_document.assert_not_called()
 
 
@@ -288,8 +309,27 @@ def test_slave_message_file_sends_remote_image_url_as_document():
         message_thread_id=None,
         reply_markup=None,
         disable_notification=True,
-        _send_mode="eventual",
+        _send_mode="blocking",
     )
+
+
+def test_slave_message_file_sends_placeholder_when_remote_document_url_fails():
+    processor = build_slave_message_processor()
+    processor.bot.send_document.side_effect = [
+        BadRequest("failed to get HTTP URL content"),
+        "__placeholder_message__",
+    ]
+    msg = build_remote_image_message()
+
+    result = processor.slave_message_file(msg, 100, None, "__template__", "__reactions__")
+
+    assert result == "__placeholder_message__"
+    assert processor.bot.send_document.call_count == 2
+    first_call, second_call = processor.bot.send_document.call_args_list
+    assert first_call.args[1] == REMOTE_IMAGE_URL
+    assert hasattr(second_call.args[1], "read")
+    assert second_call.kwargs["filename"] == "remote-image-placeholder.png"
+    assert second_call.kwargs["_send_mode"] == "blocking"
 
 
 def test_reaction_target_prefers_primary_message_for_slave_origin_text():

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,5 +1,5 @@
 from pytest import fixture
-from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+from telegram import InlineKeyboardMarkup, InlineKeyboardButton, InputMediaPhoto
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -66,6 +66,37 @@ def build_dummy_message(chat: Chat, author: ChatMember) -> Message:
     message.chat = chat
     message.author = author
     return message
+
+
+REMOTE_IMAGE_URL = "https://example.com/images/photo.jpg"
+
+
+def build_remote_image_message(remote_image_url: str = REMOTE_IMAGE_URL) -> Message:
+    message = Message()
+    message.uid = "__remote_image_msg__"
+    message.type = MsgType.Image
+    message.text = "remote <image>"
+    message.file = None
+    message.path = None
+    message.mime = None
+    message.filename = None
+    message.edit_media = False
+    message.commands = None
+    message.substitutions = None
+    message.vendor_specific = {
+        SlaveMessageProcessor.REMOTE_IMAGE_URL_VENDOR_KEY: remote_image_url,
+    }
+    return message
+
+
+def build_slave_message_processor() -> SlaveMessageProcessor:
+    processor = object.__new__(SlaveMessageProcessor)
+    processor.bot = Mock()
+    processor.bot._cleanup_tls = SimpleNamespace(pending_cleanup=[])
+    processor.flag = Mock(return_value="emoji")
+    processor.logger = Mock()
+    processor.channel = SimpleNamespace(config={"admins": [1]})
+    return processor
 
 
 def test_slave_message_generate_common_private(generate_message_template, private):
@@ -188,6 +219,77 @@ def test_build_inline_keyboard_existing_buttons(build_inline_keyboard, private):
     assert "__text__" in seq
     assert "__template__" in seq
     assert "__reactions__" in seq
+
+
+def test_slave_message_image_sends_remote_image_url():
+    processor = build_slave_message_processor()
+    processor.bot.send_photo.return_value = "__telegram_message__"
+    msg = build_remote_image_message()
+
+    result = processor.slave_message_image(
+        msg, 100, 200, "__template__", "__reactions__",
+        target_msg_id=300, silent=True
+    )
+
+    assert result == "__telegram_message__"
+    processor.bot.send_photo.assert_called_once_with(
+        100,
+        REMOTE_IMAGE_URL,
+        prefix="__template__",
+        suffix="__reactions__",
+        caption="remote &lt;image&gt;",
+        parse_mode="HTML",
+        reply_to_message_id=300,
+        message_thread_id=200,
+        reply_markup=None,
+        disable_notification=True,
+        _send_mode="eventual",
+    )
+    processor.bot.send_document.assert_not_called()
+
+
+def test_slave_message_image_edits_remote_image_url_media():
+    processor = build_slave_message_processor()
+    processor.bot.edit_message_media.return_value = "__edited_message__"
+    msg = build_remote_image_message()
+    msg.text = ""
+    msg.edit_media = True
+
+    result = processor.slave_message_image(msg, 100, None, "", "", old_msg_id=(100, 10))
+
+    assert result == "__edited_message__"
+    media = processor.bot.edit_message_media.call_args.kwargs["media"]
+    assert isinstance(media, InputMediaPhoto)
+    assert media.media == REMOTE_IMAGE_URL
+    processor.bot.edit_message_caption.assert_not_called()
+
+
+def test_slave_message_file_sends_remote_image_url_as_document():
+    remote_image_url = "https://example.com/images/photo;1.jpg"
+    processor = build_slave_message_processor()
+    processor.bot.send_document.return_value = "__telegram_message__"
+    msg = build_remote_image_message(remote_image_url)
+
+    result = processor.slave_message_file(
+        msg, 100, None, "__template__", "__reactions__",
+        target_msg_id=300, silent=True
+    )
+
+    assert result == "__telegram_message__"
+    processor.bot.send_document.assert_called_once_with(
+        100,
+        remote_image_url,
+        prefix="__template__",
+        suffix="__reactions__",
+        caption="remote &lt;image&gt;",
+        parse_mode="HTML",
+        filename="photo 1.jpg",
+        reply_to_message_id=300,
+        message_thread_id=None,
+        reply_markup=None,
+        disable_notification=True,
+        _send_mode="eventual",
+    )
 
 
 def test_reaction_target_prefers_primary_message_for_slave_origin_text():


### PR DESCRIPTION
## Summary

- support Telegram-specific remote image URLs via `msg.vendor_specific["blueset.telegram.image_url"]` on `MsgType.Image`
- send URL-backed images through `send_photo`, edit them with `InputMediaPhoto`, and respect `send_image_as_file` by sending them as documents
- send an editable placeholder media message when Telegram cannot download the remote URL on first send, so a later media edit can replace it
- skip local empty-file `stat()` checks for HTTP(S) file arguments
- document the extension key for slave channel authors

## Tests

- `.venv/bin/python -m pytest -q tests/unit/test_slave_message.py::test_slave_message_image_sends_remote_image_url tests/unit/test_slave_message.py::test_slave_message_image_sends_placeholder_when_remote_image_url_fails tests/unit/test_slave_message.py::test_slave_message_image_edits_remote_image_url_media tests/unit/test_slave_message.py::test_slave_message_file_sends_remote_image_url_as_document tests/unit/test_slave_message.py::test_slave_message_file_sends_placeholder_when_remote_document_url_fails tests/unit/test_bot_manager.py::test_empty_file_detection_skips_http_url`
- `.venv/bin/python -m mypy efb_telegram_master tests`
- `.venv/bin/python -m py_compile efb_telegram_master/slave_message.py efb_telegram_master/bot_manager.py tests/unit/test_slave_message.py tests/unit/test_bot_manager.py`
- `git diff --check`
