### PR TITLE
Deduplicate queued slave messages

### DIFF
--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -1591,6 +1591,8 @@ class TelegramBotManager(LocaleMixin):
                     self._handle_delayed_database_update(
                         task.task_id, result, sender_bot_id=sender_bot_id,
                     )
+                else:
+                    TelegramBotManager._drop_delayed_database_update(self, task.task_id)
 
             except telegram.error.RetryAfter as e:
                 should_cleanup = False
@@ -1620,6 +1622,7 @@ class TelegramBotManager(LocaleMixin):
                     task.kwargs.get("message_thread_id"),
                     getattr(task.function, "__name__", repr(task.function)),
                 )
+                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
 
             except (telegram.error.TimedOut, telegram.error.NetworkError) as e:
                 should_cleanup = False
@@ -1643,9 +1646,11 @@ class TelegramBotManager(LocaleMixin):
                         self._requeue_delayed_task(task, 0.0)
                         continue
                 self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
+                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
 
             except Exception as e:
                 self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
+                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
 
             finally:
                 if should_cleanup:
@@ -1656,6 +1661,32 @@ class TelegramBotManager(LocaleMixin):
                         except OSError as e:
                             self.logger.warning("Failed to clean up temp file %s: %s", path, e)
 
+    def _run_database_update_callback(self, on_complete: Optional[Callable[[], None]]):
+        if on_complete is None:
+            return
+        try:
+            on_complete()
+        except Exception as e:
+            self.logger.warning("Database update completion callback failed: %s", e)
+
+    @staticmethod
+    def _delayed_log_callback(entry: Optional[tuple]) -> Optional[Callable[[], None]]:
+        if entry is not None and len(entry) >= 4:
+            return entry[3]
+        return None
+
+    def _drop_delayed_database_update(self, task_id: str):
+        """Release bookkeeping for a delayed task that will not produce a Telegram message."""
+        if not hasattr(self, '_pending_logs_lock'):
+            return
+        pending_update = None
+        with self._pending_logs_lock:
+            pending_update = self._pending_delayed_logs.pop(task_id, None)
+            self._completed_delayed_results.pop(task_id, None)
+        TelegramBotManager._run_database_update_callback(
+            self, TelegramBotManager._delayed_log_callback(pending_update)
+        )
+
     def _finalize_delayed_database_update(
         self,
         etm_msg,
@@ -1663,6 +1694,7 @@ class TelegramBotManager(LocaleMixin):
         real_tg_msg: TelegramMessage,
         *,
         sender_bot_id: Optional[str] = None,
+        on_complete: Optional[Callable[[], None]] = None,
     ):
         """Write the send result to the database.
 
@@ -1679,6 +1711,7 @@ class TelegramBotManager(LocaleMixin):
                 old_msg_id,
                 sender_bot_id=sender_bot_id,
             )
+            TelegramBotManager._run_database_update_callback(self, on_complete)
         except Exception as e:
             self.logger.warning(
                 "DB write failed for tg_msg %s, queuing for retry: %s",
@@ -1686,15 +1719,18 @@ class TelegramBotManager(LocaleMixin):
                 e,
             )
             TelegramBotManager._enqueue_db_retry(
-                self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id
+                self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, on_complete=on_complete
             )
 
-    def _enqueue_db_retry(self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt: int = 0):
+    def _enqueue_db_retry(self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
+                          attempt: int = 0,
+                          on_complete: Optional[Callable[[], None]] = None):
         """Push a failed DB write into the retry queue with exponential back-off."""
         next_retry_at = time.time() + min(2 ** attempt, 30)  # cap at 30 s
         with self._db_retry_lock:
             self._db_retry_queue.append(
-                (etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt + 1, next_retry_at)
+                (etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
+                 attempt + 1, next_retry_at, on_complete)
             )
 
     def _process_db_retry_queue(self):
@@ -1709,9 +1745,17 @@ class TelegramBotManager(LocaleMixin):
             items = self._db_retry_queue[:]
             self._db_retry_queue.clear()
 
-        for etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at in items:
+        for item in items:
+            if len(item) >= 7:
+                etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at, on_complete = item
+            else:
+                etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at = item
+                on_complete = None
             if current_time < next_retry_at:
-                still_pending.append((etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at))
+                still_pending.append(
+                    (etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
+                     attempt, next_retry_at, on_complete)
+                )
                 continue
             try:
                 self.channel.db.add_or_update_message_log(
@@ -1725,6 +1769,7 @@ class TelegramBotManager(LocaleMixin):
                     getattr(real_tg_msg, 'message_id', '?'),
                     attempt,
                 )
+                TelegramBotManager._run_database_update_callback(self, on_complete)
             except Exception as e:
                 if attempt >= self._db_max_retries:
                     self.logger.error(
@@ -1741,7 +1786,7 @@ class TelegramBotManager(LocaleMixin):
                         e,
                     )
                     TelegramBotManager._enqueue_db_retry(
-                        self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt
+                        self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, on_complete=on_complete
                     )
 
         if still_pending:
@@ -1757,6 +1802,10 @@ class TelegramBotManager(LocaleMixin):
                 if len(entry) >= 3 and entry[2] < cutoff
             ]
             for tid in stale_logs:
+                TelegramBotManager._run_database_update_callback(
+                    self,
+                    TelegramBotManager._delayed_log_callback(self._pending_delayed_logs.get(tid)),
+                )
                 del self._pending_delayed_logs[tid]
                 self.logger.warning("Rendezvous TTL: dropped stale pending log for task %s", tid)
 
@@ -1775,17 +1824,22 @@ class TelegramBotManager(LocaleMixin):
         old_msg_id=None,
         *,
         sender_bot_id: Optional[str] = None,
+        on_complete: Optional[Callable[[], None]] = None,
     ):
         """Fire-and-forget database write, usable from both blocking and eventual paths.
 
         Failures are caught and routed to the retry queue — callers should
         NEVER re-send to Telegram on a DB-write error.
         """
-        self._finalize_delayed_database_update(
-            etm_msg, old_msg_id, real_tg_msg, sender_bot_id=sender_bot_id,
+        TelegramBotManager._finalize_delayed_database_update(
+            self,
+            etm_msg, old_msg_id, real_tg_msg,
+            sender_bot_id=sender_bot_id,
+            on_complete=on_complete,
         )
 
-    def register_delayed_database_update(self, task_id: str, etm_msg, old_msg_id=None):
+    def register_delayed_database_update(self, task_id: str, etm_msg, old_msg_id=None,
+                                         on_complete: Optional[Callable[[], None]] = None):
         """
         Register a pending database update for a delayed task.
 
@@ -1798,17 +1852,22 @@ class TelegramBotManager(LocaleMixin):
         with self._pending_logs_lock:
             completed_result = self._completed_delayed_results.pop(task_id, None)
             if completed_result is None:
-                self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time())
+                if on_complete is not None:
+                    self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time(), on_complete)
+                else:
+                    self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time())
                 self.logger.debug(f"Registered delayed database update for task {task_id}")
                 return
 
         real_tg_msg, sender_bot_id = completed_result[0], completed_result[1]
         self.logger.debug(f"Finalizing already-completed delayed task {task_id}")
-        self._finalize_delayed_database_update(
+        TelegramBotManager._finalize_delayed_database_update(
+            self,
             etm_msg,
             old_msg_id,
             real_tg_msg,
             sender_bot_id=sender_bot_id,
+            on_complete=on_complete,
         )
 
     def _handle_delayed_database_update(
@@ -1834,11 +1893,14 @@ class TelegramBotManager(LocaleMixin):
                 return
 
         etm_msg, old_msg_id = pending_update[0], pending_update[1]
-        self._finalize_delayed_database_update(
+        on_complete = TelegramBotManager._delayed_log_callback(pending_update)
+        TelegramBotManager._finalize_delayed_database_update(
+            self,
             etm_msg,
             old_msg_id,
             real_tg_msg,
             sender_bot_id=sender_bot_id,
+            on_complete=on_complete,
         )
         self.logger.debug(f"Updated database with real message for delayed task {task_id}")
 

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -52,6 +52,7 @@ MAX_CALLBACK_QUERY_ANSWER_LENGTH = 200
 P = ParamSpec("P")
 T = TypeVar("T")
 BotMethod: TypeAlias = Callable[..., object]
+_DELAYED_DATABASE_UPDATE_DROPPED = object()
 
 
 class SyncBotProtocol(Protocol):
@@ -843,7 +844,7 @@ class TelegramBotManager(LocaleMixin):
         # Rendezvous dicts for delayed DB updates — with timestamps for TTL cleanup
         # task_id -> (etm_msg, old_msg_id, registered_at)
         self._pending_delayed_logs: dict[str, tuple] = {}
-        # task_id -> (real_tg_msg, sender_bot_id, completed_at)
+        # task_id -> (real_tg_msg, sender_bot_id, completed_at), or a dropped marker
         self._completed_delayed_results: dict[str, tuple] = {}
         self._pending_logs_lock = threading.Lock()
         self._rendezvous_ttl = 600.0          # 10 minutes
@@ -1682,7 +1683,12 @@ class TelegramBotManager(LocaleMixin):
         pending_update = None
         with self._pending_logs_lock:
             pending_update = self._pending_delayed_logs.pop(task_id, None)
-            self._completed_delayed_results.pop(task_id, None)
+            if pending_update is None:
+                self._completed_delayed_results[task_id] = (
+                    _DELAYED_DATABASE_UPDATE_DROPPED, None, time.time()
+                )
+            else:
+                self._completed_delayed_results.pop(task_id, None)
         TelegramBotManager._run_database_update_callback(
             self, TelegramBotManager._delayed_log_callback(pending_update)
         )
@@ -1858,6 +1864,11 @@ class TelegramBotManager(LocaleMixin):
                     self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time())
                 self.logger.debug(f"Registered delayed database update for task {task_id}")
                 return
+
+        if completed_result[0] is _DELAYED_DATABASE_UPDATE_DROPPED:
+            self.logger.debug("Delayed task %s was dropped before database registration", task_id)
+            TelegramBotManager._run_database_update_callback(self, on_complete)
+            return
 
         real_tg_msg, sender_bot_id = completed_result[0], completed_result[1]
         self.logger.debug(f"Finalizing already-completed delayed task {task_id}")

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -4,6 +4,7 @@ import html
 import itertools
 import logging
 import os
+import threading
 import tempfile
 import time
 import traceback
@@ -59,6 +60,27 @@ class SlaveMessageProcessor(LocaleMixin):
         self.db: 'DatabaseManager' = channel.db
         self.chat_dest_cache: ChatDestinationCache = channel.chat_dest_cache
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
+        self._pending_slave_messages: set[Tuple[str, str]] = set()
+        self._pending_slave_messages_lock = threading.Lock()
+
+    def _claim_pending_slave_message(self, key: Tuple[str, str]) -> bool:
+        with self._pending_slave_messages_lock:
+            if key in self._pending_slave_messages:
+                return False
+            self._pending_slave_messages.add(key)
+            return True
+
+    def _release_pending_slave_message(self, key: Optional[Tuple[str, str]]):
+        if key is None:
+            return
+        with self._pending_slave_messages_lock:
+            self._pending_slave_messages.discard(key)
+
+    @staticmethod
+    def _dedupe_key(msg: Message, slave_origin_uid: str) -> Optional[Tuple[str, str]]:
+        if msg.edit or msg.uid is None or msg.type == MsgType.Status:
+            return None
+        return slave_origin_uid, str(msg.uid)
 
     @staticmethod
     def _get_edit_kwargs(msg: Message):
@@ -100,19 +122,40 @@ class SlaveMessageProcessor(LocaleMixin):
         Args:
             msg (Message): The message.
         """
+        dedupe_key: Optional[Tuple[str, str]] = None
+        pending_claimed = False
         try:
             xid = msg.uid
             self.logger.debug("[%s] Slave message delivered to ETM.\n%s", xid, msg)
+
+            slave_origin_uid = utils.chat_id_to_str(chat=msg.chat)
+            dedupe_key = self._dedupe_key(msg, slave_origin_uid)
+            if dedupe_key is not None:
+                existing_msg = self.db.get_msg_log(slave_msg_id=msg.uid,
+                                                   slave_origin_uid=slave_origin_uid)
+                if existing_msg is not None:
+                    self.logger.info(
+                        "[%s] Duplicate slave message is already logged as Telegram message %s; skipping.",
+                        xid, existing_msg.master_msg_id,
+                    )
+                    return msg
+                if not self._claim_pending_slave_message(dedupe_key):
+                    self.logger.info("[%s] Duplicate slave message is already pending delivery; skipping.",
+                                     xid)
+                    return msg
+                pending_claimed = True
 
             msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(msg)
 
             silent = self.is_silent(msg)
             if silent is None:
                 self.logger.debug("[%s] Message is not delivered per silent settings.", xid)
+                self._release_pending_slave_message(dedupe_key)
                 return msg
 
             if tg_dest is None:
                 self.logger.debug("[%s] Sender of the message is muted.", xid)
+                self._release_pending_slave_message(dedupe_key)
                 return msg
 
             # When editing message
@@ -137,8 +180,11 @@ class SlaveMessageProcessor(LocaleMixin):
                 msg.vendor_specific = msg.vendor_specific or {}
                 msg.vendor_specific['_sender_bot_id'] = _edit_sender_bot_id
 
-            self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent)
+            self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent,
+                                  dedupe_key=dedupe_key)
         except Exception as e:
+            if pending_claimed:
+                self._release_pending_slave_message(dedupe_key)
             if isinstance(e, telegram.error.BadRequest) and e.message:
                 if "Topic" in e.message:
                     try:
@@ -161,7 +207,8 @@ class SlaveMessageProcessor(LocaleMixin):
                          old_msg_id: Optional[OldMsgID],
                          tg_dest: TelegramChatID,
                          thread_id: Optional[TelegramTopicID],
-                         silent: bool = False):
+                         silent: bool = False,
+                         dedupe_key: Optional[Tuple[str, str]] = None):
         """Dispatch with header, destination and Telegram message ID and destinations."""
 
         xid = msg.uid
@@ -236,6 +283,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                               reply_markup, silent)
         elif msg.type == MsgType.Status:
             # Status messages are not to be recorded in databases
+            self._release_pending_slave_message(dedupe_key)
             return self.slave_message_status(msg, tg_dest, thread_id)
         elif msg.type == MsgType.Unsupported:
             tg_msg = self.slave_message_unsupported(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id,
@@ -256,7 +304,12 @@ class SlaveMessageProcessor(LocaleMixin):
         if tg_msg is None:
             self.logger.warning("[%s] Message sending returned None, skipping database logging. "
                                "This may happen during shutdown or when Telegram API is unavailable.", xid)
+            self._release_pending_slave_message(dedupe_key)
             return
+
+        on_db_complete = None
+        if dedupe_key is not None:
+            on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
 
         if hasattr(tg_msg, '_delayed_execution_pending') and tg_msg._delayed_execution_pending:
             self.logger.debug("[%s] Message execution is delayed (task_id: %s), deferring database logging.",
@@ -265,9 +318,12 @@ class SlaveMessageProcessor(LocaleMixin):
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
 
             if hasattr(tg_msg, 'task_id'):
-                self.bot.register_delayed_database_update(tg_msg.task_id, etm_msg, old_msg_id)
+                self.bot.register_delayed_database_update(
+                    tg_msg.task_id, etm_msg, old_msg_id, on_complete=on_db_complete,
+                )
             else:
                 self.logger.warning("[%s] Delayed message missing task_id, cannot register database update", xid)
+                self._release_pending_slave_message(dedupe_key)
         else:
             # Normal (blocking) execution — send already succeeded,
             # hand off DB write asynchronously so the calling thread is
@@ -281,7 +337,7 @@ class SlaveMessageProcessor(LocaleMixin):
             sender_bot_id = getattr(tg_msg, 'sender_bot_id', None)
 
             self.bot.submit_async_db_write(
-                etm_msg, tg_msg, old_msg_id, sender_bot_id=sender_bot_id,
+                etm_msg, tg_msg, old_msg_id, sender_bot_id=sender_bot_id, on_complete=on_db_complete,
             )
 
     def get_slave_msg_dest(self, msg: Message) -> Tuple[str, Tuple[Optional[TelegramChatID], Optional[TelegramTopicID]]]:

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1262,6 +1262,31 @@ def test_drop_delayed_database_update_runs_completion_callback():
     on_complete.assert_called_once()
 
 
+def test_drop_delayed_database_update_before_register_runs_late_callback():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    on_complete = Mock()
+    db_mock = Mock()
+    db_mock.add_or_update_message_log = Mock()
+    mgr = SimpleNamespace(
+        channel=SimpleNamespace(db=db_mock),
+        _pending_delayed_logs={},
+        _completed_delayed_results={},
+        _pending_logs_lock=threading.Lock(),
+        logger=Mock(),
+    )
+
+    TelegramBotManager._drop_delayed_database_update(mgr, "task-1")
+    TelegramBotManager.register_delayed_database_update(
+        mgr, "task-1", Mock(), None, on_complete=on_complete,
+    )
+
+    assert "task-1" not in mgr._pending_delayed_logs
+    assert "task-1" not in mgr._completed_delayed_results
+    db_mock.add_or_update_message_log.assert_not_called()
+    on_complete.assert_called_once()
+
+
 def test_handle_delayed_database_update_runs_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1121,6 +1121,7 @@ def test_process_db_retry_queue_succeeds_on_retry():
 
     db_mock = Mock()
     db_mock.add_or_update_message_log = Mock()  # succeeds now
+    on_complete = Mock()
 
     etm_msg = Mock()
     real_tg_msg = Mock()
@@ -1128,7 +1129,7 @@ def test_process_db_retry_queue_succeeds_on_retry():
 
     mgr = SimpleNamespace(
         channel=SimpleNamespace(db=db_mock),
-        _db_retry_queue=[(etm_msg, None, real_tg_msg, None, 1, 0.0)],
+        _db_retry_queue=[(etm_msg, None, real_tg_msg, None, 1, 0.0, on_complete)],
         _db_retry_lock=threading.Lock(),
         _db_max_retries=5,
         logger=Mock(),
@@ -1138,6 +1139,7 @@ def test_process_db_retry_queue_succeeds_on_retry():
 
     db_mock.add_or_update_message_log.assert_called_once()
     assert len(mgr._db_retry_queue) == 0
+    on_complete.assert_called_once()
 
 
 def test_process_db_retry_queue_gives_up_after_max_retries():
@@ -1221,6 +1223,67 @@ def test_register_delayed_database_update_stores_timestamp():
     entry = mgr._pending_delayed_logs["task-1"]
     assert len(entry) == 3
     assert entry[2] == 42.0  # registered_at timestamp
+
+
+def test_register_delayed_database_update_stores_completion_callback():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    on_complete = Mock()
+    mgr = SimpleNamespace(
+        _pending_delayed_logs={},
+        _completed_delayed_results={},
+        _pending_logs_lock=threading.Lock(),
+        logger=Mock(),
+    )
+
+    TelegramBotManager.register_delayed_database_update(
+        mgr, "task-1", Mock(), None, on_complete=on_complete,
+    )
+
+    entry = mgr._pending_delayed_logs["task-1"]
+    assert len(entry) == 4
+    assert entry[3] is on_complete
+
+
+def test_drop_delayed_database_update_runs_completion_callback():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    on_complete = Mock()
+    mgr = SimpleNamespace(
+        _pending_delayed_logs={"task-1": (Mock(), None, 1.0, on_complete)},
+        _completed_delayed_results={},
+        _pending_logs_lock=threading.Lock(),
+        logger=Mock(),
+    )
+
+    TelegramBotManager._drop_delayed_database_update(mgr, "task-1")
+
+    assert "task-1" not in mgr._pending_delayed_logs
+    on_complete.assert_called_once()
+
+
+def test_handle_delayed_database_update_runs_completion_callback():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    on_complete = Mock()
+    etm_msg = Mock()
+    real_tg_msg = Mock()
+    real_tg_msg.message_id = 999
+    db_mock = Mock()
+    mgr = SimpleNamespace(
+        channel=SimpleNamespace(db=db_mock),
+        _pending_delayed_logs={"task-1": (etm_msg, None, 1.0, on_complete)},
+        _completed_delayed_results={},
+        _pending_logs_lock=threading.Lock(),
+        logger=Mock(),
+    )
+
+    with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
+        TelegramBotManager._handle_delayed_database_update(mgr, "task-1", real_tg_msg)
+
+    assert "task-1" not in mgr._pending_delayed_logs
+    db_mock.add_or_update_message_log.assert_called_once()
+    on_complete.assert_called_once()
 
 
 def test_handle_delayed_database_update_stores_timestamp():

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,3 +1,4 @@
+import threading
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 from types import SimpleNamespace
@@ -66,6 +67,82 @@ def build_dummy_message(chat: Chat, author: ChatMember) -> Message:
     message.chat = chat
     message.author = author
     return message
+
+
+def build_duplicate_test_processor() -> SlaveMessageProcessor:
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    processor.db = Mock()
+    processor.logger = Mock()
+    processor.get_slave_msg_dest = Mock(return_value=("__template__", (123, None)))
+    processor.is_silent = Mock(return_value=False)
+    processor.dispatch_message = Mock()
+    processor._pending_slave_messages = set()
+    processor._pending_slave_messages_lock = threading.Lock()
+    return processor
+
+
+def build_duplicate_test_message(uid: str = "__msg_id__") -> SimpleNamespace:
+    return SimpleNamespace(
+        uid=uid,
+        edit=False,
+        type=MsgType.Text,
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+    )
+
+
+def test_duplicate_slave_message_logged_is_skipped():
+    processor = build_duplicate_test_processor()
+    processor.db.get_msg_log.return_value = SimpleNamespace(master_msg_id="100.10")
+    message = build_duplicate_test_message()
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    processor.get_slave_msg_dest.assert_not_called()
+    processor.dispatch_message.assert_not_called()
+
+
+def test_duplicate_slave_message_pending_is_skipped():
+    processor = build_duplicate_test_processor()
+    processor.db.get_msg_log.return_value = None
+    message = build_duplicate_test_message()
+    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
+    processor._pending_slave_messages.add(key)
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    processor.get_slave_msg_dest.assert_not_called()
+    processor.dispatch_message.assert_not_called()
+
+
+def test_new_slave_message_claims_pending_before_dispatch():
+    processor = build_duplicate_test_processor()
+    processor.db.get_msg_log.return_value = None
+    message = build_duplicate_test_message()
+    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    assert key in processor._pending_slave_messages
+    processor.dispatch_message.assert_called_once_with(
+        message, "__template__", None, 123, None, False, dedupe_key=key,
+    )
+
+
+def test_undelivered_slave_message_releases_pending_claim():
+    processor = build_duplicate_test_processor()
+    processor.db.get_msg_log.return_value = None
+    processor.is_silent.return_value = None
+    message = build_duplicate_test_message()
+    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    assert key not in processor._pending_slave_messages
+    processor.dispatch_message.assert_not_called()
 
 
 def test_slave_message_generate_common_private(generate_message_template, private):


### PR DESCRIPTION
Summary:
- Add in-memory pending dedupe for slave messages before queued delivery.
- Keep existing MsgLog dedupe for messages already logged.
- Release pending keys after delayed/DB completion or terminal delayed drops.