### PR TITLE
Simplify FIFO send queue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -723,6 +723,11 @@ done by adjusting values ``request_kwargs`` section in ETM’s
        read_timeout: 6
        connect_timeout: 7
 
+For high queued-send throughput, ETM sizes the Telegram HTTPX connection
+pool from the send worker count. Set the environment variable
+``ETM_HTTPX_POOL_MULTIPLIER`` to a positive number to tune that pool size
+multiplier; the default is ``2.0``.
+
 Run ETM behind a proxy
 ----------------------
 

--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -659,10 +659,23 @@ class TelegramChannel(MasterChannel):
                 self.logger.exception('Unhandled telegram bot error!\n'
                                       'Update %s caused error %s. Exception', update, error)
 
+    def _is_stopping(self) -> bool:
+        bot_manager = getattr(self, "bot_manager", None)
+        return bool(
+            getattr(self, "_stop_polling_called", False)
+            or getattr(bot_manager, "_stopping", False)
+        )
+
     def send_message(self, msg: EFBMessage) -> EFBMessage:
+        if self._is_stopping():
+            self.logger.debug("Dropping slave message during Telegram Master shutdown: %s", msg)
+            return msg
         return self.slave_messages.send_message(msg)
 
     def send_status(self, status: Status):
+        if self._is_stopping():
+            self.logger.debug("Dropping slave status during Telegram Master shutdown: %s", status)
+            return None
         return self.slave_messages.send_status(status)
 
     def get_message_by_id(self, chat: Chat,

--- a/efb_telegram_master/__init__.py
+++ b/efb_telegram_master/__init__.py
@@ -661,9 +661,12 @@ class TelegramChannel(MasterChannel):
 
     def _is_stopping(self) -> bool:
         bot_manager = getattr(self, "bot_manager", None)
+        manager_stopping = getattr(bot_manager, "_stopping", False)
+        if hasattr(manager_stopping, "is_set"):
+            manager_stopping = manager_stopping.is_set()
         return bool(
             getattr(self, "_stop_polling_called", False)
-            or getattr(bot_manager, "_stopping", False)
+            or manager_stopping
         )
 
     def send_message(self, msg: EFBMessage) -> EFBMessage:

--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -169,6 +169,10 @@ class AuxiliaryBot:
         """Reserve a send slot and return the delay. Thread-safe."""
         return self._rate_limiter.reserve_slot(chat_id)
 
+    def release_slot(self, chat_id: int) -> None:
+        """Release the latest reservation when a send did not happen."""
+        self._rate_limiter.release_slot(chat_id)
+
     def get_chat_send_count(self, chat_id: int) -> int:
         """Return this bot's current per-chat sliding-window send count."""
         chat_count, _global_count = self._rate_limiter.get_counts(chat_id)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -850,7 +850,7 @@ class TelegramBotManager(LocaleMixin):
 
         self._send_queues: dict[SendTarget, _deque[QueuedSendTask]] = {}
         self._send_queues_lock = threading.Lock()
-        self._tasks_scheduled = 0  # monotonic counter for diagnostics
+        self._tasks_enqueued = 0  # monotonic counter for diagnostics
         self._send_worker_stop = threading.Event()
 
         # Per-target concurrency tracking
@@ -1438,8 +1438,8 @@ class TelegramBotManager(LocaleMixin):
         """Append a task to the per-target FIFO queue."""
         slave_id, chat_id = target
         with self._send_queues_lock:
-            self._tasks_scheduled += 1
-            arrival_seq = self._tasks_scheduled
+            self._tasks_enqueued += 1
+            arrival_seq = self._tasks_enqueued
             task_id = f"{slave_id}_{chat_id}_{arrival_seq}_{time.time_ns()}"
             task = QueuedSendTask(
                 target=target,
@@ -1519,7 +1519,7 @@ class TelegramBotManager(LocaleMixin):
                 # ── 3. Housekeeping ──
                 self._process_db_retry_queue()
 
-                # Purge expired freeze entries
+                # Purge expired disabled bot/chat entries
                 if self._bot_chat_disabled_until:
                     expired = [k for k, v in self._bot_chat_disabled_until.items() if v <= now]
                     for k in expired:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -44,7 +44,6 @@ class QueuedSendTask(NamedTuple):
     args: tuple
     kwargs: dict
     task_id: str
-    arrival_seq: int = 0
     cleanup_files: tuple[str, ...] = ()
     enqueued_at: float = 0.0
 
@@ -1492,15 +1491,13 @@ class TelegramBotManager(LocaleMixin):
         enqueued_at = time.monotonic()
         with self._send_queues_lock:
             self._tasks_enqueued += 1
-            arrival_seq = self._tasks_enqueued
-            task_id = f"{slave_id}_{chat_id}_{arrival_seq}_{time.time_ns()}"
+            task_id = f"{slave_id}_{chat_id}_{self._tasks_enqueued}_{time.time_ns()}"
             task = QueuedSendTask(
                 target=target,
                 function=function,
                 args=args,
                 kwargs=kwargs,
                 task_id=task_id,
-                arrival_seq=arrival_seq,
                 cleanup_files=tuple(cleanup_files or ()),
                 enqueued_at=enqueued_at,
             )

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -512,6 +512,9 @@ class TelegramBotManager(LocaleMixin):
                         )
 
                     message_thread_id = kwargs.get('message_thread_id')
+                    allow_aux_fallback = not (
+                        force_main_bot or has_callback or is_edit_method or force_sender_known
+                    )
                     if force_main_bot or has_callback or is_edit_method:
                         bot, chosen_sender_bot_id, wait_seconds = self._bot, None, 0.0
                     elif force_sender_known:
@@ -527,6 +530,18 @@ class TelegramBotManager(LocaleMixin):
                         )
                     if chosen_sender_bot_id is None:
                         wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
+                        if wait_seconds > 0 and allow_aux_fallback and self.bot_pool:
+                            slot = self.bot_pool.acquire_send_slot(
+                                int(chat_id),
+                                max_delay=wait_seconds,
+                                affinity_key=str(slave_id) if slave_id else (chat_id, message_thread_id),
+                                notify_admin=True,
+                            )
+                            if slot is not None:
+                                self._release_reserved_slot(None, int(chat_id))
+                                aux_bot, wait_seconds = slot
+                                bot = aux_bot.bot
+                                chosen_sender_bot_id = str(aux_bot.bot_id)
                     if wait_seconds > 0:
                         time.sleep(wait_seconds)
                     try:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -451,11 +451,11 @@ class TelegramBotManager(LocaleMixin):
 
                 if sender_bot_id and self.bot_pool and not has_callback and chat_id is not None:
                     chat_id_int = int(chat_id)
-                    bot, chosen_sender_bot_id, delay_time = self._select_forced_sender(
+                    bot, chosen_sender_bot_id, wait_seconds = self._select_forced_sender(
                         chat_id_int, sender_bot_id,
                     )
-                    if delay_time > 0:
-                        time.sleep(delay_time)
+                    if wait_seconds > 0:
+                        time.sleep(wait_seconds)
                     if chosen_sender_bot_id:
                         try:
                             with self._using_bot(bot):
@@ -481,9 +481,9 @@ class TelegramBotManager(LocaleMixin):
                     aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
                     if aux_bot:
                         aux_bot.update_membership(chat_id_int, False)
-                    delay_time, _, _ = self._calculate_rate_limit_delay(chat_id_int)
-                    if delay_time > 0:
-                        time.sleep(delay_time)
+                    wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id_int)
+                    if wait_seconds > 0:
+                        time.sleep(wait_seconds)
                     return self._make_send_receipt(fn(self, *args, **kwargs))
 
                 if chat_id:
@@ -506,22 +506,22 @@ class TelegramBotManager(LocaleMixin):
 
                     message_thread_id = kwargs.get('message_thread_id')
                     if force_main_bot or has_callback or is_edit_method:
-                        bot, chosen_sender_bot_id, delay_time = self._bot, None, 0.0
+                        bot, chosen_sender_bot_id, wait_seconds = self._bot, None, 0.0
                     elif force_sender_known:
-                        bot, chosen_sender_bot_id, delay_time = self._select_forced_sender(
+                        bot, chosen_sender_bot_id, wait_seconds = self._select_forced_sender(
                             chat_id, forced_sender_bot_id,
                         )
                     else:
-                        bot, chosen_sender_bot_id, delay_time = self._select_sender(
+                        bot, chosen_sender_bot_id, wait_seconds = self._select_sender(
                             chat_id,
                             slave_id=str(slave_id) if slave_id else None,
                             has_callback=has_callback,
                             message_thread_id=message_thread_id,
                         )
                     if chosen_sender_bot_id is None:
-                        delay_time, _, _ = self._calculate_rate_limit_delay(chat_id)
-                    if delay_time > 0:
-                        time.sleep(delay_time)
+                        wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
+                    if wait_seconds > 0:
+                        time.sleep(wait_seconds)
                     try:
                         with self._using_bot(bot):
                             result = fn(self, *args, **kwargs)
@@ -538,9 +538,9 @@ class TelegramBotManager(LocaleMixin):
                                     "marking it as non-member for this chat and retrying with main bot.",
                                     chosen_sender_bot_id, chat_id,
                                 )
-                                delay_time, _, _ = self._calculate_rate_limit_delay(chat_id)
-                                if delay_time > 0:
-                                    time.sleep(delay_time)
+                                wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
+                                if wait_seconds > 0:
+                                    time.sleep(wait_seconds)
                                 return self._make_send_receipt(fn(self, *args, **kwargs))
                         raise
 
@@ -1398,7 +1398,7 @@ class TelegramBotManager(LocaleMixin):
             peek_only: If True, compute delay without reserving a slot.
 
         Returns:
-            tuple: (delay_time, chat_count, global_count)
+            tuple: (wait_seconds, chat_count, global_count)
         """
         if peek_only:
             sleep_time = self._rate_limiter.peek_delay(chat_id)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -34,16 +34,26 @@ from .ptb_compat import Filters
 from .utils import TelegramChatID, TelegramMessageID, message_id_to_str
 
 
-class DelayedTask(NamedTuple):
-    """Represents a delayed message task."""
-    execute_time: float  # When to execute (timestamp)
-    chat_id: int        # Target chat ID
-    function: Callable  # Function to execute
-    args: tuple        # Function arguments
-    kwargs: dict       # Function keyword arguments
-    task_id: str       # Unique task identifier
-    arrival_seq: int = 0  # Monotonic arrival order; preserved across requeues
-    cleanup_files: list = []  # Files to delete after task completes
+SendTarget: TypeAlias = Tuple[str, int]
+
+
+class QueuedSendTask(NamedTuple):
+    """Represents an in-memory FIFO send task."""
+    target: SendTarget
+    function: Callable
+    args: tuple
+    kwargs: dict
+    task_id: str
+    arrival_seq: int = 0
+    cleanup_files: tuple[str, ...] = ()
+
+    @property
+    def slave_id(self) -> str:
+        return self.target[0]
+
+    @property
+    def chat_id(self) -> int:
+        return self.target[1]
 
 if TYPE_CHECKING:
     from . import TelegramChannel
@@ -52,7 +62,7 @@ MAX_CALLBACK_QUERY_ANSWER_LENGTH = 200
 P = ParamSpec("P")
 T = TypeVar("T")
 BotMethod: TypeAlias = Callable[..., object]
-_DELAYED_DATABASE_UPDATE_DROPPED = object()
+_QUEUED_DATABASE_UPDATE_DROPPED = object()
 
 
 class SyncBotProtocol(Protocol):
@@ -235,9 +245,8 @@ class QueuedSendPlaceholder:
     date: int
     text: str
     task_id: str
-    is_delayed: bool = True
-    delay_time: float = 0.0
-    _delayed_execution_pending: bool = True
+    is_queued: bool = True
+    _queued_execution_pending: bool = True
     sender_bot_id: Optional[str] = None
 
     def __post_init__(self):
@@ -294,7 +303,7 @@ def _has_callback_keyboard(reply_markup) -> bool:
 
 
 def _clone_file_argument(value):
-    """Copy file-like send arguments so delayed tasks don't depend on caller-owned handles."""
+    """Copy file-like send arguments so queued tasks don't depend on caller-owned handles."""
     if isinstance(value, InputFile):
         return InputFile(io.BytesIO(value.input_file_content), filename=value.filename)
     if hasattr(value, 'read') and hasattr(value, 'seek'):
@@ -355,6 +364,9 @@ class TelegramBotManager(LocaleMixin):
 
     webhook = False
     logger = logging.getLogger(__name__)
+    DEFAULT_SEND_WORKER_COUNT = 8
+    DEFAULT_HTTPX_POOL_MULTIPLIER = 2.0
+    HTTPX_POOL_MULTIPLIER_ENV = "ETM_HTTPX_POOL_MULTIPLIER"
 
     # Type declarations for instance attributes assigned in __init__
     application: Application
@@ -364,8 +376,8 @@ class TelegramBotManager(LocaleMixin):
     admins: List[int]
     dispatcher: Application
     bot_pool: Optional['BotPool']
-    _delayed_worker_stop: threading.Event
-    _chat_queues_lock: threading.Lock
+    _send_worker_stop: threading.Event
+    _send_queues_lock: threading.Lock
     _cleanup_tls: threading.local
     _tls: threading.local
     _aux_recent_use: dict[int, float]
@@ -401,6 +413,7 @@ class TelegramBotManager(LocaleMixin):
                     return fn(self, *args, **kwargs)
 
                 sender_bot_id = kwargs.pop('_sender_bot_id', None)
+                slave_id = kwargs.pop('_slave_id', None)
                 send_mode = kwargs.pop('_send_mode', 'blocking')
                 force_main_bot = kwargs.pop('_force_main_bot', False)
                 force_sender_known = False
@@ -413,9 +426,8 @@ class TelegramBotManager(LocaleMixin):
                     chat_id = kwargs['chat_id']
                 has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
 
-                # if _delayed_worker_stop is set, we should not schedule new tasks
-                if self._delayed_worker_stop.is_set():
-                    self.logger.warning(f"Delayed worker is stopped. Not scheduling new tasks for chat {chat_id}.")
+                if self._send_worker_stop.is_set():
+                    self.logger.warning(f"Queued send worker is stopped. Not scheduling new tasks for chat {chat_id}.")
                     return None
 
                 reply_to_message_id = kwargs.get('reply_to_message_id')
@@ -478,17 +490,14 @@ class TelegramBotManager(LocaleMixin):
                     cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]
                     self._cleanup_tls.pending_cleanup = []
 
-                    if send_mode == 'eventual':
-                        if is_edit_method:
-                            kwargs = dict(kwargs)
-                            kwargs['_force_sender_known'] = True
-                            kwargs['_force_sender_bot_id'] = None
-                        elif force_sender_known and not has_callback:
+                    if send_mode == 'eventual' and not is_edit_method and not has_callback and slave_id:
+                        if force_sender_known:
                             kwargs = dict(kwargs)
                             kwargs['_force_sender_known'] = True
                             kwargs['_force_sender_bot_id'] = forced_sender_bot_id
-                        return self._schedule_eventual_send(
-                            chat_id,
+                        return self._enqueue_eventual_send(
+                            str(slave_id),
+                            int(chat_id),
                             fn,
                             (self,) + args,
                             kwargs,
@@ -505,6 +514,7 @@ class TelegramBotManager(LocaleMixin):
                     else:
                         bot, chosen_sender_bot_id, delay_time = self._select_sender(
                             chat_id,
+                            slave_id=str(slave_id) if slave_id else None,
                             has_callback=has_callback,
                             message_thread_id=message_thread_id,
                         )
@@ -583,10 +593,10 @@ class TelegramBotManager(LocaleMixin):
                         cls.logger.warning(f"Rate limit hit, waiting {retry_after}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
 
                         # Use interruptible sleep for rate limit waits
-                        if hasattr(self, '_delayed_worker_stop'):
+                        if hasattr(self, '_send_worker_stop'):
                             # Sleep in small chunks to allow for interruption during shutdown
                             remaining_seconds = retry_after
-                            while remaining_seconds > 0 and not self._delayed_worker_stop.is_set():
+                            while remaining_seconds > 0 and not self._send_worker_stop.is_set():
                                 sleep_chunk = min(1.0, remaining_seconds)
                                 time.sleep(sleep_chunk)
                                 remaining_seconds -= sleep_chunk
@@ -607,10 +617,10 @@ class TelegramBotManager(LocaleMixin):
                             cls.logger.warning(f"Rate limit detected, waiting {delay}s before retry {attempt + 1}/{max_retries} (chat_id: {chat_id}){timestamp_info}")
 
                             # Use interruptible sleep for rate limit waits
-                            if hasattr(self, '_delayed_worker_stop'):
+                            if hasattr(self, '_send_worker_stop'):
                                 # Sleep in small chunks to allow for interruption during shutdown
                                 remaining_seconds = float(delay)
-                                while remaining_seconds > 0 and not self._delayed_worker_stop.is_set():
+                                while remaining_seconds > 0 and not self._send_worker_stop.is_set():
                                     sleep_chunk = min(1.0, remaining_seconds)
                                     time.sleep(sleep_chunk)
                                     remaining_seconds -= sleep_chunk
@@ -699,8 +709,8 @@ class TelegramBotManager(LocaleMixin):
 
             @wraps(fn)
             def skip_wrapper(self: 'TelegramBotManager', *args, **kwargs):
-                with self._chat_queues_lock:
-                    if any(self._chat_queues.values()) or self._chat_in_flight:
+                with self._send_queues_lock:
+                    if any(self._send_queues.values()) or self._send_in_flight:
                         return None
 
                 # Suppress when aux bots were recently used for this chat
@@ -736,11 +746,27 @@ class TelegramBotManager(LocaleMixin):
 
             return retry_on_chat_migration_wrap
 
+    @classmethod
+    def _default_connection_pool_size(cls, config: Mapping[str, object]) -> int:
+        multiplier = cls.DEFAULT_HTTPX_POOL_MULTIPLIER
+        multiplier_value = os.getenv(cls.HTTPX_POOL_MULTIPLIER_ENV)
+        if multiplier_value:
+            try:
+                parsed_multiplier = float(multiplier_value)
+            except ValueError:
+                parsed_multiplier = multiplier
+            if parsed_multiplier > 0:
+                multiplier = parsed_multiplier
+        return max(1, int(round(cls.DEFAULT_SEND_WORKER_COUNT * multiplier)))
+
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
         config = self.channel.config
 
-        req_kwargs = {'read_timeout': 15.0}
+        req_kwargs = {
+            'read_timeout': 15.0,
+            'connection_pool_size': self._default_connection_pool_size(config),
+        }
         conf_req_kwargs = config.get('request_kwargs')
         if isinstance(conf_req_kwargs, collections.abc.Mapping):
             req_kwargs.update(conf_req_kwargs)
@@ -816,36 +842,36 @@ class TelegramBotManager(LocaleMixin):
         self.logger.debug("Bot pool initialization complete...")
 
         # ── Outbound send pipeline ────────────────────────────────────
-        # Per-chat FIFO queues + thread pool for concurrent dispatch.
-        # Same chat_id: sends are serial (ordering guarantee).
-        # Different chat_ids: sends run in parallel threads.
+        # Per-target FIFO queues + thread pool for concurrent dispatch.
+        # Same (slave_id, chat_id): sends are serial (ordering guarantee).
+        # Different targets: sends run in parallel threads.
         from collections import deque as _deque
-        from concurrent.futures import ThreadPoolExecutor, Future
+        from concurrent.futures import ThreadPoolExecutor
 
-        self._chat_queues: dict[int, _deque[DelayedTask]] = {}
-        self._chat_queues_lock = threading.Lock()
+        self._send_queues: dict[SendTarget, _deque[QueuedSendTask]] = {}
+        self._send_queues_lock = threading.Lock()
         self._tasks_scheduled = 0  # monotonic counter for diagnostics
-        self._delayed_worker_stop = threading.Event()
+        self._send_worker_stop = threading.Event()
 
-        # Per-chat concurrency tracking
-        self._chat_in_flight: dict[int, tuple] = {}  # chat_id -> (Future, task, sender_bot_id)
-        self._chat_frozen_until: dict[int, float] = {}  # chat_id -> when ALL bots are rate-limited
-        self._bot_chat_frozen_until: dict[tuple, float] = {}  # (bot_id|None, chat_id) -> RetryAfter deadline
+        # Per-target concurrency tracking
+        self._send_in_flight: dict[SendTarget, tuple] = {}  # target -> (Future, task, sender_bot_id)
+        self._bot_chat_disabled_until: dict[tuple, float] = {}  # (bot_id|None, chat_id) -> RetryAfter deadline
 
         # Per-chat send interval (200ms safety gap)
         self._last_send_by_chat: dict[int, float] = {}
         self.CHAT_SEND_INTERVAL = 0.2  # seconds
 
         # Thread pool for non-blocking sends
+        self._send_worker_count = self.DEFAULT_SEND_WORKER_COUNT
         self._send_executor: ThreadPoolExecutor = ThreadPoolExecutor(
-            max_workers=8, thread_name_prefix="ETM-send",
+            max_workers=self._send_worker_count, thread_name_prefix="ETM-send",
         )
 
-        # Rendezvous dicts for delayed DB updates — with timestamps for TTL cleanup
+        # Rendezvous dicts for queued DB updates — with timestamps for TTL cleanup
         # task_id -> (etm_msg, old_msg_id, registered_at)
-        self._pending_delayed_logs: dict[str, tuple] = {}
+        self._pending_queued_logs: dict[str, tuple] = {}
         # task_id -> (real_tg_msg, sender_bot_id, completed_at), or a dropped marker
-        self._completed_delayed_results: dict[str, tuple] = {}
+        self._completed_queued_results: dict[str, tuple] = {}
         self._pending_logs_lock = threading.Lock()
         self._rendezvous_ttl = 600.0          # 10 minutes
         self._rendezvous_cleanup_interval = 300.0  # 5 minutes
@@ -856,13 +882,13 @@ class TelegramBotManager(LocaleMixin):
         self._db_retry_lock = threading.Lock()
         self._db_max_retries = 5
 
-        self._delayed_worker_thread = threading.Thread(
-            target=self._delayed_message_worker,
-            name="ETM delayed messages worker",
+        self._send_worker_thread = threading.Thread(
+            target=self._queued_send_worker,
+            name="ETM queued send worker",
             daemon=True
         )
-        self._delayed_worker_thread.start()
-        self.logger.debug("Delayed message system initialized...")
+        self._send_worker_thread.start()
+        self.logger.debug("Queued send system initialized...")
 
         self.logger.debug("Adding base dispatchers...")
         self._add_base_dispatchers()
@@ -1109,15 +1135,15 @@ class TelegramBotManager(LocaleMixin):
             manager=self,
         )
 
-    def _schedule_eventual_send(
+    def _enqueue_eventual_send(
         self,
+        slave_id: str,
         chat_id: int,
         function: Callable,
         args: tuple,
         kwargs: dict,
         *,
         cleanup_files: Optional[list] = None,
-        delay_time: float = 0.0,
     ) -> SendReceipt:
         kwargs = dict(kwargs)
         for key in ('photo', 'document', 'video', 'animation', 'audio', 'voice', 'sticker'):
@@ -1128,27 +1154,28 @@ class TelegramBotManager(LocaleMixin):
         if len(args) >= 3:
             args = args[:2] + (_clone_file_argument(args[2]),) + args[3:]
 
-        task_id = self._schedule_delayed_task(
-            chat_id=chat_id,
-            delay_time=delay_time,
+        task_id = self._enqueue_send_task(
+            target=(slave_id, int(chat_id)),
             function=function,
             args=args,
             kwargs=kwargs,
             cleanup_files=cleanup_files,
         )
-        placeholder = self._create_delayed_message_placeholder(chat_id, delay_time, task_id)
+        placeholder = self._create_queued_message_placeholder(chat_id, task_id)
         return self._make_send_receipt(placeholder, queued=True, task_id=task_id)
 
-    def _select_sender(self, chat_id: int, *, has_callback: bool = False, message_thread_id: Optional[int] = None):
+    def _select_sender(self, chat_id: int, *, slave_id: Optional[str] = None,
+                       has_callback: bool = False, message_thread_id: Optional[int] = None):
         """Choose the earliest sender using the current main/aux heuristics."""
         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         if main_delay <= 0:
             return self._bot, None, main_delay
         if self.bot_pool and not has_callback:
+            affinity_key = slave_id or (chat_id, message_thread_id)
             slot = self.bot_pool.acquire_send_slot(
                 chat_id,
                 max_delay=main_delay,
-                affinity_key=(chat_id, message_thread_id),
+                affinity_key=affinity_key,
                 notify_admin=(main_delay > 0),
             )
             if slot is not None:
@@ -1170,85 +1197,79 @@ class TelegramBotManager(LocaleMixin):
         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         return self._bot, None, main_delay
 
-    def _select_unfrozen_sender(self, chat_id: int, *, has_callback: bool = False,
+    def _select_available_sender(self, chat_id: int, *, slave_id: Optional[str] = None,
+                                has_callback: bool = False,
                                 message_thread_id: Optional[int] = None, now: float = 0.0):
-        """Like _select_sender, but skips bots frozen by Telegram RetryAfter.
+        """Select an immediately available sender, skipping Telegram-disabled bot/chat pairs.
 
-        Returns (bot, bot_id, delay) or (None, None, soonest_unfreeze_delay)
-        when every candidate is frozen.
+        Returns ``(bot, bot_id, 0.0)`` when a slot is reserved.  A non-zero
+        delay means no sender is currently available; callers must requeue and
+        try again instead of storing that delay on the task.
         """
         now = now or time.time()
         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
 
-        # ── Try aux bots first (skip frozen ones) ──
         if self.bot_pool and not has_callback:
-            # Allow aux bots to participate even when main bot isn't delayed,
-            # but only notify admin when the main bot is actually rate-limited.
-            max_delay = max(main_delay, 0.01)
             slot = self.bot_pool.acquire_send_slot(
                 chat_id,
-                max_delay=max_delay,
-                skip_bot=lambda aux_bot: self._bot_chat_frozen_until.get((str(aux_bot.bot_id), chat_id), 0.0) > now,
-                affinity_key=(chat_id, message_thread_id),
+                max_delay=1e-9,
+                skip_bot=lambda aux_bot: self._bot_chat_disabled_until.get((str(aux_bot.bot_id), chat_id), 0.0) > now,
+                affinity_key=slave_id or (chat_id, message_thread_id),
                 notify_admin=(main_delay > 0),
             )
             if slot is not None:
                 aux_bot_obj, aux_delay = slot
                 return aux_bot_obj.bot, str(aux_bot_obj.bot_id), aux_delay
 
-        # ── Try main bot ──
-        main_frozen = self._bot_chat_frozen_until.get((None, chat_id), 0.0)
-        if main_frozen <= now:
-            if main_delay <= 0:
-                self._calculate_rate_limit_delay(chat_id)  # reserve
-                return self._bot, None, 0.0
-            # Main bot available but rate-limited — return its delay
-            return self._bot, None, main_delay
+        main_disabled = self._bot_chat_disabled_until.get((None, chat_id), 0.0)
+        if main_disabled > now:
+            return None, None, main_disabled - now
 
-        # ── All bots frozen ──
-        # Find earliest unfreeze time so the caller knows when to retry
-        soonest = float('inf')
-        for key, until in self._bot_chat_frozen_until.items():
-            if key[1] == chat_id and until > now:
-                soonest = min(soonest, until - now)
-        return None, None, soonest if soonest != float('inf') else 0.5
+        if main_delay <= 0:
+            self._calculate_rate_limit_delay(chat_id)  # reserve
+            return self._bot, None, 0.0
+        return None, None, main_delay
 
-    def _select_forced_unfrozen_sender(self, chat_id: int, sender_bot_id: Optional[str], *, now: float = 0.0):
-        """Select the reply target's sender bot, respecting RetryAfter freezes."""
+    def _select_forced_available_sender(self, chat_id: int, sender_bot_id: Optional[str], *, now: float = 0.0):
+        """Select the reply target's sender bot when it is immediately available."""
         now = now or time.time()
         if sender_bot_id and self.bot_pool:
-            frozen_until = self._bot_chat_frozen_until.get((str(sender_bot_id), chat_id), 0.0)
-            if frozen_until > now:
-                return None, None, frozen_until - now
+            disabled_until = self._bot_chat_disabled_until.get((str(sender_bot_id), chat_id), 0.0)
+            if disabled_until > now:
+                return None, None, disabled_until - now
             aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
             if aux_bot and not aux_bot.disabled:
-                delay = aux_bot.reserve_slot(chat_id)
-                return aux_bot.bot, str(sender_bot_id), delay
+                delay = aux_bot.peek_delay(chat_id)
+                if delay <= 0:
+                    aux_bot.reserve_slot(chat_id)
+                    return aux_bot.bot, str(sender_bot_id), 0.0
+                return None, None, delay
             self.logger.warning(
-                "Reply target sender bot %s is unavailable for delayed chat %s; falling back to main bot.",
+                "Reply target sender bot %s is unavailable for queued chat %s; falling back to main bot.",
                 sender_bot_id, chat_id,
             )
 
-        main_frozen = self._bot_chat_frozen_until.get((None, chat_id), 0.0)
-        if main_frozen > now:
-            return None, None, main_frozen - now
+        main_disabled = self._bot_chat_disabled_until.get((None, chat_id), 0.0)
+        if main_disabled > now:
+            return None, None, main_disabled - now
         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         if main_delay > 0:
-            return self._bot, None, main_delay
+            return None, None, main_delay
         self._calculate_rate_limit_delay(chat_id)
         return self._bot, None, 0.0
 
-    def _requeue_delayed_task(self, task: DelayedTask, delay_time: float):
-        """Put a task back at the front of its chat queue and freeze that chat."""
-        with self._chat_queues_lock:
-            q = self._chat_queues.setdefault(task.chat_id, collections.deque())
+    def _requeue_send_task(self, task: QueuedSendTask):
+        """Put a task back at the front of its target FIFO."""
+        with self._send_queues_lock:
+            q = self._send_queues.setdefault(task.target, collections.deque())
             q.appendleft(task)
-        if delay_time > 0:
-            self._chat_frozen_until[task.chat_id] = time.time() + delay_time
 
     def _init_bot_pool(self, aux_configs: list, config: dict, channel: 'TelegramChannel'):
         """Initialize the auxiliary bot pool from config."""
-        req_kwargs = {'read_timeout': 15.0}
+        req_kwargs = {
+            'read_timeout': 15.0,
+            'connection_pool_size': self._default_connection_pool_size(config),
+        }
         conf_req_kwargs = config.get('request_kwargs')
         if isinstance(conf_req_kwargs, collections.abc.Mapping):
             req_kwargs.update(conf_req_kwargs)
@@ -1399,71 +1420,93 @@ class TelegramBotManager(LocaleMixin):
 
         return sleep_time, chat_count, global_count
 
-    def _create_delayed_message_placeholder(self, chat_id: int, delay_time: float, task_id: str):
-        """
-        Create a placeholder message object for delayed execution.
-
-        Args:
-            chat_id: Telegram chat ID
-            delay_time: Delay time in seconds
-            task_id: Unique task identifier
-
-        Returns:
-            A mock message object indicating delayed execution
-        """
-
+    def _create_queued_message_placeholder(self, chat_id: int, task_id: str):
+        """Create a placeholder message object for queued execution."""
         placeholder = QueuedSendPlaceholder(
             chat_id=chat_id,
             message_id=int(time.time() * 1000),
             date=int(time.time()),
-            text=f"[Message scheduled for delivery in {delay_time:.2f}s due to rate limiting]",
+            text="[Message queued for delivery]",
             task_id=task_id,
-            delay_time=delay_time,
         )
-        self.logger.debug(f"Created delayed message placeholder for chat {chat_id} with {delay_time:.2f}s delay")
+        self.logger.debug("Created queued message placeholder for chat %s", chat_id)
         return placeholder
 
-    def _schedule_delayed_task(self, chat_id: int, delay_time: float, function: Callable,
-                              args: tuple, kwargs: dict, cleanup_files: Optional[list] = None) -> str:
-        """Append a task to the per-chat FIFO queue."""
-        task_id = f"{chat_id}_{str(time.time_ns())}_{id(function)}"
-
-        task = DelayedTask(
-            execute_time=time.time() + delay_time,
-            chat_id=chat_id,
-            function=function,
-            args=args,
-            kwargs=kwargs,
-            task_id=task_id,
-            cleanup_files=cleanup_files or []
-        )
-
-        with self._chat_queues_lock:
-            q = self._chat_queues.setdefault(chat_id, collections.deque())
-            q.append(task)
+    def _enqueue_send_task(self, target: SendTarget, function: Callable,
+                           args: tuple, kwargs: dict,
+                           cleanup_files: Optional[list] = None) -> str:
+        """Append a task to the per-target FIFO queue."""
+        slave_id, chat_id = target
+        with self._send_queues_lock:
             self._tasks_scheduled += 1
-
-        if delay_time > 0:
-            self._chat_frozen_until[chat_id] = max(
-                self._chat_frozen_until.get(chat_id, 0.0),
-                time.time() + delay_time,
+            arrival_seq = self._tasks_scheduled
+            task_id = f"{slave_id}_{chat_id}_{arrival_seq}_{time.time_ns()}"
+            task = QueuedSendTask(
+                target=target,
+                function=function,
+                args=args,
+                kwargs=kwargs,
+                task_id=task_id,
+                arrival_seq=arrival_seq,
+                cleanup_files=tuple(cleanup_files or ())
             )
+            q = self._send_queues.setdefault(target, collections.deque())
+            q.append(task)
 
-        self.logger.debug(f"Scheduled delayed task {task_id} for chat {chat_id} in {delay_time:.2f}s")
+        self.logger.debug("Queued send task %s for target %s", task_id, target)
         return task_id
 
-    # ── Async-dispatch delayed message worker ──────────────────────
+    # ── Async-dispatch queued send worker ──────────────────────
 
-    def _delayed_message_worker(self):
+    def _dispatch_ready_send_tasks(self, now: float):
+        with self._send_queues_lock:
+            dispatchable_targets = [
+                target for target, q in self._send_queues.items()
+                if q and target not in self._send_in_flight
+            ]
+
+        for target in dispatchable_targets:
+            if self._send_worker_stop.is_set():
+                break
+
+            with self._send_queues_lock:
+                q = self._send_queues.get(target)
+                if not q:
+                    continue
+                task = q.popleft()
+                if not q:
+                    del self._send_queues[target]
+
+            if task.kwargs.get('_force_sender_known'):
+                sender_bot, sender_bot_id, wait_time = self._select_forced_available_sender(
+                    task.chat_id,
+                    task.kwargs.get('_force_sender_bot_id'),
+                    now=now,
+                )
+            else:
+                sender_bot, sender_bot_id, wait_time = self._select_available_sender(
+                    task.chat_id,
+                    slave_id=task.slave_id,
+                    has_callback=_has_callback_keyboard(task.kwargs.get('reply_markup')),
+                    message_thread_id=task.kwargs.get('message_thread_id'),
+                    now=now,
+                )
+            if sender_bot is None or wait_time > 0:
+                self._requeue_send_task(task)
+                continue
+
+            self._dispatch_send(task, sender_bot, sender_bot_id)
+
+    def _queued_send_worker(self):
         """Worker thread: dispatch sends to a thread pool.
 
-        Same chat_id → serial (one in-flight at a time, preserves order).
-        Different chat_ids → parallel (thread pool).
+        Same (slave_id, chat_id) → serial (one in-flight at a time, preserves order).
+        Different targets → parallel (thread pool).
         The worker thread itself never blocks on HTTP; it only orchestrates.
         """
-        self.logger.debug("Delayed message worker started")
+        self.logger.debug("Queued send worker started")
 
-        while not self._delayed_worker_stop.is_set():
+        while not self._send_worker_stop.is_set():
             try:
                 now = time.time()
 
@@ -1471,112 +1514,88 @@ class TelegramBotManager(LocaleMixin):
                 self._harvest_completed_sends()
 
                 # ── 2. Dispatch ready tasks ──
-                with self._chat_queues_lock:
-                    dispatchable_chats = [
-                        cid for cid, q in self._chat_queues.items()
-                        if q and cid not in self._chat_in_flight
-                    ]
-
-                for chat_id in dispatchable_chats:
-                    if self._delayed_worker_stop.is_set():
-                        break
-
-                    # Frozen (RetryAfter / rate limit)?
-                    if self._chat_frozen_until.get(chat_id, 0.0) > now:
-                        continue
-
-                    # Per-chat 200ms interval
-                    last_sent = self._last_send_by_chat.get(chat_id, 0.0)
-                    if now - last_sent < self.CHAT_SEND_INTERVAL:
-                        continue
-
-                    # Peek at front task
-                    with self._chat_queues_lock:
-                        q = self._chat_queues.get(chat_id)
-                        if not q:
-                            continue
-                        task = q[0]
-                        if task.execute_time > now:
-                            continue
-                        task = q.popleft()
-
-                    # Select sender, skipping (bot, chat) pairs frozen by RetryAfter
-                    if task.kwargs.get('_force_sender_known'):
-                        sender_bot, sender_bot_id, delay_time = self._select_forced_unfrozen_sender(
-                            task.chat_id,
-                            task.kwargs.get('_force_sender_bot_id'),
-                            now=now,
-                        )
-                    else:
-                        sender_bot, sender_bot_id, delay_time = self._select_unfrozen_sender(
-                            task.chat_id,
-                            has_callback=_has_callback_keyboard(task.kwargs.get('reply_markup')),
-                            message_thread_id=task.kwargs.get('message_thread_id'),
-                            now=now,
-                        )
-                    if sender_bot is None:
-                        # Every bot is frozen or rate-limited for this chat — put task back
-                        self._requeue_delayed_task(task, delay_time if delay_time > 0 else 0.5)
-                        continue
-                    if delay_time > 0:
-                        self._requeue_delayed_task(task, delay_time)
-                        continue
-
-                    # Submit to thread pool — non-blocking
-                    self._dispatch_send(task, sender_bot, sender_bot_id)
+                self._dispatch_ready_send_tasks(now)
 
                 # ── 3. Housekeeping ──
                 self._process_db_retry_queue()
 
                 # Purge expired freeze entries
-                if self._bot_chat_frozen_until:
-                    expired = [k for k, v in self._bot_chat_frozen_until.items() if v <= now]
+                if self._bot_chat_disabled_until:
+                    expired = [k for k, v in self._bot_chat_disabled_until.items() if v <= now]
                     for k in expired:
-                        del self._bot_chat_frozen_until[k]
-                if self._chat_frozen_until:
-                    expired = [k for k, v in self._chat_frozen_until.items() if v <= now]
-                    for k in expired:
-                        del self._chat_frozen_until[k]
-
+                        del self._bot_chat_disabled_until[k]
                 if now - self._last_rendezvous_cleanup > self._rendezvous_cleanup_interval:
                     self._cleanup_stale_rendezvous()
                     self._last_rendezvous_cleanup = now
 
-                self._delayed_worker_stop.wait(timeout=0.05)
+                self._send_worker_stop.wait(timeout=0.05)
 
             except Exception as e:
-                self.logger.exception(f"Error in delayed message worker: {e}")
-                self._delayed_worker_stop.wait(timeout=1)
+                self.logger.exception(f"Error in queued send worker: {e}")
+                self._send_worker_stop.wait(timeout=1)
 
         # Shutdown: wait for in-flight sends to finish
-        for chat_id, (future, task, _bot_id) in list(self._chat_in_flight.items()):
+        for _target, (future, task, _bot_id) in list(self._send_in_flight.items()):
             try:
                 future.result(timeout=10)
             except Exception:
                 pass
         self._send_executor.shutdown(wait=False)
-        self.logger.debug("Delayed message worker stopped")
+        self.logger.debug("Queued send worker stopped")
 
-    def _dispatch_send(self, task: DelayedTask, sender_bot, sender_bot_id: Optional[str]):
+    def _dispatch_send(self, task: QueuedSendTask, sender_bot, sender_bot_id: Optional[str]):
         """Submit a send operation to the thread pool."""
 
         def _do_send():
             send_kwargs = dict(task.kwargs)
             send_kwargs.pop('_force_sender_known', None)
             send_kwargs.pop('_force_sender_bot_id', None)
+            send_kwargs.pop('_slave_id', None)
             send_kwargs['_skip_rate_limit_retry'] = True
             with self._using_bot(sender_bot):
                 return task.function(*task.args, **send_kwargs)
 
         future = self._send_executor.submit(_do_send)
-        self._chat_in_flight[task.chat_id] = (future, task, sender_bot_id)
+        self._send_in_flight[task.target] = (future, task, sender_bot_id)
+
+    def _release_reserved_slot(self, sender_bot_id: Optional[str], chat_id: int):
+        if sender_bot_id and self.bot_pool:
+            aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
+            if aux_bot and hasattr(aux_bot, "release_slot"):
+                aux_bot.release_slot(chat_id)
+            return
+        if hasattr(self, "_rate_limiter"):
+            self._rate_limiter.release_slot(chat_id)
+
+    @staticmethod
+    def _rate_limit_retry_after_seconds(error: Exception) -> Optional[float]:
+        if isinstance(error, telegram.error.RetryAfter):
+            retry_after_value = error.retry_after
+            if isinstance(retry_after_value, timedelta):
+                return retry_after_value.total_seconds()
+            return float(retry_after_value)
+        error_text = str(error)
+        if "Too Many Requests" in error_text or "429" in error_text or "Flood" in error_text:
+            return 60.0
+        return None
+
+    def _requeue_after_telegram_rate_limit(self, task: QueuedSendTask,
+                                           sender_bot_id: Optional[str],
+                                           retry_after: float):
+        self.logger.warning(
+            "Telegram rate limit for bot %s in chat %d (task %s): %.2fs; other bots can still send",
+            sender_bot_id or "main", task.chat_id, task.task_id, retry_after,
+        )
+        self._bot_chat_disabled_until[(sender_bot_id, task.chat_id)] = time.time() + retry_after
+        self._release_reserved_slot(sender_bot_id, task.chat_id)
+        self._requeue_send_task(task)
 
     def _harvest_completed_sends(self):
         """Check all in-flight futures; handle success / errors."""
-        completed = [(cid, ft) for cid, ft in self._chat_in_flight.items() if ft[0].done()]
+        completed = [(target, ft) for target, ft in self._send_in_flight.items() if ft[0].done()]
 
-        for chat_id, (future, task, sender_bot_id) in completed:
-            del self._chat_in_flight[chat_id]
+        for target, (future, task, sender_bot_id) in completed:
+            del self._send_in_flight[target]
             should_cleanup = True
 
             try:
@@ -1586,79 +1605,97 @@ class TelegramBotManager(LocaleMixin):
                     self._record_aux_use(task.chat_id)
 
                 self._last_send_by_chat[task.chat_id] = time.time()
-                self.logger.debug(f"Delayed task {task.task_id} completed successfully")
+                self.logger.debug("Queued send task %s completed successfully", task.task_id)
 
                 if result and hasattr(result, 'message_id'):
-                    self._handle_delayed_database_update(
+                    self._handle_queued_database_update(
                         task.task_id, result, sender_bot_id=sender_bot_id,
                     )
                 else:
-                    TelegramBotManager._drop_delayed_database_update(self, task.task_id)
+                    TelegramBotManager._drop_queued_database_update(self, task.task_id)
 
             except telegram.error.RetryAfter as e:
                 should_cleanup = False
-                retry_after_value = e.retry_after
-                retry_after = (
-                    retry_after_value.total_seconds()
-                    if isinstance(retry_after_value, timedelta)
-                    else float(retry_after_value)
+                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
+                TelegramBotManager._requeue_after_telegram_rate_limit(
+                    self, task, sender_bot_id, retry_after or 60.0
                 )
-                self.logger.warning(
-                    "RetryAfter for bot %s in chat %d (task %s): %.2fs — other bots can still send",
-                    sender_bot_id or "main", chat_id, task.task_id, retry_after,
-                )
-                # Freeze only THIS bot for THIS chat; other bots remain available
-                self._bot_chat_frozen_until[(sender_bot_id, chat_id)] = time.time() + retry_after
-                # Put task back at front — next dispatch will try a different bot
-                with self._chat_queues_lock:
-                    q = self._chat_queues.setdefault(chat_id, collections.deque())
-                    q.appendleft(task)
 
             except telegram.error.BadRequest as e:
+                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
+                if retry_after is not None:
+                    should_cleanup = False
+                    TelegramBotManager._requeue_after_telegram_rate_limit(
+                        self, task, sender_bot_id, retry_after
+                    )
+                    continue
+                self._release_reserved_slot(sender_bot_id, task.chat_id)
                 self.logger.warning(
-                    "Non-retryable BadRequest for delayed task %s, dropping: %s "
+                    "Non-retryable BadRequest for queued task %s, dropping: %s "
                     "(chat_id=%s, reply_to_message_id=%s, message_thread_id=%s, method=%s)",
                     task.task_id, e, task.chat_id,
                     task.kwargs.get("reply_to_message_id"),
                     task.kwargs.get("message_thread_id"),
                     getattr(task.function, "__name__", repr(task.function)),
                 )
-                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
+                TelegramBotManager._drop_queued_database_update(self, task.task_id)
 
             except (telegram.error.TimedOut, telegram.error.NetworkError) as e:
+                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
+                if retry_after is not None:
+                    should_cleanup = False
+                    TelegramBotManager._requeue_after_telegram_rate_limit(
+                        self, task, sender_bot_id, retry_after
+                    )
+                    continue
                 should_cleanup = False
                 self.logger.warning(
-                    "Transient error for delayed task %s, retrying: %s",
+                    "Transient error for queued task %s, retrying: %s",
                     task.task_id, e,
                 )
-                self._requeue_delayed_task(task, 1.0)
+                self._release_reserved_slot(sender_bot_id, task.chat_id)
+                self._requeue_send_task(task)
 
             except telegram.error.Forbidden as e:
+                self._release_reserved_slot(sender_bot_id, task.chat_id)
                 if sender_bot_id and self.bot_pool:
                     aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
                     if aux_bot:
-                        aux_bot.update_membership(chat_id, False)
+                        aux_bot.update_membership(task.chat_id, False)
                         should_cleanup = False
                         self.logger.warning(
-                            "Aux bot %s got Forbidden in chat %s for delayed task %s; "
+                            "Aux bot %s got Forbidden in chat %s for queued task %s; "
                             "marking it as non-member for this chat and retrying.",
-                            sender_bot_id, chat_id, task.task_id,
+                            sender_bot_id, task.chat_id, task.task_id,
                         )
-                        self._requeue_delayed_task(task, 0.0)
+                        self._requeue_send_task(task)
                         continue
-                self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
-                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
+                self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
+                TelegramBotManager._drop_queued_database_update(self, task.task_id)
+
+            except telegram.error.TelegramError as e:
+                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
+                if retry_after is not None:
+                    should_cleanup = False
+                    TelegramBotManager._requeue_after_telegram_rate_limit(
+                        self, task, sender_bot_id, retry_after
+                    )
+                    continue
+                self._release_reserved_slot(sender_bot_id, task.chat_id)
+                self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
+                TelegramBotManager._drop_queued_database_update(self, task.task_id)
 
             except Exception as e:
-                self.logger.exception(f"Error executing delayed task {task.task_id}: {e}")
-                TelegramBotManager._drop_delayed_database_update(self, task.task_id)
+                self._release_reserved_slot(sender_bot_id, task.chat_id)
+                self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
+                TelegramBotManager._drop_queued_database_update(self, task.task_id)
 
             finally:
                 if should_cleanup:
                     for path in task.cleanup_files:
                         try:
                             os.unlink(path)
-                            self.logger.debug("Cleaned up delayed task temp file: %s", path)
+                            self.logger.debug("Cleaned up queued task temp file: %s", path)
                         except OSError as e:
                             self.logger.warning("Failed to clean up temp file %s: %s", path, e)
 
@@ -1670,30 +1707,34 @@ class TelegramBotManager(LocaleMixin):
         except Exception as e:
             self.logger.warning("Database update completion callback failed: %s", e)
 
+    def _queued_rendezvous_maps(self) -> tuple[dict[str, tuple], dict[str, tuple]]:
+        return self._pending_queued_logs, self._completed_queued_results
+
     @staticmethod
-    def _delayed_log_callback(entry: Optional[tuple]) -> Optional[Callable[[], None]]:
+    def _queued_log_callback(entry: Optional[tuple]) -> Optional[Callable[[], None]]:
         if entry is not None and len(entry) >= 4:
             return entry[3]
         return None
 
-    def _drop_delayed_database_update(self, task_id: str):
-        """Release bookkeeping for a delayed task that will not produce a Telegram message."""
+    def _drop_queued_database_update(self, task_id: str):
+        """Release bookkeeping for a queued task that will not produce a Telegram message."""
         if not hasattr(self, '_pending_logs_lock'):
             return
         pending_update = None
         with self._pending_logs_lock:
-            pending_update = self._pending_delayed_logs.pop(task_id, None)
+            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_update = pending_logs.pop(task_id, None)
             if pending_update is None:
-                self._completed_delayed_results[task_id] = (
-                    _DELAYED_DATABASE_UPDATE_DROPPED, None, time.time()
+                completed_results[task_id] = (
+                    _QUEUED_DATABASE_UPDATE_DROPPED, None, time.time()
                 )
             else:
-                self._completed_delayed_results.pop(task_id, None)
+                completed_results.pop(task_id, None)
         TelegramBotManager._run_database_update_callback(
-            self, TelegramBotManager._delayed_log_callback(pending_update)
+            self, TelegramBotManager._queued_log_callback(pending_update)
         )
 
-    def _finalize_delayed_database_update(
+    def _finalize_queued_database_update(
         self,
         etm_msg,
         old_msg_id,
@@ -1803,24 +1844,25 @@ class TelegramBotManager(LocaleMixin):
         """Remove rendezvous entries that were never paired within the TTL."""
         cutoff = time.time() - self._rendezvous_ttl
         with self._pending_logs_lock:
+            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
             stale_logs = [
-                tid for tid, entry in self._pending_delayed_logs.items()
+                tid for tid, entry in pending_logs.items()
                 if len(entry) >= 3 and entry[2] < cutoff
             ]
             for tid in stale_logs:
                 TelegramBotManager._run_database_update_callback(
                     self,
-                    TelegramBotManager._delayed_log_callback(self._pending_delayed_logs.get(tid)),
+                    TelegramBotManager._queued_log_callback(pending_logs.get(tid)),
                 )
-                del self._pending_delayed_logs[tid]
+                del pending_logs[tid]
                 self.logger.warning("Rendezvous TTL: dropped stale pending log for task %s", tid)
 
             stale_results = [
-                tid for tid, entry in self._completed_delayed_results.items()
+                tid for tid, entry in completed_results.items()
                 if len(entry) >= 3 and entry[2] < cutoff
             ]
             for tid in stale_results:
-                del self._completed_delayed_results[tid]
+                del completed_results[tid]
                 self.logger.warning("Rendezvous TTL: dropped stale completed result for task %s", tid)
 
     def submit_async_db_write(
@@ -1837,42 +1879,43 @@ class TelegramBotManager(LocaleMixin):
         Failures are caught and routed to the retry queue — callers should
         NEVER re-send to Telegram on a DB-write error.
         """
-        TelegramBotManager._finalize_delayed_database_update(
+        TelegramBotManager._finalize_queued_database_update(
             self,
             etm_msg, old_msg_id, real_tg_msg,
             sender_bot_id=sender_bot_id,
             on_complete=on_complete,
         )
 
-    def register_delayed_database_update(self, task_id: str, etm_msg, old_msg_id=None,
+    def register_queued_database_update(self, task_id: str, etm_msg, old_msg_id=None,
                                          on_complete: Optional[Callable[[], None]] = None):
         """
-        Register a pending database update for a delayed task.
+        Register a pending database update for a queued task.
 
         Args:
-            task_id: Task identifier from delayed execution
+            task_id: Task identifier from queued execution
             etm_msg: ETMMsg object to log
             old_msg_id: Optional old message ID for updates
         """
         completed_result: Optional[tuple]
         with self._pending_logs_lock:
-            completed_result = self._completed_delayed_results.pop(task_id, None)
+            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            completed_result = completed_results.pop(task_id, None)
             if completed_result is None:
                 if on_complete is not None:
-                    self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time(), on_complete)
+                    pending_logs[task_id] = (etm_msg, old_msg_id, time.time(), on_complete)
                 else:
-                    self._pending_delayed_logs[task_id] = (etm_msg, old_msg_id, time.time())
-                self.logger.debug(f"Registered delayed database update for task {task_id}")
+                    pending_logs[task_id] = (etm_msg, old_msg_id, time.time())
+                self.logger.debug("Registered queued database update for task %s", task_id)
                 return
 
-        if completed_result[0] is _DELAYED_DATABASE_UPDATE_DROPPED:
-            self.logger.debug("Delayed task %s was dropped before database registration", task_id)
+        if completed_result[0] is _QUEUED_DATABASE_UPDATE_DROPPED:
+            self.logger.debug("Queued task %s was dropped before database registration", task_id)
             TelegramBotManager._run_database_update_callback(self, on_complete)
             return
 
         real_tg_msg, sender_bot_id = completed_result[0], completed_result[1]
-        self.logger.debug(f"Finalizing already-completed delayed task {task_id}")
-        TelegramBotManager._finalize_delayed_database_update(
+        self.logger.debug("Finalizing already-completed queued task %s", task_id)
+        TelegramBotManager._finalize_queued_database_update(
             self,
             etm_msg,
             old_msg_id,
@@ -1881,7 +1924,7 @@ class TelegramBotManager(LocaleMixin):
             on_complete=on_complete,
         )
 
-    def _handle_delayed_database_update(
+    def _handle_queued_database_update(
         self,
         task_id: str,
         real_tg_msg,
@@ -1889,7 +1932,7 @@ class TelegramBotManager(LocaleMixin):
         sender_bot_id: Optional[str] = None,
     ):
         """
-        Handle database update when delayed task completes.
+        Handle database update when queued task completes.
 
         Args:
             task_id: Task identifier
@@ -1897,15 +1940,16 @@ class TelegramBotManager(LocaleMixin):
         """
         pending_update = None
         with self._pending_logs_lock:
-            pending_update = self._pending_delayed_logs.pop(task_id, None)
+            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_update = pending_logs.pop(task_id, None)
             if pending_update is None:
-                self._completed_delayed_results[task_id] = (real_tg_msg, sender_bot_id, time.time())
-                self.logger.debug(f"Stored delayed result for task {task_id} until database registration is ready")
+                completed_results[task_id] = (real_tg_msg, sender_bot_id, time.time())
+                self.logger.debug("Stored queued result for task %s until database registration is ready", task_id)
                 return
 
         etm_msg, old_msg_id = pending_update[0], pending_update[1]
-        on_complete = TelegramBotManager._delayed_log_callback(pending_update)
-        TelegramBotManager._finalize_delayed_database_update(
+        on_complete = TelegramBotManager._queued_log_callback(pending_update)
+        TelegramBotManager._finalize_queued_database_update(
             self,
             etm_msg,
             old_msg_id,
@@ -1913,23 +1957,23 @@ class TelegramBotManager(LocaleMixin):
             sender_bot_id=sender_bot_id,
             on_complete=on_complete,
         )
-        self.logger.debug(f"Updated database with real message for delayed task {task_id}")
+        self.logger.debug("Updated database with real message for queued task %s", task_id)
 
-    def stop_delayed_worker(self):
-        """Stop the delayed message worker thread."""
-        self.logger.debug("Stopping delayed message worker...")
+    def stop_queued_worker(self):
+        """Stop the queued send worker thread."""
+        self.logger.debug("Stopping queued send worker...")
 
-        if hasattr(self, '_delayed_worker_stop'):
-            self._delayed_worker_stop.set()
+        if hasattr(self, '_send_worker_stop'):
+            self._send_worker_stop.set()
 
-        if hasattr(self, '_delayed_worker_thread') and self._delayed_worker_thread.is_alive():
-            self.logger.debug("Waiting for delayed message worker to stop...")
-            self._delayed_worker_thread.join(timeout=5)
+        if hasattr(self, '_send_worker_thread') and self._send_worker_thread.is_alive():
+            self.logger.debug("Waiting for queued send worker to stop...")
+            self._send_worker_thread.join(timeout=5)
 
-            if self._delayed_worker_thread.is_alive():
-                self.logger.warning("Delayed message worker did not stop gracefully within timeout")
+            if self._send_worker_thread.is_alive():
+                self.logger.warning("Queued send worker did not stop gracefully within timeout")
             else:
-                self.logger.debug("Delayed message worker stopped successfully")
+                self.logger.debug("Queued send worker stopped successfully")
 
         # Drain any remaining DB retries before shutdown
         if hasattr(self, '_db_retry_queue') and self._db_retry_queue:
@@ -2452,16 +2496,16 @@ class TelegramBotManager(LocaleMixin):
 
         # Log pending tasks count before stopping
         pending_count = 0
-        if hasattr(self, '_chat_queues'):
-            with self._chat_queues_lock:
-                pending_count = sum(len(q) for q in self._chat_queues.values())
-            pending_count += len(self._chat_in_flight)
+        if hasattr(self, '_send_queues'):
+            with self._send_queues_lock:
+                pending_count = sum(len(q) for q in self._send_queues.values())
+            pending_count += len(self._send_in_flight)
 
         if pending_count > 0:
-            self.logger.info(f"Found {pending_count} pending delayed tasks")
+            self.logger.info("Found %d pending queued send tasks", pending_count)
 
-        # Stop the delayed message worker first
-        self.stop_delayed_worker()
+        # Stop the queued send worker first
+        self.stop_queued_worker()
 
         # Shut down auxiliary bot pool
         if self.bot_pool:
@@ -2533,11 +2577,11 @@ class TelegramBotManager(LocaleMixin):
     def __del__(self):
         """Ensure cleanup on object destruction"""
         try:
-            if hasattr(self, '_delayed_worker_stop') and hasattr(self, '_delayed_worker_thread'):
-                if not self._delayed_worker_stop.is_set():
-                    self._delayed_worker_stop.set()
-                if self._delayed_worker_thread.is_alive():
-                    self._delayed_worker_thread.join(timeout=1)
+            if hasattr(self, '_send_worker_stop') and hasattr(self, '_send_worker_thread'):
+                if not self._send_worker_stop.is_set():
+                    self._send_worker_stop.set()
+                if self._send_worker_thread.is_alive():
+                    self._send_worker_thread.join(timeout=1)
         except Exception:
             # Don't raise exceptions in __del__
             pass

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -8,7 +8,7 @@ import os
 import re
 import threading
 import time
-from concurrent.futures import TimeoutError as FutureTimeoutError
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
@@ -55,6 +55,8 @@ class QueuedSendTask(NamedTuple):
     cleanup_files: tuple[str, ...] = ()
     enqueued_at: float = 0.0
     db_log_context: Optional[QueuedDbLogContext] = None
+    priority: bool = False
+    waiter: Optional[Future] = None
 
     @property
     def slave_id(self) -> str:
@@ -79,8 +81,6 @@ _INTERNAL_KWARGS = frozenset({
     '_force_main_bot',
     '_force_sender_known',
     '_force_sender_bot_id',
-    '_timing_receive_monotonic',
-    '_timing_destination_monotonic',
     '_queued_db_log_context',
     '_skip_rate_limit_retry',
 })
@@ -431,8 +431,6 @@ class TelegramBotManager(LocaleMixin):
                 is_edit_method = fn.__name__.startswith('edit_message_')
 
                 # Bypass: caller already reserved a slot and set _using_bot
-                timing_receive_monotonic = kwargs.pop('_timing_receive_monotonic', None)
-                timing_destination_monotonic = kwargs.pop('_timing_destination_monotonic', None)
                 if kwargs.pop('_bypass_rate_limit', False):
                     return fn(self, *args, **kwargs)
 
@@ -450,12 +448,16 @@ class TelegramBotManager(LocaleMixin):
                     chat_id = kwargs['chat_id']
                 has_callback = _has_callback_keyboard(kwargs.get('reply_markup'))
 
-                if self._send_worker_stop.is_set():
+                send_worker_stop = getattr(self, '_send_worker_stop', None)
+                if send_worker_stop is not None and send_worker_stop.is_set():
                     self.logger.warning(f"Queued send worker is stopped. Not scheduling new tasks for chat {chat_id}.")
                     return None
 
                 reply_to_message_id = kwargs.get('reply_to_message_id')
-                if sender_bot_id is None and chat_id and reply_to_message_id and hasattr(self, 'channel'):
+                if sender_bot_id and not (has_callback and not is_edit_method):
+                    force_sender_known = True
+                    forced_sender_bot_id = sender_bot_id
+                elif sender_bot_id is None and not has_callback and chat_id and reply_to_message_id and hasattr(self, 'channel'):
                     try:
                         target_log = self.channel.db.get_msg_log(
                             master_msg_id=message_id_to_str(
@@ -473,53 +475,12 @@ class TelegramBotManager(LocaleMixin):
                             force_sender_known = True
                             forced_sender_bot_id = target_log.sender_bot_id
 
-                if sender_bot_id and self.bot_pool and not has_callback and chat_id is not None:
-                    chat_id_int = int(chat_id)
-                    bot, chosen_sender_bot_id, wait_seconds = self._select_forced_sender(
-                        chat_id_int, sender_bot_id,
-                    )
-                    if wait_seconds > 0:
-                        time.sleep(wait_seconds)
-                    if chosen_sender_bot_id:
-                        try:
-                            result = self._call_with_reserved_slot(
-                                bot, chosen_sender_bot_id, chat_id_int, fn, args, kwargs,
-                            )
-                            return self._make_send_receipt(result, sender_bot_id=chosen_sender_bot_id)
-                        except telegram.error.Forbidden:
-                            aux_bot = self.bot_pool.get_bot_by_id(chosen_sender_bot_id)
-                            if aux_bot:
-                                aux_bot.update_membership(chat_id_int, False)
-                            self.logger.warning(
-                                "Auxiliary bot %s got Forbidden in chat %s during forced-route API call; "
-                                "marking it as non-member for this chat.",
-                                chosen_sender_bot_id, chat_id,
-                            )
-                    else:
-                        self.logger.warning(
-                            "Auxiliary bot %s is unavailable for forced-route API call in chat %s; "
-                            "falling back to main bot.",
-                            sender_bot_id, chat_id,
-                        )
-                        self._calculate_rate_limit_delay(chat_id_int)
-                        result = self._call_with_reserved_slot(
-                            self._bot, None, chat_id_int, fn, args, kwargs,
-                        )
-                        return self._make_send_receipt(result)
-                    aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
-                    if aux_bot:
-                        aux_bot.update_membership(chat_id_int, False)
-                    wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id_int)
-                    if wait_seconds > 0:
-                        time.sleep(wait_seconds)
-                    result = self._call_with_reserved_slot(
-                        self._bot, None, chat_id_int, fn, args, kwargs,
-                    )
-                    return self._make_send_receipt(result)
-
                 if chat_id:
-                    cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]
-                    self._cleanup_tls.pending_cleanup = []
+                    chat_id_int = int(chat_id)
+                    cleanup_tls = getattr(self, '_cleanup_tls', None)
+                    cleanup_files = getattr(cleanup_tls, 'pending_cleanup', [])[:]
+                    if cleanup_tls is not None:
+                        cleanup_tls.pending_cleanup = []
 
                     if send_mode == 'eventual':
                         if not slave_id:
@@ -539,68 +500,23 @@ class TelegramBotManager(LocaleMixin):
                                 (self,) + args,
                                 kwargs,
                                 cleanup_files=cleanup_files,
-                                timing_receive_monotonic=timing_receive_monotonic,
-                                timing_destination_monotonic=timing_destination_monotonic,
                             )
 
-                    message_thread_id = kwargs.get('message_thread_id')
-                    allow_aux_fallback = not (
-                        force_main_bot or has_callback or is_edit_method or force_sender_known
+                    blocking_kwargs = dict(kwargs)
+                    if force_sender_known:
+                        blocking_kwargs['_force_sender_known'] = True
+                        blocking_kwargs['_force_sender_bot_id'] = forced_sender_bot_id
+                    if force_main_bot or (has_callback and not is_edit_method) or (is_edit_method and not force_sender_known):
+                        blocking_kwargs['_force_main_bot'] = True
+
+                    return self._enqueue_blocking_send_and_wait(
+                        str(slave_id) if slave_id else None,
+                        chat_id_int,
+                        fn,
+                        (self,) + args,
+                        blocking_kwargs,
+                        cleanup_files=cleanup_files,
                     )
-                    if force_main_bot or has_callback or is_edit_method:
-                        bot, chosen_sender_bot_id, wait_seconds = self._bot, None, 0.0
-                    elif force_sender_known:
-                        bot, chosen_sender_bot_id, wait_seconds = self._select_forced_sender(
-                            chat_id, forced_sender_bot_id,
-                        )
-                    else:
-                        bot, chosen_sender_bot_id, wait_seconds = self._select_sender(
-                            chat_id,
-                            slave_id=str(slave_id) if slave_id else None,
-                            has_callback=has_callback,
-                            message_thread_id=message_thread_id,
-                        )
-                    if chosen_sender_bot_id is None:
-                        wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
-                        if wait_seconds > 0 and allow_aux_fallback and self.bot_pool:
-                            slot = self.bot_pool.acquire_send_slot(
-                                int(chat_id),
-                                max_delay=wait_seconds,
-                                affinity_key=str(slave_id) if slave_id else (chat_id, message_thread_id),
-                                notify_admin=True,
-                            )
-                            if slot is not None:
-                                self._release_reserved_slot(None, int(chat_id))
-                                aux_bot, wait_seconds = slot
-                                bot = aux_bot.bot
-                                chosen_sender_bot_id = str(aux_bot.bot_id)
-                    if wait_seconds > 0:
-                        time.sleep(wait_seconds)
-                    try:
-                        result = self._call_with_reserved_slot(
-                            bot, chosen_sender_bot_id, int(chat_id), fn, args, kwargs,
-                        )
-                        if chosen_sender_bot_id is not None:
-                            self._record_aux_use(chat_id)
-                        return self._make_send_receipt(result, sender_bot_id=chosen_sender_bot_id)
-                    except telegram.error.Forbidden:
-                        if chosen_sender_bot_id and self.bot_pool:
-                            aux_bot = self.bot_pool.get_bot_by_id(chosen_sender_bot_id)
-                            if aux_bot:
-                                aux_bot.update_membership(int(chat_id), False)
-                                self.logger.warning(
-                                    "Auxiliary bot %s got Forbidden in chat %s during pool-route API call; "
-                                    "marking it as non-member for this chat and retrying with main bot.",
-                                    chosen_sender_bot_id, chat_id,
-                                )
-                                wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
-                                if wait_seconds > 0:
-                                    time.sleep(wait_seconds)
-                                result = self._call_with_reserved_slot(
-                                    self._bot, None, int(chat_id), fn, args, kwargs,
-                                )
-                                return self._make_send_receipt(result)
-                        raise
 
                 return self._make_send_receipt(fn(self, *args, **kwargs))
 
@@ -1188,8 +1104,6 @@ class TelegramBotManager(LocaleMixin):
         kwargs: dict,
         *,
         cleanup_files: Optional[list] = None,
-        timing_receive_monotonic: Optional[float] = None,
-        timing_destination_monotonic: Optional[float] = None,
     ) -> SendReceipt:
         kwargs = dict(kwargs)
         db_log_context = kwargs.pop('_queued_db_log_context', None)
@@ -1209,77 +1123,77 @@ class TelegramBotManager(LocaleMixin):
             cleanup_files=cleanup_files,
             db_log_context=db_log_context,
         )
-        now = time.monotonic()
-        if timing_receive_monotonic is not None:
-            self.logger.debug(
-                "Queued send task %s enqueued %.3fs after message receive.",
-                task_id,
-                now - timing_receive_monotonic,
-            )
-        if timing_destination_monotonic is not None:
-            self.logger.debug(
-                "Queued send task %s enqueued %.3fs after destination resolution.",
-                task_id,
-                now - timing_destination_monotonic,
-            )
         placeholder = self._create_queued_message_placeholder(chat_id, task_id)
         return self._make_send_receipt(placeholder, queued=True, task_id=task_id)
 
-    def _select_sender(self, chat_id: int, *, slave_id: Optional[str] = None,
-                       has_callback: bool = False, message_thread_id: Optional[int] = None):
-        """Choose the earliest sender using the current main/aux heuristics."""
-        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
-        if main_delay <= 0:
-            return self._bot, None, main_delay
-        if self.bot_pool and not has_callback:
-            affinity_key = slave_id or (chat_id, message_thread_id)
-            slot = self.bot_pool.acquire_send_slot(
-                chat_id,
-                max_delay=main_delay,
-                affinity_key=affinity_key,
-                notify_admin=(main_delay > 0),
-            )
-            if slot is not None:
-                aux_bot, aux_delay = slot
-                return aux_bot.bot, str(aux_bot.bot_id), aux_delay
-        return self._bot, None, main_delay
+    def _enqueue_blocking_send_and_wait(
+        self,
+        slave_id: Optional[str],
+        chat_id: int,
+        function: Callable,
+        args: tuple,
+        kwargs: dict,
+        *,
+        cleanup_files: Optional[list] = None,
+    ) -> SendReceipt:
+        kwargs = dict(kwargs)
+        kwargs.pop('_queued_db_log_context', None)
+        for key in ('photo', 'document', 'video', 'animation', 'audio', 'voice', 'sticker'):
+            if key in kwargs:
+                kwargs[key] = _clone_file_argument(kwargs[key])
+        if 'media' in kwargs:
+            kwargs['media'] = _clone_media_argument(kwargs['media'])
+        if len(args) >= 3:
+            args = args[:2] + (_clone_file_argument(args[2]),) + args[3:]
 
-    def _select_forced_sender(self, chat_id: int, sender_bot_id: Optional[str]):
-        """Select the bot that sent the reply target message."""
-        if sender_bot_id and self.bot_pool:
-            aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
-            if aux_bot and not aux_bot.disabled:
-                delay = aux_bot.reserve_slot(chat_id)
-                return aux_bot.bot, str(sender_bot_id), delay
-            self.logger.warning(
-                "Reply target sender bot %s is unavailable for chat %s; falling back to main bot.",
-                sender_bot_id, chat_id,
-            )
-        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
-        return self._bot, None, main_delay
+        waiter: Future = Future()
+        target = (slave_id or "__blocking__", int(chat_id))
+        self._enqueue_send_task(
+            target=target,
+            function=function,
+            args=args,
+            kwargs=kwargs,
+            cleanup_files=cleanup_files,
+            priority=True,
+            waiter=waiter,
+        )
+        return waiter.result()
 
-    def _call_with_reserved_slot(self, bot: object, sender_bot_id: Optional[str],
-                                 chat_id: int, fn: Callable, args: tuple, kwargs: dict):
-        try:
-            with self._using_bot(bot):
-                return fn(self, *args, **kwargs)
-        except Exception:
-            self._release_reserved_slot(sender_bot_id, chat_id)
-            raise
-
-    def _select_available_sender(self, chat_id: int, *, slave_id: Optional[str] = None,
-                                has_callback: bool = False,
-                                message_thread_id: Optional[int] = None, now: float = 0.0):
-        """Select an immediately available sender, skipping Telegram-disabled bot/chat pairs.
-
-        Returns ``(bot, bot_id, 0.0)`` when a slot is reserved.  A non-zero
-        delay means no sender is currently available; callers must requeue and
-        try again instead of storing that delay on the task.
-        """
+    def _select_queued_sender(
+        self,
+        chat_id: int,
+        *,
+        forced_sender_bot_id: Optional[str] = None,
+        force_main: bool = False,
+        slave_id: Optional[str] = None,
+        has_callback: bool = False,
+        message_thread_id: Optional[int] = None,
+        now: float = 0.0,
+    ):
+        """Select an immediately available sender for a queued task."""
         now = now or time.time()
-        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
 
-        if self.bot_pool and not has_callback:
+        if not force_main and forced_sender_bot_id and self.bot_pool:
+            disabled_until = self._bot_chat_disabled_until.get((str(forced_sender_bot_id), chat_id), 0.0)
+            if disabled_until > now:
+                return None, None, disabled_until - now
+            aux_bot = self.bot_pool.get_bot_by_id(forced_sender_bot_id)
+            is_member = True
+            if aux_bot is not None and hasattr(aux_bot, 'check_membership_tri'):
+                is_member = aux_bot.check_membership_tri(chat_id) is not False
+            if aux_bot and not aux_bot.disabled and is_member:
+                delay = aux_bot.peek_delay(chat_id)
+                if delay <= 0:
+                    aux_bot.reserve_slot(chat_id)
+                    return aux_bot.bot, str(forced_sender_bot_id), 0.0
+                return None, None, delay
+            self.logger.warning(
+                "Forced sender bot %s is unavailable for queued chat %s; falling back to main bot.",
+                forced_sender_bot_id, chat_id,
+            )
+
+        if not force_main and forced_sender_bot_id is None and self.bot_pool and not has_callback:
+            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
             slot = self.bot_pool.acquire_send_slot(
                 chat_id,
                 max_delay=1e-9,
@@ -1295,38 +1209,11 @@ class TelegramBotManager(LocaleMixin):
         if main_disabled > now:
             return None, None, main_disabled - now
 
+        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         if main_delay <= 0:
             self._calculate_rate_limit_delay(chat_id)  # reserve
             return self._bot, None, 0.0
         return None, None, main_delay
-
-    def _select_forced_available_sender(self, chat_id: int, sender_bot_id: Optional[str], *, now: float = 0.0):
-        """Select the reply target's sender bot when it is immediately available."""
-        now = now or time.time()
-        if sender_bot_id and self.bot_pool:
-            disabled_until = self._bot_chat_disabled_until.get((str(sender_bot_id), chat_id), 0.0)
-            if disabled_until > now:
-                return None, None, disabled_until - now
-            aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
-            if aux_bot and not aux_bot.disabled:
-                delay = aux_bot.peek_delay(chat_id)
-                if delay <= 0:
-                    aux_bot.reserve_slot(chat_id)
-                    return aux_bot.bot, str(sender_bot_id), 0.0
-                return None, None, delay
-            self.logger.warning(
-                "Reply target sender bot %s is unavailable for queued chat %s; falling back to main bot.",
-                sender_bot_id, chat_id,
-            )
-
-        main_disabled = self._bot_chat_disabled_until.get((None, chat_id), 0.0)
-        if main_disabled > now:
-            return None, None, main_disabled - now
-        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
-        if main_delay > 0:
-            return None, None, main_delay
-        self._calculate_rate_limit_delay(chat_id)
-        return self._bot, None, 0.0
 
     def _requeue_send_task(self, task: QueuedSendTask):
         """Put a task back at the front of its target FIFO."""
@@ -1505,7 +1392,9 @@ class TelegramBotManager(LocaleMixin):
     def _enqueue_send_task(self, target: SendTarget, function: Callable,
                            args: tuple, kwargs: dict,
                            cleanup_files: Optional[list] = None,
-                           db_log_context: Optional[QueuedDbLogContext] = None) -> str:
+                           db_log_context: Optional[QueuedDbLogContext] = None,
+                           priority: bool = False,
+                           waiter: Optional[Future] = None) -> str:
         """Append a task to the per-target FIFO queue."""
         slave_id, chat_id = target
         enqueued_at = time.monotonic()
@@ -1521,9 +1410,19 @@ class TelegramBotManager(LocaleMixin):
                 cleanup_files=tuple(cleanup_files or ()),
                 enqueued_at=enqueued_at,
                 db_log_context=db_log_context,
+                priority=priority,
+                waiter=waiter,
             )
             q = self._send_queues.setdefault(target, collections.deque())
-            q.append(task)
+            if priority:
+                insert_at = 0
+                for existing in q:
+                    if not existing.priority:
+                        break
+                    insert_at += 1
+                q.insert(insert_at, task)
+            else:
+                q.append(task)
             queue_depth = len(q)
 
         self.logger.debug("Queued send task %s for target %s (target_queue_depth=%d)",
@@ -1555,20 +1454,16 @@ class TelegramBotManager(LocaleMixin):
                 if not q:
                     del self._send_queues[target]
 
-            if task.kwargs.get('_force_sender_known'):
-                sender_bot, sender_bot_id, wait_time = self._select_forced_available_sender(
-                    task.chat_id,
-                    task.kwargs.get('_force_sender_bot_id'),
-                    now=now,
-                )
-            else:
-                sender_bot, sender_bot_id, wait_time = self._select_available_sender(
-                    task.chat_id,
-                    slave_id=task.slave_id,
-                    has_callback=_has_callback_keyboard(task.kwargs.get('reply_markup')),
-                    message_thread_id=task.kwargs.get('message_thread_id'),
-                    now=now,
-                )
+            sender_bot, sender_bot_id, wait_time = self._select_queued_sender(
+                task.chat_id,
+                forced_sender_bot_id=task.kwargs.get('_force_sender_bot_id')
+                if task.kwargs.get('_force_sender_known') else None,
+                force_main=bool(task.kwargs.get('_force_main_bot')),
+                slave_id=task.slave_id,
+                has_callback=_has_callback_keyboard(task.kwargs.get('reply_markup')),
+                message_thread_id=task.kwargs.get('message_thread_id'),
+                now=now,
+            )
             if sender_bot is None or wait_time > 0:
                 if sender_bot_id is not None:
                     self._release_reserved_slot(sender_bot_id, task.chat_id)
@@ -1636,11 +1531,16 @@ class TelegramBotManager(LocaleMixin):
                 self._send_worker_stop.wait(timeout=1)
 
         # Shutdown: wait for in-flight sends to finish
-        for _target, (future, task, _bot_id) in list(self._send_in_flight.items()):
+        self._drop_pending_queued_tasks_on_shutdown()
+        for target, (future, task, bot_id) in list(self._send_in_flight.items()):
             try:
-                future.result(timeout=10)
-            except Exception:
-                pass
+                result = future.result(timeout=10)
+            except Exception as e:
+                self._finish_failed_send(task, e)
+            else:
+                self._finish_successful_send(task, result, bot_id)
+            finally:
+                self._send_in_flight.pop(target, None)
         self._send_executor.shutdown(wait=False)
         self.logger.debug("Queued send worker stopped")
 
@@ -1705,6 +1605,73 @@ class TelegramBotManager(LocaleMixin):
         self._release_reserved_slot(sender_bot_id, task.chat_id)
         self._requeue_send_task(task)
 
+    def _resolve_task_waiter_success(
+        self,
+        task: QueuedSendTask,
+        result: object,
+        sender_bot_id: Optional[str],
+    ):
+        if task.waiter is not None and not task.waiter.done():
+            task.waiter.set_result(
+                self._make_send_receipt(result, sender_bot_id=sender_bot_id)
+            )
+
+    @staticmethod
+    def _resolve_task_waiter_exception(task: QueuedSendTask, error: Exception):
+        if task.waiter is not None and not task.waiter.done():
+            task.waiter.set_exception(error)
+
+    def _finish_successful_send(
+        self,
+        task: QueuedSendTask,
+        result: object,
+        sender_bot_id: Optional[str],
+    ):
+        if sender_bot_id is not None:
+            self._record_aux_use(task.chat_id)
+
+        if task.enqueued_at:
+            self.logger.debug(
+                "Queued send task %s completed successfully in %.3fs since enqueue",
+                task.task_id,
+                time.monotonic() - task.enqueued_at,
+            )
+        else:
+            self.logger.debug("Queued send task %s completed successfully", task.task_id)
+
+        if result and hasattr(result, 'message_id'):
+            self._finish_queued_database_update(
+                task.db_log_context, result, sender_bot_id=sender_bot_id,
+            )
+        else:
+            self._finish_queued_database_update(task.db_log_context)
+        self._resolve_task_waiter_success(task, result, sender_bot_id)
+
+    def _finish_failed_send(self, task: QueuedSendTask, error: Exception):
+        self._finish_queued_database_update(task.db_log_context)
+        self._resolve_task_waiter_exception(task, error)
+
+    def _cleanup_queued_task_files(self, task: QueuedSendTask):
+        for path in task.cleanup_files:
+            try:
+                os.unlink(path)
+                self.logger.debug("Cleaned up queued task temp file: %s", path)
+            except OSError as e:
+                self.logger.warning("Failed to clean up temp file %s: %s", path, e)
+
+    def _drop_pending_queued_tasks_on_shutdown(self):
+        error = RuntimeError("Queued send worker stopped before task was dispatched.")
+        with self._send_queues_lock:
+            pending_tasks = [
+                task
+                for q in self._send_queues.values()
+                for task in q
+            ]
+            self._send_queues.clear()
+        for task in pending_tasks:
+            self._finish_failed_send(task, error)
+            self._cleanup_queued_task_files(task)
+
     def _harvest_completed_sends(self):
         """Check all in-flight futures; handle success / errors."""
         completed = [(target, ft) for target, ft in self._send_in_flight.items() if ft[0].done()]
@@ -1715,116 +1682,71 @@ class TelegramBotManager(LocaleMixin):
 
             try:
                 result = future.result()  # already done, won't block
-
-                if sender_bot_id is not None:
-                    self._record_aux_use(task.chat_id)
-
-                if task.enqueued_at:
-                    self.logger.debug(
-                        "Queued send task %s completed successfully in %.3fs since enqueue",
-                        task.task_id,
-                        time.monotonic() - task.enqueued_at,
-                    )
-                else:
-                    self.logger.debug("Queued send task %s completed successfully", task.task_id)
-
-                if result and hasattr(result, 'message_id'):
-                    self._finish_queued_database_update(
-                        task.db_log_context, result, sender_bot_id=sender_bot_id,
-                    )
-                else:
-                    self._finish_queued_database_update(task.db_log_context)
-
-            except telegram.error.RetryAfter as e:
-                should_cleanup = False
-                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
-                TelegramBotManager._requeue_after_telegram_rate_limit(
-                    self, task, sender_bot_id, retry_after or 60.0
-                )
-
-            except telegram.error.BadRequest as e:
-                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
-                if retry_after is not None:
-                    should_cleanup = False
-                    TelegramBotManager._requeue_after_telegram_rate_limit(
-                        self, task, sender_bot_id, retry_after
-                    )
-                    continue
-                self._release_reserved_slot(sender_bot_id, task.chat_id)
-                self.logger.warning(
-                    "Non-retryable BadRequest for queued task %s, dropping: %s "
-                    "(chat_id=%s, reply_to_message_id=%s, message_thread_id=%s, method=%s)",
-                    task.task_id, e, task.chat_id,
-                    task.kwargs.get("reply_to_message_id"),
-                    task.kwargs.get("message_thread_id"),
-                    getattr(task.function, "__name__", repr(task.function)),
-                )
-                self._finish_queued_database_update(task.db_log_context)
-
-            except (telegram.error.TimedOut, telegram.error.NetworkError) as e:
-                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
-                if retry_after is not None:
-                    should_cleanup = False
-                    TelegramBotManager._requeue_after_telegram_rate_limit(
-                        self, task, sender_bot_id, retry_after
-                    )
-                    continue
-                should_cleanup = False
-                self.logger.warning(
-                    "Transient error for queued task %s, retrying: %s",
-                    task.task_id, e,
-                )
-                self._release_reserved_slot(sender_bot_id, task.chat_id)
-                self._requeue_send_task(task)
-
-            except telegram.error.Forbidden as e:
-                self._release_reserved_slot(sender_bot_id, task.chat_id)
-                if sender_bot_id and self.bot_pool:
-                    aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
-                    if aux_bot:
-                        aux_bot.update_membership(task.chat_id, False)
-                        should_cleanup = False
-                        self.logger.warning(
-                            "Aux bot %s got Forbidden in chat %s for queued task %s; "
-                            "marking it as non-member for this chat and retrying.",
-                            sender_bot_id, task.chat_id, task.task_id,
-                        )
-                        self._requeue_send_task(task)
-                        continue
-                if sender_bot_id is None:
-                    self.logger.error(
-                        "Main bot got Forbidden in chat %s for queued task %s; dropping task: %s",
-                        task.chat_id, task.task_id, e,
-                    )
-                else:
-                    self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                self._finish_queued_database_update(task.db_log_context)
-
-            except telegram.error.TelegramError as e:
-                retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
-                if retry_after is not None:
-                    should_cleanup = False
-                    TelegramBotManager._requeue_after_telegram_rate_limit(
-                        self, task, sender_bot_id, retry_after
-                    )
-                    continue
-                self._release_reserved_slot(sender_bot_id, task.chat_id)
-                self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                self._finish_queued_database_update(task.db_log_context)
+                self._finish_successful_send(task, result, sender_bot_id)
 
             except Exception as e:
+                retry_after = self._rate_limit_retry_after_seconds(e)
+                if retry_after is not None:
+                    should_cleanup = False
+                    self._requeue_after_telegram_rate_limit(
+                        task, sender_bot_id, retry_after
+                    )
+                    continue
+
+                if isinstance(e, telegram.error.BadRequest):
+                    self._release_reserved_slot(sender_bot_id, task.chat_id)
+                    self.logger.warning(
+                        "Non-retryable BadRequest for queued task %s, dropping: %s "
+                        "(chat_id=%s, reply_to_message_id=%s, message_thread_id=%s, method=%s)",
+                        task.task_id, e, task.chat_id,
+                        task.kwargs.get("reply_to_message_id"),
+                        task.kwargs.get("message_thread_id"),
+                        getattr(task.function, "__name__", repr(task.function)),
+                    )
+                    self._finish_failed_send(task, e)
+                    continue
+
+                if isinstance(e, (telegram.error.TimedOut, telegram.error.NetworkError)):
+                    should_cleanup = False
+                    self.logger.warning(
+                        "Transient error for queued task %s, retrying: %s",
+                        task.task_id, e,
+                    )
+                    self._release_reserved_slot(sender_bot_id, task.chat_id)
+                    self._requeue_send_task(task)
+                    continue
+
+                if isinstance(e, telegram.error.Forbidden):
+                    self._release_reserved_slot(sender_bot_id, task.chat_id)
+                    if sender_bot_id and self.bot_pool:
+                        aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
+                        if aux_bot:
+                            aux_bot.update_membership(task.chat_id, False)
+                            should_cleanup = False
+                            self.logger.warning(
+                                "Aux bot %s got Forbidden in chat %s for queued task %s; "
+                                "marking it as non-member for this chat and retrying.",
+                                sender_bot_id, task.chat_id, task.task_id,
+                            )
+                            self._requeue_send_task(task)
+                            continue
+                    if sender_bot_id is None:
+                        self.logger.error(
+                            "Main bot got Forbidden in chat %s for queued task %s; dropping task: %s",
+                            task.chat_id, task.task_id, e,
+                        )
+                    else:
+                        self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
+                    self._finish_failed_send(task, e)
+                    continue
+
                 self._release_reserved_slot(sender_bot_id, task.chat_id)
                 self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                self._finish_queued_database_update(task.db_log_context)
+                self._finish_failed_send(task, e)
 
             finally:
                 if should_cleanup:
-                    for path in task.cleanup_files:
-                        try:
-                            os.unlink(path)
-                            self.logger.debug("Cleaned up queued task temp file: %s", path)
-                        except OSError as e:
-                            self.logger.warning("Failed to clean up temp file %s: %s", path, e)
+                    self._cleanup_queued_task_files(task)
 
     def _run_database_update_callback(self, on_complete: Optional[Callable[[], None]]):
         if on_complete is None:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -5,6 +5,7 @@ import html
 import io
 import logging
 import os
+import re
 import threading
 import time
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -63,6 +64,18 @@ P = ParamSpec("P")
 T = TypeVar("T")
 BotMethod: TypeAlias = Callable[..., object]
 _QUEUED_DATABASE_UPDATE_DROPPED = object()
+_INTERNAL_KWARGS = frozenset({
+    '_bypass_rate_limit',
+    '_sender_bot_id',
+    '_slave_id',
+    '_send_mode',
+    '_force_main_bot',
+    '_force_sender_known',
+    '_force_sender_bot_id',
+    '_timing_receive_monotonic',
+    '_timing_destination_monotonic',
+    '_skip_rate_limit_retry',
+})
 
 
 class SyncBotProtocol(Protocol):
@@ -378,6 +391,7 @@ class TelegramBotManager(LocaleMixin):
     bot_pool: Optional['BotPool']
     _send_worker_stop: threading.Event
     _send_queues_lock: threading.Lock
+    _stopping: threading.Event
     _cleanup_tls: threading.local
     _tls: threading.local
     _aux_recent_use: dict[int, float]
@@ -499,21 +513,27 @@ class TelegramBotManager(LocaleMixin):
                     cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]
                     self._cleanup_tls.pending_cleanup = []
 
-                    if send_mode == 'eventual' and not is_edit_method and not has_callback and slave_id:
-                        if force_sender_known:
-                            kwargs = dict(kwargs)
-                            kwargs['_force_sender_known'] = True
-                            kwargs['_force_sender_bot_id'] = forced_sender_bot_id
-                        return self._enqueue_eventual_send(
-                            str(slave_id),
-                            int(chat_id),
-                            fn,
-                            (self,) + args,
-                            kwargs,
-                            cleanup_files=cleanup_files,
-                            timing_receive_monotonic=timing_receive_monotonic,
-                            timing_destination_monotonic=timing_destination_monotonic,
-                        )
+                    if send_mode == 'eventual':
+                        if not slave_id:
+                            self.logger.warning(
+                                "Eventual send requested for chat %s without _slave_id; falling back to blocking.",
+                                chat_id,
+                            )
+                        elif not is_edit_method and not has_callback:
+                            if force_sender_known:
+                                kwargs = dict(kwargs)
+                                kwargs['_force_sender_known'] = True
+                                kwargs['_force_sender_bot_id'] = forced_sender_bot_id
+                            return self._enqueue_eventual_send(
+                                str(slave_id),
+                                int(chat_id),
+                                fn,
+                                (self,) + args,
+                                kwargs,
+                                cleanup_files=cleanup_files,
+                                timing_receive_monotonic=timing_receive_monotonic,
+                                timing_destination_monotonic=timing_destination_monotonic,
+                            )
 
                     message_thread_id = kwargs.get('message_thread_id')
                     allow_aux_fallback = not (
@@ -792,7 +812,7 @@ class TelegramBotManager(LocaleMixin):
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
         config = self.channel.config
-        self._stopping = False
+        self._stopping = threading.Event()
 
         req_kwargs = {
             'read_timeout': 15.0,
@@ -887,6 +907,7 @@ class TelegramBotManager(LocaleMixin):
         # Per-target concurrency tracking
         self._send_in_flight: dict[SendTarget, tuple] = {}  # target -> (Future, task, sender_bot_id)
         self._bot_chat_disabled_until: dict[tuple, float] = {}  # (bot_id|None, chat_id) -> RetryAfter deadline
+        self._target_retry_after: dict[SendTarget, float] = {}
 
         # Thread pool for non-blocking sends
         self._send_worker_count = self.DEFAULT_SEND_WORKER_COUNT
@@ -903,6 +924,8 @@ class TelegramBotManager(LocaleMixin):
         self._rendezvous_ttl = 600.0          # 10 minutes
         self._rendezvous_cleanup_interval = 300.0  # 5 minutes
         self._last_rendezvous_cleanup = time.time()
+        self._last_queue_stats_log = time.time()
+        self._queue_stats_log_interval = 60.0
 
         # DB write retry queue
         self._db_retry_queue: list[tuple] = []
@@ -1491,7 +1514,7 @@ class TelegramBotManager(LocaleMixin):
         enqueued_at = time.monotonic()
         with self._send_queues_lock:
             self._tasks_enqueued += 1
-            task_id = f"{slave_id}_{chat_id}_{self._tasks_enqueued}_{time.time_ns()}"
+            task_id = f"{slave_id}_{chat_id}_{self._tasks_enqueued}"
             task = QueuedSendTask(
                 target=target,
                 function=function,
@@ -1515,7 +1538,11 @@ class TelegramBotManager(LocaleMixin):
         with self._send_queues_lock:
             dispatchable_targets = [
                 target for target, q in self._send_queues.items()
-                if q and target not in self._send_in_flight
+                if (
+                    q
+                    and target not in self._send_in_flight
+                    and self._target_retry_after.get(target, 0.0) <= now
+                )
             ]
 
         for target in dispatchable_targets:
@@ -1545,6 +1572,9 @@ class TelegramBotManager(LocaleMixin):
                     now=now,
                 )
             if sender_bot is None or wait_time > 0:
+                if sender_bot_id is not None:
+                    self._release_reserved_slot(sender_bot_id, task.chat_id)
+                self._target_retry_after[task.target] = now + max(float(wait_time or 0.0), 0.05)
                 self._requeue_send_task(task)
                 continue
 
@@ -1584,6 +1614,26 @@ class TelegramBotManager(LocaleMixin):
                     expired = [k for k, v in self._bot_chat_disabled_until.items() if v <= now]
                     for k in expired:
                         del self._bot_chat_disabled_until[k]
+                if self._target_retry_after:
+                    expired = [k for k, v in self._target_retry_after.items() if v <= now]
+                    for k in expired:
+                        del self._target_retry_after[k]
+                if now - self._last_queue_stats_log >= self._queue_stats_log_interval:
+                    with self._send_queues_lock:
+                        queued_targets = len(self._send_queues)
+                        queued_tasks = sum(len(q) for q in self._send_queues.values())
+                        in_flight = len(self._send_in_flight)
+                        retry_targets = len(self._target_retry_after)
+                    with self._db_retry_lock:
+                        db_retries = len(self._db_retry_queue)
+                    if queued_tasks or in_flight or retry_targets or self._bot_chat_disabled_until or db_retries:
+                        self.logger.info(
+                            "Queued send backlog: queued_tasks=%d queued_targets=%d "
+                            "in_flight=%d retry_targets=%d disabled_bot_chats=%d db_retries=%d",
+                            queued_tasks, queued_targets, in_flight, retry_targets,
+                            len(self._bot_chat_disabled_until), db_retries,
+                        )
+                    self._last_queue_stats_log = now
                 if now - self._last_rendezvous_cleanup > self._rendezvous_cleanup_interval:
                     self._cleanup_stale_rendezvous()
                     self._last_rendezvous_cleanup = now
@@ -1607,12 +1657,10 @@ class TelegramBotManager(LocaleMixin):
         """Submit a send operation to the thread pool."""
 
         def _do_send():
-            send_kwargs = dict(task.kwargs)
-            send_kwargs.pop('_force_sender_known', None)
-            send_kwargs.pop('_force_sender_bot_id', None)
-            send_kwargs.pop('_slave_id', None)
-            send_kwargs.pop('_timing_receive_monotonic', None)
-            send_kwargs.pop('_timing_destination_monotonic', None)
+            send_kwargs = {
+                key: value for key, value in task.kwargs.items()
+                if key not in _INTERNAL_KWARGS
+            }
             send_kwargs['_skip_rate_limit_retry'] = True
             with self._using_bot(sender_bot):
                 return task.function(*task.args, **send_kwargs)
@@ -1636,19 +1684,33 @@ class TelegramBotManager(LocaleMixin):
             if isinstance(retry_after_value, timedelta):
                 return retry_after_value.total_seconds()
             return float(retry_after_value)
-        error_text = str(error)
-        if "Too Many Requests" in error_text or "429" in error_text or "Flood" in error_text:
+        response = getattr(getattr(error, "__cause__", None), "response", None)
+        if getattr(response, "status_code", None) == 429:
             return 60.0
+        for error_text in (getattr(error, "message", None), str(error)):
+            if not error_text:
+                continue
+            retry_after_match = re.search(
+                r"(?:retry after|retry_after|retry in)\s+(\d+(?:\.\d+)?)",
+                error_text,
+                re.IGNORECASE,
+            )
+            if retry_after_match:
+                return float(retry_after_match.group(1))
+            if re.search(r"Too Many Requests|\b429\b|Flood", error_text, re.IGNORECASE):
+                return 60.0
         return None
 
     def _requeue_after_telegram_rate_limit(self, task: QueuedSendTask,
                                            sender_bot_id: Optional[str],
                                            retry_after: float):
         self.logger.warning(
-            "Telegram rate limit for bot %s in chat %d (task %s): %.2fs; other bots can still send",
+            "Telegram rate limit for bot %s in chat %d (task %s): %.2fs; other targets can still send",
             sender_bot_id or "main", task.chat_id, task.task_id, retry_after,
         )
-        self._bot_chat_disabled_until[(sender_bot_id, task.chat_id)] = time.time() + retry_after
+        deadline = time.time() + retry_after
+        self._bot_chat_disabled_until[(sender_bot_id, task.chat_id)] = deadline
+        self._target_retry_after[task.target] = deadline
         self._release_reserved_slot(sender_bot_id, task.chat_id)
         self._requeue_send_task(task)
 
@@ -1738,7 +1800,13 @@ class TelegramBotManager(LocaleMixin):
                         )
                         self._requeue_send_task(task)
                         continue
-                self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
+                if sender_bot_id is None:
+                    self.logger.error(
+                        "Main bot got Forbidden in chat %s for queued task %s; dropping task: %s",
+                        task.chat_id, task.task_id, e,
+                    )
+                else:
+                    self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
                 TelegramBotManager._drop_queued_database_update(self, task.task_id)
 
             except telegram.error.TelegramError as e:
@@ -1775,9 +1843,6 @@ class TelegramBotManager(LocaleMixin):
         except Exception as e:
             self.logger.warning("Database update completion callback failed: %s", e)
 
-    def _queued_rendezvous_maps(self) -> tuple[dict[str, tuple], dict[str, tuple]]:
-        return self._pending_queued_logs, self._completed_queued_results
-
     @staticmethod
     def _queued_log_callback(entry: Optional[tuple]) -> Optional[Callable[[], None]]:
         if entry is not None and len(entry) >= 4:
@@ -1790,7 +1855,8 @@ class TelegramBotManager(LocaleMixin):
             return
         pending_update = None
         with self._pending_logs_lock:
-            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_logs = self._pending_queued_logs
+            completed_results = self._completed_queued_results
             pending_update = pending_logs.pop(task_id, None)
             if pending_update is None:
                 completed_results[task_id] = (
@@ -1912,7 +1978,8 @@ class TelegramBotManager(LocaleMixin):
         """Remove rendezvous entries that were never paired within the TTL."""
         cutoff = time.time() - self._rendezvous_ttl
         with self._pending_logs_lock:
-            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_logs = self._pending_queued_logs
+            completed_results = self._completed_queued_results
             stale_logs = [
                 tid for tid, entry in pending_logs.items()
                 if len(entry) >= 3 and entry[2] < cutoff
@@ -1966,7 +2033,8 @@ class TelegramBotManager(LocaleMixin):
         """
         completed_result: Optional[tuple]
         with self._pending_logs_lock:
-            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_logs = self._pending_queued_logs
+            completed_results = self._completed_queued_results
             completed_result = completed_results.pop(task_id, None)
             if completed_result is None:
                 if on_complete is not None:
@@ -2008,7 +2076,8 @@ class TelegramBotManager(LocaleMixin):
         """
         pending_update = None
         with self._pending_logs_lock:
-            pending_logs, completed_results = TelegramBotManager._queued_rendezvous_maps(self)
+            pending_logs = self._pending_queued_logs
+            completed_results = self._completed_queued_results
             pending_update = pending_logs.pop(task_id, None)
             if pending_update is None:
                 completed_results[task_id] = (real_tg_msg, sender_bot_id, time.time())
@@ -2560,7 +2629,9 @@ class TelegramBotManager(LocaleMixin):
 
     def graceful_stop(self):
         """Gracefully stop the bot"""
-        self._stopping = True
+        if not hasattr(self, '_stopping') or not hasattr(self._stopping, 'set'):
+            self._stopping = threading.Event()
+        self._stopping.set()
         self.logger.info("Starting graceful shutdown...")
 
         # Log pending tasks count before stopping

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -1641,7 +1641,7 @@ class TelegramBotManager(LocaleMixin):
 
         if result and hasattr(result, 'message_id'):
             self._finish_queued_database_update(
-                task.db_log_context, result, sender_bot_id=sender_bot_id,
+                task.db_log_context, cast(TelegramMessage, result), sender_bot_id=sender_bot_id,
             )
         else:
             self._finish_queued_database_update(task.db_log_context)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -773,6 +773,7 @@ class TelegramBotManager(LocaleMixin):
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
         config = self.channel.config
+        self._stopping = False
 
         req_kwargs = {
             'read_timeout': 15.0,
@@ -2507,6 +2508,7 @@ class TelegramBotManager(LocaleMixin):
 
     def graceful_stop(self):
         """Gracefully stop the bot"""
+        self._stopping = True
         self.logger.info("Starting graceful shutdown...")
 
         # Log pending tasks count before stopping

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Collection, Coroutine, Deque, List, Literal, Mapping, NamedTuple, Optional, ParamSpec, Protocol, TypeAlias, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Collection, Coroutine, List, Literal, Mapping, NamedTuple, Optional, ParamSpec, Protocol, TypeAlias, Tuple, TypeVar, cast
 from urllib.parse import quote, urlparse, urlunparse
 from urllib.request import url2pathname
 from unittest.mock import Mock, patch
@@ -38,6 +38,13 @@ from .utils import TelegramChatID, TelegramMessageID, message_id_to_str
 SendTarget: TypeAlias = Tuple[str, int]
 
 
+class QueuedDbLogContext(NamedTuple):
+    """Database log context carried by a queued send task."""
+    etm_msg: object
+    old_msg_id: object = None
+    on_complete: Optional[Callable[[], None]] = None
+
+
 class QueuedSendTask(NamedTuple):
     """Represents an in-memory FIFO send task."""
     target: SendTarget
@@ -47,6 +54,7 @@ class QueuedSendTask(NamedTuple):
     task_id: str
     cleanup_files: tuple[str, ...] = ()
     enqueued_at: float = 0.0
+    db_log_context: Optional[QueuedDbLogContext] = None
 
     @property
     def slave_id(self) -> str:
@@ -63,7 +71,6 @@ MAX_CALLBACK_QUERY_ANSWER_LENGTH = 200
 P = ParamSpec("P")
 T = TypeVar("T")
 BotMethod: TypeAlias = Callable[..., object]
-_QUEUED_DATABASE_UPDATE_DROPPED = object()
 _INTERNAL_KWARGS = frozenset({
     '_bypass_rate_limit',
     '_sender_bot_id',
@@ -74,6 +81,7 @@ _INTERNAL_KWARGS = frozenset({
     '_force_sender_bot_id',
     '_timing_receive_monotonic',
     '_timing_destination_monotonic',
+    '_queued_db_log_context',
     '_skip_rate_limit_retry',
 })
 
@@ -915,22 +923,8 @@ class TelegramBotManager(LocaleMixin):
             max_workers=self._send_worker_count, thread_name_prefix="ETM-send",
         )
 
-        # Rendezvous dicts for queued DB updates — with timestamps for TTL cleanup
-        # task_id -> (etm_msg, old_msg_id, registered_at)
-        self._pending_queued_logs: dict[str, tuple] = {}
-        # task_id -> (real_tg_msg, sender_bot_id, completed_at), or a dropped marker
-        self._completed_queued_results: dict[str, tuple] = {}
-        self._pending_logs_lock = threading.Lock()
-        self._rendezvous_ttl = 600.0          # 10 minutes
-        self._rendezvous_cleanup_interval = 300.0  # 5 minutes
-        self._last_rendezvous_cleanup = time.time()
         self._last_queue_stats_log = time.time()
         self._queue_stats_log_interval = 60.0
-
-        # DB write retry queue
-        self._db_retry_queue: list[tuple] = []
-        self._db_retry_lock = threading.Lock()
-        self._db_max_retries = 5
 
         self._send_worker_thread = threading.Thread(
             target=self._queued_send_worker,
@@ -1198,6 +1192,7 @@ class TelegramBotManager(LocaleMixin):
         timing_destination_monotonic: Optional[float] = None,
     ) -> SendReceipt:
         kwargs = dict(kwargs)
+        db_log_context = kwargs.pop('_queued_db_log_context', None)
         for key in ('photo', 'document', 'video', 'animation', 'audio', 'voice', 'sticker'):
             if key in kwargs:
                 kwargs[key] = _clone_file_argument(kwargs[key])
@@ -1212,6 +1207,7 @@ class TelegramBotManager(LocaleMixin):
             args=args,
             kwargs=kwargs,
             cleanup_files=cleanup_files,
+            db_log_context=db_log_context,
         )
         now = time.monotonic()
         if timing_receive_monotonic is not None:
@@ -1508,7 +1504,8 @@ class TelegramBotManager(LocaleMixin):
 
     def _enqueue_send_task(self, target: SendTarget, function: Callable,
                            args: tuple, kwargs: dict,
-                           cleanup_files: Optional[list] = None) -> str:
+                           cleanup_files: Optional[list] = None,
+                           db_log_context: Optional[QueuedDbLogContext] = None) -> str:
         """Append a task to the per-target FIFO queue."""
         slave_id, chat_id = target
         enqueued_at = time.monotonic()
@@ -1523,6 +1520,7 @@ class TelegramBotManager(LocaleMixin):
                 task_id=task_id,
                 cleanup_files=tuple(cleanup_files or ()),
                 enqueued_at=enqueued_at,
+                db_log_context=db_log_context,
             )
             q = self._send_queues.setdefault(target, collections.deque())
             q.append(task)
@@ -1607,8 +1605,6 @@ class TelegramBotManager(LocaleMixin):
                 self._dispatch_ready_send_tasks(now)
 
                 # ── 3. Housekeeping ──
-                self._process_db_retry_queue()
-
                 # Purge expired disabled bot/chat entries
                 if self._bot_chat_disabled_until:
                     expired = [k for k, v in self._bot_chat_disabled_until.items() if v <= now]
@@ -1624,19 +1620,14 @@ class TelegramBotManager(LocaleMixin):
                         queued_tasks = sum(len(q) for q in self._send_queues.values())
                         in_flight = len(self._send_in_flight)
                         retry_targets = len(self._target_retry_after)
-                    with self._db_retry_lock:
-                        db_retries = len(self._db_retry_queue)
-                    if queued_tasks or in_flight or retry_targets or self._bot_chat_disabled_until or db_retries:
+                    if queued_tasks or in_flight or retry_targets or self._bot_chat_disabled_until:
                         self.logger.info(
                             "Queued send backlog: queued_tasks=%d queued_targets=%d "
-                            "in_flight=%d retry_targets=%d disabled_bot_chats=%d db_retries=%d",
+                            "in_flight=%d retry_targets=%d disabled_bot_chats=%d",
                             queued_tasks, queued_targets, in_flight, retry_targets,
-                            len(self._bot_chat_disabled_until), db_retries,
+                            len(self._bot_chat_disabled_until),
                         )
                     self._last_queue_stats_log = now
-                if now - self._last_rendezvous_cleanup > self._rendezvous_cleanup_interval:
-                    self._cleanup_stale_rendezvous()
-                    self._last_rendezvous_cleanup = now
 
                 self._send_worker_stop.wait(timeout=0.05)
 
@@ -1738,11 +1729,11 @@ class TelegramBotManager(LocaleMixin):
                     self.logger.debug("Queued send task %s completed successfully", task.task_id)
 
                 if result and hasattr(result, 'message_id'):
-                    self._handle_queued_database_update(
-                        task.task_id, result, sender_bot_id=sender_bot_id,
+                    self._finish_queued_database_update(
+                        task.db_log_context, result, sender_bot_id=sender_bot_id,
                     )
                 else:
-                    TelegramBotManager._drop_queued_database_update(self, task.task_id)
+                    self._finish_queued_database_update(task.db_log_context)
 
             except telegram.error.RetryAfter as e:
                 should_cleanup = False
@@ -1768,7 +1759,7 @@ class TelegramBotManager(LocaleMixin):
                     task.kwargs.get("message_thread_id"),
                     getattr(task.function, "__name__", repr(task.function)),
                 )
-                TelegramBotManager._drop_queued_database_update(self, task.task_id)
+                self._finish_queued_database_update(task.db_log_context)
 
             except (telegram.error.TimedOut, telegram.error.NetworkError) as e:
                 retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
@@ -1807,7 +1798,7 @@ class TelegramBotManager(LocaleMixin):
                     )
                 else:
                     self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                TelegramBotManager._drop_queued_database_update(self, task.task_id)
+                self._finish_queued_database_update(task.db_log_context)
 
             except telegram.error.TelegramError as e:
                 retry_after = TelegramBotManager._rate_limit_retry_after_seconds(e)
@@ -1819,12 +1810,12 @@ class TelegramBotManager(LocaleMixin):
                     continue
                 self._release_reserved_slot(sender_bot_id, task.chat_id)
                 self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                TelegramBotManager._drop_queued_database_update(self, task.task_id)
+                self._finish_queued_database_update(task.db_log_context)
 
             except Exception as e:
                 self._release_reserved_slot(sender_bot_id, task.chat_id)
                 self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
-                TelegramBotManager._drop_queued_database_update(self, task.task_id)
+                self._finish_queued_database_update(task.db_log_context)
 
             finally:
                 if should_cleanup:
@@ -1843,32 +1834,7 @@ class TelegramBotManager(LocaleMixin):
         except Exception as e:
             self.logger.warning("Database update completion callback failed: %s", e)
 
-    @staticmethod
-    def _queued_log_callback(entry: Optional[tuple]) -> Optional[Callable[[], None]]:
-        if entry is not None and len(entry) >= 4:
-            return entry[3]
-        return None
-
-    def _drop_queued_database_update(self, task_id: str):
-        """Release bookkeeping for a queued task that will not produce a Telegram message."""
-        if not hasattr(self, '_pending_logs_lock'):
-            return
-        pending_update = None
-        with self._pending_logs_lock:
-            pending_logs = self._pending_queued_logs
-            completed_results = self._completed_queued_results
-            pending_update = pending_logs.pop(task_id, None)
-            if pending_update is None:
-                completed_results[task_id] = (
-                    _QUEUED_DATABASE_UPDATE_DROPPED, None, time.time()
-                )
-            else:
-                completed_results.pop(task_id, None)
-        TelegramBotManager._run_database_update_callback(
-            self, TelegramBotManager._queued_log_callback(pending_update)
-        )
-
-    def _finalize_queued_database_update(
+    def _write_database_update(
         self,
         etm_msg,
         old_msg_id,
@@ -1877,12 +1843,7 @@ class TelegramBotManager(LocaleMixin):
         sender_bot_id: Optional[str] = None,
         on_complete: Optional[Callable[[], None]] = None,
     ):
-        """Write the send result to the database.
-
-        On failure the write is pushed to a retry queue instead of being
-        silently dropped — a lost mapping would cause subsequent edits /
-        deletes to create duplicate messages.
-        """
+        """Write a sent Telegram message to the database once."""
         try:
             etm_msg.type_telegram = get_msg_type(real_tg_msg)
             etm_msg.put_telegram_file(real_tg_msg)
@@ -1892,113 +1853,34 @@ class TelegramBotManager(LocaleMixin):
                 old_msg_id,
                 sender_bot_id=sender_bot_id,
             )
-            TelegramBotManager._run_database_update_callback(self, on_complete)
         except Exception as e:
             self.logger.warning(
-                "DB write failed for tg_msg %s, queuing for retry: %s",
+                "DB write failed for tg_msg %s, dropping mapping: %s",
                 getattr(real_tg_msg, 'message_id', '?'),
                 e,
             )
-            TelegramBotManager._enqueue_db_retry(
-                self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, on_complete=on_complete
-            )
+        finally:
+            self._run_database_update_callback(on_complete)
 
-    def _enqueue_db_retry(self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
-                          attempt: int = 0,
-                          on_complete: Optional[Callable[[], None]] = None):
-        """Push a failed DB write into the retry queue with exponential back-off."""
-        next_retry_at = time.time() + min(2 ** attempt, 30)  # cap at 30 s
-        with self._db_retry_lock:
-            self._db_retry_queue.append(
-                (etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
-                 attempt + 1, next_retry_at, on_complete)
-            )
-
-    def _process_db_retry_queue(self):
-        """Process pending DB-write retries.  Called from the worker loop."""
-        if not self._db_retry_queue:
+    def _finish_queued_database_update(
+        self,
+        db_log_context: Optional[QueuedDbLogContext],
+        real_tg_msg: Optional[TelegramMessage] = None,
+        *,
+        sender_bot_id: Optional[str] = None,
+    ):
+        if db_log_context is None:
             return
-
-        current_time = time.time()
-        still_pending: list[tuple] = []
-
-        with self._db_retry_lock:
-            items = self._db_retry_queue[:]
-            self._db_retry_queue.clear()
-
-        for item in items:
-            if len(item) >= 7:
-                etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at, on_complete = item
-            else:
-                etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, next_retry_at = item
-                on_complete = None
-            if current_time < next_retry_at:
-                still_pending.append(
-                    (etm_msg, old_msg_id, real_tg_msg, sender_bot_id,
-                     attempt, next_retry_at, on_complete)
-                )
-                continue
-            try:
-                self.channel.db.add_or_update_message_log(
-                    etm_msg,
-                    real_tg_msg,
-                    old_msg_id,
-                    sender_bot_id=sender_bot_id,
-                )
-                self.logger.info(
-                    "DB retry succeeded for tg_msg %s (attempt %d)",
-                    getattr(real_tg_msg, 'message_id', '?'),
-                    attempt,
-                )
-                TelegramBotManager._run_database_update_callback(self, on_complete)
-            except Exception as e:
-                if attempt >= self._db_max_retries:
-                    self.logger.error(
-                        "DB write permanently failed after %d attempts for tg_msg %s: %s",
-                        attempt,
-                        getattr(real_tg_msg, 'message_id', '?'),
-                        e,
-                    )
-                else:
-                    self.logger.warning(
-                        "DB retry %d failed for tg_msg %s, will retry: %s",
-                        attempt,
-                        getattr(real_tg_msg, 'message_id', '?'),
-                        e,
-                    )
-                    TelegramBotManager._enqueue_db_retry(
-                        self, etm_msg, old_msg_id, real_tg_msg, sender_bot_id, attempt, on_complete=on_complete
-                    )
-
-        if still_pending:
-            with self._db_retry_lock:
-                self._db_retry_queue.extend(still_pending)
-
-    def _cleanup_stale_rendezvous(self):
-        """Remove rendezvous entries that were never paired within the TTL."""
-        cutoff = time.time() - self._rendezvous_ttl
-        with self._pending_logs_lock:
-            pending_logs = self._pending_queued_logs
-            completed_results = self._completed_queued_results
-            stale_logs = [
-                tid for tid, entry in pending_logs.items()
-                if len(entry) >= 3 and entry[2] < cutoff
-            ]
-            for tid in stale_logs:
-                TelegramBotManager._run_database_update_callback(
-                    self,
-                    TelegramBotManager._queued_log_callback(pending_logs.get(tid)),
-                )
-                del pending_logs[tid]
-                self.logger.warning("Rendezvous TTL: dropped stale pending log for task %s", tid)
-
-            stale_results = [
-                tid for tid, entry in completed_results.items()
-                if len(entry) >= 3 and entry[2] < cutoff
-            ]
-            for tid in stale_results:
-                del completed_results[tid]
-                self.logger.warning("Rendezvous TTL: dropped stale completed result for task %s", tid)
+        if real_tg_msg is None:
+            self._run_database_update_callback(db_log_context.on_complete)
+            return
+        self._write_database_update(
+            db_log_context.etm_msg,
+            db_log_context.old_msg_id,
+            real_tg_msg,
+            sender_bot_id=sender_bot_id,
+            on_complete=db_log_context.on_complete,
+        )
 
     def submit_async_db_write(
         self,
@@ -2009,92 +1891,14 @@ class TelegramBotManager(LocaleMixin):
         sender_bot_id: Optional[str] = None,
         on_complete: Optional[Callable[[], None]] = None,
     ):
-        """Fire-and-forget database write, usable from both blocking and eventual paths.
-
-        Failures are caught and routed to the retry queue — callers should
-        NEVER re-send to Telegram on a DB-write error.
-        """
-        TelegramBotManager._finalize_queued_database_update(
-            self,
-            etm_msg, old_msg_id, real_tg_msg,
-            sender_bot_id=sender_bot_id,
-            on_complete=on_complete,
-        )
-
-    def register_queued_database_update(self, task_id: str, etm_msg, old_msg_id=None,
-                                         on_complete: Optional[Callable[[], None]] = None):
-        """
-        Register a pending database update for a queued task.
-
-        Args:
-            task_id: Task identifier from queued execution
-            etm_msg: ETMMsg object to log
-            old_msg_id: Optional old message ID for updates
-        """
-        completed_result: Optional[tuple]
-        with self._pending_logs_lock:
-            pending_logs = self._pending_queued_logs
-            completed_results = self._completed_queued_results
-            completed_result = completed_results.pop(task_id, None)
-            if completed_result is None:
-                if on_complete is not None:
-                    pending_logs[task_id] = (etm_msg, old_msg_id, time.time(), on_complete)
-                else:
-                    pending_logs[task_id] = (etm_msg, old_msg_id, time.time())
-                self.logger.debug("Registered queued database update for task %s", task_id)
-                return
-
-        if completed_result[0] is _QUEUED_DATABASE_UPDATE_DROPPED:
-            self.logger.debug("Queued task %s was dropped before database registration", task_id)
-            TelegramBotManager._run_database_update_callback(self, on_complete)
-            return
-
-        real_tg_msg, sender_bot_id = completed_result[0], completed_result[1]
-        self.logger.debug("Finalizing already-completed queued task %s", task_id)
-        TelegramBotManager._finalize_queued_database_update(
-            self,
+        """Write database mapping after a blocking send has succeeded."""
+        self._write_database_update(
             etm_msg,
             old_msg_id,
             real_tg_msg,
             sender_bot_id=sender_bot_id,
             on_complete=on_complete,
         )
-
-    def _handle_queued_database_update(
-        self,
-        task_id: str,
-        real_tg_msg,
-        *,
-        sender_bot_id: Optional[str] = None,
-    ):
-        """
-        Handle database update when queued task completes.
-
-        Args:
-            task_id: Task identifier
-            real_tg_msg: The real Telegram message that was sent
-        """
-        pending_update = None
-        with self._pending_logs_lock:
-            pending_logs = self._pending_queued_logs
-            completed_results = self._completed_queued_results
-            pending_update = pending_logs.pop(task_id, None)
-            if pending_update is None:
-                completed_results[task_id] = (real_tg_msg, sender_bot_id, time.time())
-                self.logger.debug("Stored queued result for task %s until database registration is ready", task_id)
-                return
-
-        etm_msg, old_msg_id = pending_update[0], pending_update[1]
-        on_complete = TelegramBotManager._queued_log_callback(pending_update)
-        TelegramBotManager._finalize_queued_database_update(
-            self,
-            etm_msg,
-            old_msg_id,
-            real_tg_msg,
-            sender_bot_id=sender_bot_id,
-            on_complete=on_complete,
-        )
-        self.logger.debug("Updated database with real message for queued task %s", task_id)
 
     def stop_queued_worker(self):
         """Stop the queued send worker thread."""
@@ -2111,11 +1915,6 @@ class TelegramBotManager(LocaleMixin):
                 self.logger.warning("Queued send worker did not stop gracefully within timeout")
             else:
                 self.logger.debug("Queued send worker stopped successfully")
-
-        # Drain any remaining DB retries before shutdown
-        if hasattr(self, '_db_retry_queue') and self._db_retry_queue:
-            self.logger.info("Processing %d remaining DB retries at shutdown...", len(self._db_retry_queue))
-            self._process_db_retry_queue()
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -388,6 +388,8 @@ class TelegramBotManager(LocaleMixin):
     DEFAULT_SEND_WORKER_COUNT = 8
     DEFAULT_HTTPX_POOL_MULTIPLIER = 2.0
     HTTPX_POOL_MULTIPLIER_ENV = "ETM_HTTPX_POOL_MULTIPLIER"
+    BLOCKING_SEND_TIMEOUT = 300.0
+    BLOCKING_SEND_TARGET_SLAVE_ID = "__blocking__"
 
     # Type declarations for instance attributes assigned in __init__
     application: Application
@@ -1147,8 +1149,10 @@ class TelegramBotManager(LocaleMixin):
             args = args[:2] + (_clone_file_argument(args[2]),) + args[3:]
 
         waiter: Future = Future()
-        target = (slave_id or "__blocking__", int(chat_id))
-        self._enqueue_send_task(
+        # Blocking operations without slave affinity share one per-chat target.
+        # This keeps edit/callback sends ordered after they enter the FIFO.
+        target = (slave_id or self.BLOCKING_SEND_TARGET_SLAVE_ID, int(chat_id))
+        task_id = self._enqueue_send_task(
             target=target,
             function=function,
             args=args,
@@ -1157,7 +1161,21 @@ class TelegramBotManager(LocaleMixin):
             priority=True,
             waiter=waiter,
         )
-        return waiter.result()
+        try:
+            return waiter.result(timeout=self.BLOCKING_SEND_TIMEOUT)
+        except FutureTimeoutError as exc:
+            if waiter.done():
+                return waiter.result(timeout=0)
+            error = RuntimeError(
+                f"Blocking send to chat {chat_id} timed out after {self.BLOCKING_SEND_TIMEOUT:g}s"
+            )
+            removed_task = self._remove_queued_send_task(target, task_id)
+            if removed_task is not None:
+                self._resolve_task_waiter_exception(removed_task, error)
+                self._cleanup_queued_task_files(removed_task)
+            elif not waiter.done():
+                waiter.set_exception(error)
+            raise error from exc
 
     def _select_queued_sender(
         self,
@@ -1192,8 +1210,9 @@ class TelegramBotManager(LocaleMixin):
                 forced_sender_bot_id, chat_id,
             )
 
+        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
+
         if not force_main and forced_sender_bot_id is None and self.bot_pool and not has_callback:
-            main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
             slot = self.bot_pool.acquire_send_slot(
                 chat_id,
                 max_delay=1e-9,
@@ -1209,7 +1228,6 @@ class TelegramBotManager(LocaleMixin):
         if main_disabled > now:
             return None, None, main_disabled - now
 
-        main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         if main_delay <= 0:
             self._calculate_rate_limit_delay(chat_id)  # reserve
             return self._bot, None, 0.0
@@ -1220,6 +1238,20 @@ class TelegramBotManager(LocaleMixin):
         with self._send_queues_lock:
             q = self._send_queues.setdefault(task.target, collections.deque())
             q.appendleft(task)
+
+    def _remove_queued_send_task(self, target: SendTarget, task_id: str) -> Optional[QueuedSendTask]:
+        """Remove a task that has not yet been dispatched."""
+        with self._send_queues_lock:
+            q = self._send_queues.get(target)
+            if not q:
+                return None
+            for task in list(q):
+                if task.task_id == task_id:
+                    q.remove(task)
+                    if not q:
+                        del self._send_queues[target]
+                    return task
+        return None
 
     def _init_bot_pool(self, aux_configs: list, config: dict, channel: 'TelegramChannel'):
         """Initialize the auxiliary bot pool from config."""
@@ -1678,16 +1710,16 @@ class TelegramBotManager(LocaleMixin):
 
         for target, (future, task, sender_bot_id) in completed:
             del self._send_in_flight[target]
-            should_cleanup = True
+            should_cleanup = False
 
             try:
                 result = future.result()  # already done, won't block
                 self._finish_successful_send(task, result, sender_bot_id)
+                should_cleanup = True
 
             except Exception as e:
                 retry_after = self._rate_limit_retry_after_seconds(e)
                 if retry_after is not None:
-                    should_cleanup = False
                     self._requeue_after_telegram_rate_limit(
                         task, sender_bot_id, retry_after
                     )
@@ -1704,10 +1736,10 @@ class TelegramBotManager(LocaleMixin):
                         getattr(task.function, "__name__", repr(task.function)),
                     )
                     self._finish_failed_send(task, e)
+                    should_cleanup = True
                     continue
 
                 if isinstance(e, (telegram.error.TimedOut, telegram.error.NetworkError)):
-                    should_cleanup = False
                     self.logger.warning(
                         "Transient error for queued task %s, retrying: %s",
                         task.task_id, e,
@@ -1722,7 +1754,6 @@ class TelegramBotManager(LocaleMixin):
                         aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
                         if aux_bot:
                             aux_bot.update_membership(task.chat_id, False)
-                            should_cleanup = False
                             self.logger.warning(
                                 "Aux bot %s got Forbidden in chat %s for queued task %s; "
                                 "marking it as non-member for this chat and retrying.",
@@ -1738,11 +1769,13 @@ class TelegramBotManager(LocaleMixin):
                     else:
                         self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
                     self._finish_failed_send(task, e)
+                    should_cleanup = True
                     continue
 
                 self._release_reserved_slot(sender_bot_id, task.chat_id)
                 self.logger.exception(f"Error executing queued task {task.task_id}: {e}")
                 self._finish_failed_send(task, e)
+                should_cleanup = True
 
             finally:
                 if should_cleanup:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -458,8 +458,9 @@ class TelegramBotManager(LocaleMixin):
                         time.sleep(wait_seconds)
                     if chosen_sender_bot_id:
                         try:
-                            with self._using_bot(bot):
-                                result = fn(self, *args, **kwargs)
+                            result = self._call_with_reserved_slot(
+                                bot, chosen_sender_bot_id, chat_id_int, fn, args, kwargs,
+                            )
                             return self._make_send_receipt(result, sender_bot_id=chosen_sender_bot_id)
                         except telegram.error.Forbidden:
                             aux_bot = self.bot_pool.get_bot_by_id(chosen_sender_bot_id)
@@ -477,14 +478,20 @@ class TelegramBotManager(LocaleMixin):
                             sender_bot_id, chat_id,
                         )
                         self._calculate_rate_limit_delay(chat_id_int)
-                        return self._make_send_receipt(fn(self, *args, **kwargs))
+                        result = self._call_with_reserved_slot(
+                            self._bot, None, chat_id_int, fn, args, kwargs,
+                        )
+                        return self._make_send_receipt(result)
                     aux_bot = self.bot_pool.get_bot_by_id(sender_bot_id)
                     if aux_bot:
                         aux_bot.update_membership(chat_id_int, False)
                     wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id_int)
                     if wait_seconds > 0:
                         time.sleep(wait_seconds)
-                    return self._make_send_receipt(fn(self, *args, **kwargs))
+                    result = self._call_with_reserved_slot(
+                        self._bot, None, chat_id_int, fn, args, kwargs,
+                    )
+                    return self._make_send_receipt(result)
 
                 if chat_id:
                     cleanup_files = getattr(self._cleanup_tls, 'pending_cleanup', [])[:]
@@ -523,8 +530,9 @@ class TelegramBotManager(LocaleMixin):
                     if wait_seconds > 0:
                         time.sleep(wait_seconds)
                     try:
-                        with self._using_bot(bot):
-                            result = fn(self, *args, **kwargs)
+                        result = self._call_with_reserved_slot(
+                            bot, chosen_sender_bot_id, int(chat_id), fn, args, kwargs,
+                        )
                         if chosen_sender_bot_id is not None:
                             self._record_aux_use(chat_id)
                         return self._make_send_receipt(result, sender_bot_id=chosen_sender_bot_id)
@@ -541,7 +549,10 @@ class TelegramBotManager(LocaleMixin):
                                 wait_seconds, _, _ = self._calculate_rate_limit_delay(chat_id)
                                 if wait_seconds > 0:
                                     time.sleep(wait_seconds)
-                                return self._make_send_receipt(fn(self, *args, **kwargs))
+                                result = self._call_with_reserved_slot(
+                                    self._bot, None, int(chat_id), fn, args, kwargs,
+                                )
+                                return self._make_send_receipt(result)
                         raise
 
                 return self._make_send_receipt(fn(self, *args, **kwargs))
@@ -1192,6 +1203,15 @@ class TelegramBotManager(LocaleMixin):
             )
         main_delay, _, _ = self._calculate_rate_limit_delay(chat_id, peek_only=True)
         return self._bot, None, main_delay
+
+    def _call_with_reserved_slot(self, bot: object, sender_bot_id: Optional[str],
+                                 chat_id: int, fn: Callable, args: tuple, kwargs: dict):
+        try:
+            with self._using_bot(bot):
+                return fn(self, *args, **kwargs)
+        except Exception:
+            self._release_reserved_slot(sender_bot_id, chat_id)
+            raise
 
     def _select_available_sender(self, chat_id: int, *, slave_id: Optional[str] = None,
                                 has_callback: bool = False,

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -326,7 +326,14 @@ def _has_callback_keyboard(reply_markup) -> bool:
 def _clone_file_argument(value):
     """Copy file-like send arguments so queued tasks don't depend on caller-owned handles."""
     if isinstance(value, InputFile):
-        return InputFile(io.BytesIO(value.input_file_content), filename=value.filename)
+        content = value.input_file_content
+        if hasattr(content, 'read') and hasattr(content, 'seek'):
+            content = _clone_file_argument(content).read()
+        return InputFile(
+            io.BytesIO(content),
+            filename=value.filename,
+            attach=value.attach_name is not None,
+        )
     if hasattr(value, 'read') and hasattr(value, 'seek'):
         current_pos = None
         try:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -857,10 +857,6 @@ class TelegramBotManager(LocaleMixin):
         self._send_in_flight: dict[SendTarget, tuple] = {}  # target -> (Future, task, sender_bot_id)
         self._bot_chat_disabled_until: dict[tuple, float] = {}  # (bot_id|None, chat_id) -> RetryAfter deadline
 
-        # Per-chat send interval (200ms safety gap)
-        self._last_send_by_chat: dict[int, float] = {}
-        self.CHAT_SEND_INTERVAL = 0.2  # seconds
-
         # Thread pool for non-blocking sends
         self._send_worker_count = self.DEFAULT_SEND_WORKER_COUNT
         self._send_executor: ThreadPoolExecutor = ThreadPoolExecutor(
@@ -1604,7 +1600,6 @@ class TelegramBotManager(LocaleMixin):
                 if sender_bot_id is not None:
                     self._record_aux_use(task.chat_id)
 
-                self._last_send_by_chat[task.chat_id] = time.time()
                 self.logger.debug("Queued send task %s completed successfully", task.task_id)
 
                 if result and hasattr(result, 'message_id'):

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -1837,7 +1837,7 @@ class TelegramBotManager(LocaleMixin):
             on_complete=db_log_context.on_complete,
         )
 
-    def submit_async_db_write(
+    def write_db_mapping(
         self,
         etm_msg,
         real_tg_msg: TelegramMessage,
@@ -2224,6 +2224,7 @@ class TelegramBotManager(LocaleMixin):
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
+    @Decorators.handle_rate_limit_error
     @Decorators.caption_affix_decorator
     @Decorators.retry_on_chat_migration
     def edit_message_caption(self, *args, **kwargs):
@@ -2231,6 +2232,7 @@ class TelegramBotManager(LocaleMixin):
 
     @Decorators.rate_limit_decorator
     @Decorators.retry_on_timeout
+    @Decorators.handle_rate_limit_error
     @Decorators.retry_on_chat_migration
     def edit_message_media(self, *args, **kwargs):
         return self._active_bot.edit_message_media(*args, **kwargs)

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -46,6 +46,7 @@ class QueuedSendTask(NamedTuple):
     task_id: str
     arrival_seq: int = 0
     cleanup_files: tuple[str, ...] = ()
+    enqueued_at: float = 0.0
 
     @property
     def slave_id(self) -> str:
@@ -409,6 +410,8 @@ class TelegramBotManager(LocaleMixin):
                 is_edit_method = fn.__name__.startswith('edit_message_')
 
                 # Bypass: caller already reserved a slot and set _using_bot
+                timing_receive_monotonic = kwargs.pop('_timing_receive_monotonic', None)
+                timing_destination_monotonic = kwargs.pop('_timing_destination_monotonic', None)
                 if kwargs.pop('_bypass_rate_limit', False):
                     return fn(self, *args, **kwargs)
 
@@ -509,6 +512,8 @@ class TelegramBotManager(LocaleMixin):
                             (self,) + args,
                             kwargs,
                             cleanup_files=cleanup_files,
+                            timing_receive_monotonic=timing_receive_monotonic,
+                            timing_destination_monotonic=timing_destination_monotonic,
                         )
 
                     message_thread_id = kwargs.get('message_thread_id')
@@ -1167,6 +1172,8 @@ class TelegramBotManager(LocaleMixin):
         kwargs: dict,
         *,
         cleanup_files: Optional[list] = None,
+        timing_receive_monotonic: Optional[float] = None,
+        timing_destination_monotonic: Optional[float] = None,
     ) -> SendReceipt:
         kwargs = dict(kwargs)
         for key in ('photo', 'document', 'video', 'animation', 'audio', 'voice', 'sticker'):
@@ -1184,6 +1191,19 @@ class TelegramBotManager(LocaleMixin):
             kwargs=kwargs,
             cleanup_files=cleanup_files,
         )
+        now = time.monotonic()
+        if timing_receive_monotonic is not None:
+            self.logger.debug(
+                "Queued send task %s enqueued %.3fs after message receive.",
+                task_id,
+                now - timing_receive_monotonic,
+            )
+        if timing_destination_monotonic is not None:
+            self.logger.debug(
+                "Queued send task %s enqueued %.3fs after destination resolution.",
+                task_id,
+                now - timing_destination_monotonic,
+            )
         placeholder = self._create_queued_message_placeholder(chat_id, task_id)
         return self._make_send_receipt(placeholder, queued=True, task_id=task_id)
 
@@ -1469,6 +1489,7 @@ class TelegramBotManager(LocaleMixin):
                            cleanup_files: Optional[list] = None) -> str:
         """Append a task to the per-target FIFO queue."""
         slave_id, chat_id = target
+        enqueued_at = time.monotonic()
         with self._send_queues_lock:
             self._tasks_enqueued += 1
             arrival_seq = self._tasks_enqueued
@@ -1480,12 +1501,15 @@ class TelegramBotManager(LocaleMixin):
                 kwargs=kwargs,
                 task_id=task_id,
                 arrival_seq=arrival_seq,
-                cleanup_files=tuple(cleanup_files or ())
+                cleanup_files=tuple(cleanup_files or ()),
+                enqueued_at=enqueued_at,
             )
             q = self._send_queues.setdefault(target, collections.deque())
             q.append(task)
+            queue_depth = len(q)
 
-        self.logger.debug("Queued send task %s for target %s", task_id, target)
+        self.logger.debug("Queued send task %s for target %s (target_queue_depth=%d)",
+                          task_id, target, queue_depth)
         return task_id
 
     # ── Async-dispatch queued send worker ──────────────────────
@@ -1527,6 +1551,13 @@ class TelegramBotManager(LocaleMixin):
                 self._requeue_send_task(task)
                 continue
 
+            if task.enqueued_at:
+                self.logger.debug(
+                    "Dispatching queued send task %s after %.3fs in queue via bot %s",
+                    task.task_id,
+                    time.monotonic() - task.enqueued_at,
+                    sender_bot_id or "main",
+                )
             self._dispatch_send(task, sender_bot, sender_bot_id)
 
     def _queued_send_worker(self):
@@ -1583,6 +1614,8 @@ class TelegramBotManager(LocaleMixin):
             send_kwargs.pop('_force_sender_known', None)
             send_kwargs.pop('_force_sender_bot_id', None)
             send_kwargs.pop('_slave_id', None)
+            send_kwargs.pop('_timing_receive_monotonic', None)
+            send_kwargs.pop('_timing_destination_monotonic', None)
             send_kwargs['_skip_rate_limit_retry'] = True
             with self._using_bot(sender_bot):
                 return task.function(*task.args, **send_kwargs)
@@ -1636,7 +1669,14 @@ class TelegramBotManager(LocaleMixin):
                 if sender_bot_id is not None:
                     self._record_aux_use(task.chat_id)
 
-                self.logger.debug("Queued send task %s completed successfully", task.task_id)
+                if task.enqueued_at:
+                    self.logger.debug(
+                        "Queued send task %s completed successfully in %.3fs since enqueue",
+                        task.task_id,
+                        time.monotonic() - task.enqueued_at,
+                    )
+                else:
+                    self.logger.debug("Queued send task %s completed successfully", task.task_id)
 
                 if result and hasattr(result, 'message_id'):
                     self._handle_queued_database_update(

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -119,11 +119,7 @@ class BotPool:
             (AuxiliaryBot, delay) if a suitable aux bot was found,
             None if no aux bot beats max_delay or none are members.
         """
-        with self._pool_lock:
-            affinity_slot = self._try_affinity_bot(chat_id, max_delay, affinity_key, skip_bot)
-            if affinity_slot is not None:
-                return affinity_slot
-
+        def _select_locked() -> tuple[Optional[Tuple[AuxiliaryBot, float]], List[AuxiliaryBot], List[AuxiliaryBot]]:
             best_bot: Optional[AuxiliaryBot] = None
             best_delay = float('inf')
             confirmed_non_member_bots: List[AuxiliaryBot] = []
@@ -149,35 +145,42 @@ class BotPool:
                     if delay == 0.0:
                         break
 
-            # Cold start: synchronously resolve unknown bots so they can help now
-            if best_bot is None and unknown_bots:
-                for aux_bot in unknown_bots:
-                    if skip_bot is not None and skip_bot(aux_bot):
-                        continue
-                    if aux_bot.check_membership_sync(chat_id, timeout=3.0):
-                        delay = aux_bot.peek_delay(chat_id)
-                        if delay < best_delay:
-                            best_bot = aux_bot
-                            best_delay = delay
-                            if delay == 0.0:
-                                break
-                    else:
-                        confirmed_non_member_bots.append(aux_bot)
-
             if best_bot is not None and best_delay < max_delay:
                 best_bot.reserve_slot(chat_id)
                 self._advance_round_robin_cursor(chat_id, best_bot)
                 if affinity_key is not None:
                     self._affinity_bot_by_key[affinity_key] = best_bot.bot_id
-                return (best_bot, best_delay)
+                return (best_bot, best_delay), confirmed_non_member_bots, unknown_bots
+            return None, confirmed_non_member_bots, unknown_bots
 
-            # Suggest adding aux bots only when the caller is actually delayed.
-            # Selection budget (max_delay) may include a small epsilon for fairness,
-            # so notification should be controlled by the caller.
-            if confirmed_non_member_bots and notify_admin:
-                self._maybe_notify_admin(chat_id, confirmed_non_member_bots)
+        with self._pool_lock:
+            affinity_slot = self._try_affinity_bot(chat_id, max_delay, affinity_key, skip_bot)
+            if affinity_slot is not None:
+                return affinity_slot
+            selected, confirmed_non_member_bots, unknown_bots = _select_locked()
+            if selected is not None:
+                return selected
 
-            return None
+        if unknown_bots:
+            for aux_bot in unknown_bots:
+                if skip_bot is not None and skip_bot(aux_bot):
+                    continue
+                aux_bot.check_membership_sync(chat_id, timeout=3.0)
+            with self._pool_lock:
+                affinity_slot = self._try_affinity_bot(chat_id, max_delay, affinity_key, skip_bot)
+                if affinity_slot is not None:
+                    return affinity_slot
+                selected, confirmed_non_member_bots, _unknown_bots = _select_locked()
+                if selected is not None:
+                    return selected
+
+        # Suggest adding aux bots only when the caller is actually rate-limited.
+        # Selection budget (max_delay) may include a small epsilon for fairness,
+        # so notification should be controlled by the caller.
+        if confirmed_non_member_bots and notify_admin:
+            self._maybe_notify_admin(chat_id, confirmed_non_member_bots)
+
+        return None
 
     def send_blocking(self, chat_id: int, timeout: float = 60.0) -> Optional[AuxiliaryBot]:
         """Block until any bot in the pool has a free slot for the given chat.

--- a/efb_telegram_master/chat.py
+++ b/efb_telegram_master/chat.py
@@ -210,7 +210,7 @@ class ETMChatMixin(ETMBaseChatMixin, Chat, ABC):
         """
         now = time.time()
         if self._last_message_time is None or \
-                now - self._last_message_time_query >= self.LAST_MESSAGE_QUERY_TIMEOUT_MS / 1000:
+                now - self._last_message_time_query > self.LAST_MESSAGE_QUERY_TIMEOUT_MS / 1000:
             msg_log = self.db.get_last_message(slave_chat_id=utils.chat_id_to_str(chat=self))
             self._last_message_time_query = now
             if msg_log is None:

--- a/efb_telegram_master/chat.py
+++ b/efb_telegram_master/chat.py
@@ -210,7 +210,7 @@ class ETMChatMixin(ETMBaseChatMixin, Chat, ABC):
         """
         now = time.time()
         if self._last_message_time is None or \
-                now - self._last_message_time_query < self.LAST_MESSAGE_QUERY_TIMEOUT_MS:
+                now - self._last_message_time_query >= self.LAST_MESSAGE_QUERY_TIMEOUT_MS / 1000:
             msg_log = self.db.get_last_message(slave_chat_id=utils.chat_id_to_str(chat=self))
             self._last_message_time_query = now
             if msg_log is None:

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -669,7 +669,12 @@ class ChatBindingManager(LocaleMixin):
                     self.logger.warning("Auto update group info failed for %s: %s", chat_display_name, e)
 
         txt = self._("Chat {0} is now linked.").format(chat_display_name)
-        self.bot.edit_message_text(text=txt, chat_id=msg.chat.id, message_id=msg.message_id)
+        self.bot.edit_message_text(
+            text=txt,
+            chat_id=msg.chat.id,
+            message_id=msg.message_id,
+            _sender_bot_id=getattr(msg, 'sender_bot_id', None),
+        )
 
         self.bot.edit_message_text(chat_id=storage_key[0],
                                    message_id=storage_key[1],

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -511,19 +511,17 @@ class DatabaseManager:
             if bool(master_uid) == bool(slave_uid):
                 raise ValueError("Only one parameter is to be provided.")
             elif master_uid:
-                slaves = ChatAssoc.select(ChatAssoc.slave_uid, ChatAssoc.master_uid)\
+                slaves = list(
+                    ChatAssoc.select(ChatAssoc.slave_uid, ChatAssoc.master_uid)
                     .where(ChatAssoc.master_uid == master_uid)
-                if len(slaves) > 0:
-                    return [i.slave_uid for i in slaves]
-                else:
-                    return []
+                )
+                return [i.slave_uid for i in slaves]
             elif slave_uid:
-                masters = ChatAssoc.select(ChatAssoc.slave_uid, ChatAssoc.master_uid)\
+                masters = list(
+                    ChatAssoc.select(ChatAssoc.slave_uid, ChatAssoc.master_uid)
                     .where(ChatAssoc.slave_uid == slave_uid)
-                if len(masters) > 0:
-                    return [i.master_uid for i in masters]
-                else:
-                    return []
+                )
+                return [i.master_uid for i in masters]
             else:
                 return []
         except DoesNotExist:

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -283,16 +283,6 @@ class MasterMessageProcessor(LocaleMixin):
         else:
             return self.process_telegram_message(update, context, destination, quote=quote, edited=edited)
 
-    def get_singly_linked_chat_id_str(self, chat: Chat) -> Optional[EFBChannelChatIDStr]:
-        """Return the singly-linked remote chat if available.
-        Otherwise return None.
-        """
-        master_chat_uid = utils.chat_id_to_str(self.channel_id, ChatID(str(chat.id)))
-        chats = self.db.get_chat_assoc(master_uid=master_chat_uid)
-        if len(chats) == 1:
-            return chats[0]
-        return None
-
     def process_telegram_message(self, update: Update, context: CallbackContext,
                                  destination: EFBChannelChatIDStr, quote: bool = False,
                                  edited: Optional["MsgLog"] = None):

--- a/efb_telegram_master/master_message.py
+++ b/efb_telegram_master/master_message.py
@@ -168,6 +168,14 @@ class MasterMessageProcessor(LocaleMixin):
 
         message: Message = update.effective_message
         mid = utils.message_id_to_str(update=update)
+        master_chat_uid = utils.chat_id_to_str(self.channel_id, ChatID(str(message.chat.id)))
+        linked_slave_chats: Optional[list[EFBChannelChatIDStr]] = None
+
+        def get_linked_slave_chats() -> list[EFBChannelChatIDStr]:
+            nonlocal linked_slave_chats
+            if linked_slave_chats is None:
+                linked_slave_chats = self.db.get_chat_assoc(master_uid=master_chat_uid)
+            return linked_slave_chats
 
         self.logger.debug("[%s] Received message from Telegram: %s", mid, message.to_dict())
 
@@ -188,7 +196,9 @@ class MasterMessageProcessor(LocaleMixin):
             quote = msg_log.build_etm_msg(self.chat_manager).target is not None
 
         if destination is None:
-            destination = self.get_singly_linked_chat_id_str(update.effective_chat)
+            chats = get_linked_slave_chats()
+            if len(chats) == 1:
+                destination = chats[0]
             if destination:
                 quote = message.reply_to_message is not None
                 self.logger.debug("[%s] Chat %s is singly-linked to %s", mid, message.chat, destination)
@@ -220,7 +230,7 @@ class MasterMessageProcessor(LocaleMixin):
                         return
                 else:
                     self.logger.debug("[%s] Chat %s is a forum, but no thread ID is found.", mid, message.chat)
-                    destinations = self.db.get_chat_assoc(master_uid=utils.chat_id_to_str(self.channel_id, ChatID(str(message.chat.id))))
+                    destinations = get_linked_slave_chats()
                     if topic_destinations is not None and len(destinations) == len(topic_destinations):
                         self.logger.debug("[%s] Chat %s is a forum, and all destinations are in topics. The new message is not in any topic, so ignore it.", mid, message.chat)
                         return
@@ -253,7 +263,7 @@ class MasterMessageProcessor(LocaleMixin):
             self.logger.debug("[%s] Destination is not found for this message", mid)
             candidates = (
                  self.db.get_recent_slave_chats(TelegramChatID(message.chat.id), limit=5) or
-                 self.db.get_chat_assoc(master_uid=utils.chat_id_to_str(self.channel_id, ChatID(str(message.chat.id))))[:5]
+                 get_linked_slave_chats()[:5]
             )
             if candidates:
                 self.logger.debug("[%s] Candidate suggestions are found for this message: %s", mid, candidates)

--- a/efb_telegram_master/rate_limiter.py
+++ b/efb_telegram_master/rate_limiter.py
@@ -84,11 +84,13 @@ class SlidingWindowRateLimiter:
         """Undo the latest reservation for *chat_id* when no send happened."""
         with self._lock:
             chat_ts = self._chat_timestamps.get(chat_id)
-            if chat_ts:
-                candidate_time = chat_ts.pop()
-                idx = bisect.bisect_left(self._global_timestamps, candidate_time)
-                if idx < len(self._global_timestamps) and self._global_timestamps[idx] == candidate_time:
-                    self._global_timestamps.pop(idx)
+            if not chat_ts:
+                self._cleanup()
+                return
+            candidate_time = chat_ts.pop()
+            idx = bisect.bisect_left(self._global_timestamps, candidate_time)
+            if idx < len(self._global_timestamps) and self._global_timestamps[idx] == candidate_time:
+                self._global_timestamps.pop(idx)
             self._cleanup()
 
     def get_counts(self, chat_id: int) -> Tuple[int, int]:

--- a/efb_telegram_master/rate_limiter.py
+++ b/efb_telegram_master/rate_limiter.py
@@ -95,7 +95,7 @@ class SlidingWindowRateLimiter:
         """Return ``(chat_count, global_count)`` for diagnostics."""
         with self._lock:
             self._cleanup()
-            return len(self._chat_timestamps[chat_id]), len(self._global_timestamps)
+            return len(self._chat_timestamps.get(chat_id, ())), len(self._global_timestamps)
 
     # Internals
 
@@ -109,8 +109,8 @@ class SlidingWindowRateLimiter:
 
         # Per-chat window
         chat_delay = 0.0
-        chat_ts = self._chat_timestamps[chat_id]
-        if len(chat_ts) >= effective_chat_limit:
+        chat_ts = self._chat_timestamps.get(chat_id)
+        if chat_ts and len(chat_ts) >= effective_chat_limit:
             safe_index = len(chat_ts) - effective_chat_limit
             chat_delay = max(0.0, (chat_ts[safe_index] + self.chat_window) - current_time)
 

--- a/efb_telegram_master/rate_limiter.py
+++ b/efb_telegram_master/rate_limiter.py
@@ -80,6 +80,17 @@ class SlidingWindowRateLimiter:
             self._chat_timestamps[chat_id].append(candidate_time)
             return delay
 
+    def release_slot(self, chat_id: int) -> None:
+        """Undo the latest reservation for *chat_id* when no send happened."""
+        with self._lock:
+            chat_ts = self._chat_timestamps.get(chat_id)
+            if chat_ts:
+                candidate_time = chat_ts.pop()
+                idx = bisect.bisect_left(self._global_timestamps, candidate_time)
+                if idx < len(self._global_timestamps) and self._global_timestamps[idx] == candidate_time:
+                    self._global_timestamps.pop(idx)
+            self._cleanup()
+
     def get_counts(self, chat_id: int) -> Tuple[int, int]:
         """Return ``(chat_count, global_count)`` for diagnostics."""
         with self._lock:
@@ -125,6 +136,11 @@ class SlidingWindowRateLimiter:
             self._global_timestamps.pop(0)
 
         chat_cutoff = current_time - self.chat_window
-        for _cid, ts in self._chat_timestamps.items():
+        empty_chat_ids = []
+        for cid, ts in self._chat_timestamps.items():
             while ts and ts[0] <= chat_cutoff:
                 ts.popleft()
+            if not ts:
+                empty_chat_ids.append(cid)
+        for cid in empty_chat_ids:
+            del self._chat_timestamps[cid]

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -62,6 +62,9 @@ class SlaveMessageProcessor(LocaleMixin):
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
         self._pending_slave_messages: set[Tuple[str, str]] = set()
         self._pending_slave_messages_lock = threading.Lock()
+        self._known_forum_chat_ids: set[int] = set()
+        self._known_forum_chat_ids_lock = threading.Lock()
+        self._timing_tls = threading.local()
 
     def _claim_pending_slave_message(self, key: Tuple[str, str]) -> bool:
         with self._pending_slave_messages_lock:
@@ -81,6 +84,70 @@ class SlaveMessageProcessor(LocaleMixin):
         if msg.edit or msg.uid is None or msg.type == MsgType.Status:
             return None
         return slave_origin_uid, str(msg.uid)
+
+    def _ensure_timing_tls(self):
+        if not hasattr(self, '_timing_tls'):
+            self._timing_tls = threading.local()
+        return self._timing_tls
+
+    def _set_message_timing(self, *, receive_started: float,
+                            destination_resolved: Optional[float] = None):
+        timing_tls = self._ensure_timing_tls()
+        timing_tls.receive_started = receive_started
+        timing_tls.destination_resolved = destination_resolved
+
+    def _clear_message_timing(self):
+        timing_tls = getattr(self, '_timing_tls', None)
+        if timing_tls is None:
+            return
+        for key in ('receive_started', 'destination_resolved'):
+            if hasattr(timing_tls, key):
+                delattr(timing_tls, key)
+
+    def _current_message_timing_kwargs(self) -> dict:
+        timing_tls = getattr(self, '_timing_tls', None)
+        if timing_tls is None:
+            return {}
+        kwargs = {}
+        receive_started = getattr(timing_tls, 'receive_started', None)
+        destination_resolved = getattr(timing_tls, 'destination_resolved', None)
+        if receive_started is not None:
+            kwargs['_timing_receive_monotonic'] = receive_started
+        if destination_resolved is not None:
+            kwargs['_timing_destination_monotonic'] = destination_resolved
+        return kwargs
+
+    def _ensure_forum_cache(self):
+        if not hasattr(self, '_known_forum_chat_ids'):
+            self._known_forum_chat_ids = set()
+        if not hasattr(self, '_known_forum_chat_ids_lock'):
+            self._known_forum_chat_ids_lock = threading.Lock()
+
+    def _known_forum_chat(self, tg_dest: TelegramChatID) -> bool:
+        self._ensure_forum_cache()
+        with self._known_forum_chat_ids_lock:
+            return int(tg_dest) in self._known_forum_chat_ids
+
+    def _mark_known_forum_chat(self, tg_dest: TelegramChatID):
+        self._ensure_forum_cache()
+        with self._known_forum_chat_ids_lock:
+            self._known_forum_chat_ids.add(int(tg_dest))
+
+    def _get_master_chat_is_forum(self, xid: str, tg_dest: TelegramChatID) -> bool:
+        if self._known_forum_chat(tg_dest):
+            self.logger.debug("[%s] get_chat_info skipped for Telegram chat %s (known forum chat).",
+                              xid, tg_dest)
+            return True
+
+        started = time.monotonic()
+        master_chat_info = self.bot.get_chat_info(tg_dest)
+        elapsed = time.monotonic() - started
+        is_forum = bool(master_chat_info.is_forum)
+        self.logger.debug("[%s] get_chat_info finished in %.3fs for Telegram chat %s (is_forum=%s).",
+                          xid, elapsed, tg_dest, is_forum)
+        if is_forum:
+            self._mark_known_forum_chat(tg_dest)
+        return is_forum
 
     @staticmethod
     def _get_edit_kwargs(msg: Message):
@@ -124,9 +191,14 @@ class SlaveMessageProcessor(LocaleMixin):
         """
         dedupe_key: Optional[Tuple[str, str]] = None
         pending_claimed = False
+        receive_started = time.monotonic()
+        tg_dest = None
+        thread_id = None
+        self._set_message_timing(receive_started=receive_started)
         try:
             xid = msg.uid
             self.logger.debug("[%s] Slave message delivered to ETM.\n%s", xid, msg)
+            self.logger.debug("[%s] Message receive timing started.", xid)
 
             slave_origin_uid = utils.chat_id_to_str(chat=msg.chat)
             dedupe_key = self._dedupe_key(msg, slave_origin_uid)
@@ -145,7 +217,19 @@ class SlaveMessageProcessor(LocaleMixin):
                     return msg
                 pending_claimed = True
 
+            destination_started = time.monotonic()
             msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(msg)
+            destination_resolved = time.monotonic()
+            self._set_message_timing(
+                receive_started=receive_started,
+                destination_resolved=destination_resolved,
+            )
+            self.logger.debug(
+                "[%s] Destination resolution finished in %.3fs (%.3fs since receive).",
+                xid,
+                destination_resolved - destination_started,
+                destination_resolved - receive_started,
+            )
 
             silent = self.is_silent(msg)
             if silent is None:
@@ -180,8 +264,16 @@ class SlaveMessageProcessor(LocaleMixin):
                 msg.vendor_specific = msg.vendor_specific or {}
                 msg.vendor_specific['_sender_bot_id'] = _edit_sender_bot_id
 
+            dispatch_started = time.monotonic()
             self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent,
                                   dedupe_key=dedupe_key)
+            dispatch_finished = time.monotonic()
+            self.logger.debug(
+                "[%s] Dispatch returned in %.3fs (%.3fs since receive).",
+                xid,
+                dispatch_finished - dispatch_started,
+                dispatch_finished - receive_started,
+            )
         except Exception as e:
             if pending_claimed:
                 self._release_pending_slave_message(dedupe_key)
@@ -201,6 +293,8 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 self.logger.error("Error occurred while processing message from slave channel.\nMessage: %s\n%s\n%s",
                               repr(msg), repr(e), traceback.format_exc())
+        finally:
+            self._clear_message_timing()
         return msg
 
     def dispatch_message(self, msg: Message, msg_template: str,
@@ -315,6 +409,10 @@ class SlaveMessageProcessor(LocaleMixin):
         if hasattr(tg_msg, '_queued_execution_pending') and tg_msg._queued_execution_pending:
             self.logger.debug("[%s] Message execution is queued (task_id: %s), deferring database logging.",
                              xid, getattr(tg_msg, 'task_id', 'unknown'))
+            receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
+            if receive_started is not None:
+                self.logger.debug("[%s] Message enqueue finished in %.3fs since receive.",
+                                  xid, time.monotonic() - receive_started)
 
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
 
@@ -332,6 +430,10 @@ class SlaveMessageProcessor(LocaleMixin):
             # of silently dropped.
             self.logger.debug("[%s] Message is sent to the user with telegram message id %s.%s.",
                               xid, tg_msg.chat.id, tg_msg.message_id)
+            receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
+            if receive_started is not None:
+                self.logger.debug("[%s] Blocking send completed in %.3fs since receive.",
+                                  xid, time.monotonic() - receive_started)
 
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
 
@@ -349,12 +451,16 @@ class SlaveMessageProcessor(LocaleMixin):
             (Optional[TelegramChatID], Optional[TelegramTopicID]): Telegram destination chat ID and thread ID, None if muted.
         """
         xid = msg.uid
+        destination_started = time.monotonic()
         chat = self.chat_manager.update_chat_obj(msg.chat)
         msg.chat = chat
         msg.author = self.chat_manager.get_or_enrol_member(msg.chat, msg.author)
 
         chat_uid = utils.chat_id_to_str(chat=msg.chat)
+        assoc_started = time.monotonic()
         tg_chats = self.db.get_chat_assoc(slave_uid=chat_uid)
+        self.logger.debug("[%s] Destination chat association lookup finished in %.3fs.",
+                          xid, time.monotonic() - assoc_started)
         tg_chat = None
         tg_dest: Optional[TelegramChatID] = None
         thread_id: Optional[TelegramTopicID] = None
@@ -378,11 +484,29 @@ class SlaveMessageProcessor(LocaleMixin):
             tg_dest = TelegramChatID(int(utils.chat_id_str_to_id(tg_chat)[1]))
         if self.channel.topic_group:
             if not isinstance(chat, SystemChat):
-                tg_dest = TelegramChatID(int(utils.chat_id_str_to_id(tg_chat)[1]) if tg_chat else self.channel.topic_group)
-                master_chat_info = self.bot.get_chat_info(tg_dest)
-                if master_chat_info.is_forum:
+                if tg_chat:
+                    tg_dest = TelegramChatID(int(utils.chat_id_str_to_id(tg_chat)[1]))
+                else:
+                    tg_dest = TelegramChatID(self.channel.topic_group)
+                if self._get_master_chat_is_forum(xid, tg_dest):
+                    topic_lookup_started = time.monotonic()
                     existing_thread_id = self.db.get_topic_thread_id(slave_uid=chat_uid, topic_chat_id=tg_dest)
+                    self.logger.debug(
+                        "[%s] Topic thread lookup finished in %.3fs for Telegram chat %s (existing_thread_id=%s).",
+                        xid,
+                        time.monotonic() - topic_lookup_started,
+                        tg_dest,
+                        existing_thread_id,
+                    )
+                    topic_started = time.monotonic()
                     thread_id = self.channel.chat_binding.create_topic(slave_uid=chat_uid, telegram_chat_id=tg_dest)
+                    self.logger.debug(
+                        "[%s] Topic creation/resolution finished in %.3fs for Telegram chat %s (thread_id=%s).",
+                        xid,
+                        time.monotonic() - topic_started,
+                        tg_dest,
+                        thread_id,
+                    )
                     if thread_id is not None and existing_thread_id is None:
                         msg.vendor_specific = msg.vendor_specific or {}
                         msg.vendor_specific['_force_send_mode'] = 'blocking'
@@ -399,6 +523,8 @@ class SlaveMessageProcessor(LocaleMixin):
         if self.chat_dest_cache.get(str(tg_dest)) != chat_uid:
             self.chat_dest_cache.remove(str(tg_dest))
 
+        self.logger.debug("[%s] Destination helper finished in %.3fs.",
+                          xid, time.monotonic() - destination_started)
         return msg_template, (tg_dest, thread_id)
 
 
@@ -441,16 +567,20 @@ class SlaveMessageProcessor(LocaleMixin):
     def _send_queue_kwargs(self, msg: Message,
                            old_msg_id: Optional[OldMsgID],
                            thread_id: Optional[TelegramTopicID] = None) -> dict:
-        return {
+        kwargs = {
             '_send_mode': self._send_mode(msg, old_msg_id, thread_id),
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }
+        kwargs.update(self._current_message_timing_kwargs())
+        return kwargs
 
     def _blocking_send_kwargs(self, msg: Message) -> dict:
-        return {
+        kwargs = {
             '_send_mode': 'blocking',
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }
+        kwargs.update(self._current_message_timing_kwargs())
+        return kwargs
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
                            thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -30,6 +30,7 @@ from ehforwarderbot.constants import MsgType
 from ehforwarderbot.message import LinkAttribute, LocationAttribute, MessageCommand, Reactions, \
     StatusAttribute
 from ehforwarderbot.status import ChatUpdates, MemberUpdates, MessageRemoval, MessageReactionsUpdate
+from ehforwarderbot.types import MessageID
 from . import utils
 from .chat_destination_cache import ChatDestinationCache
 from .chat_object_cache import ChatObjectCacheManager
@@ -133,7 +134,7 @@ class SlaveMessageProcessor(LocaleMixin):
         with self._known_forum_chat_ids_lock:
             self._known_forum_chat_ids.add(int(tg_dest))
 
-    def _get_master_chat_is_forum(self, xid: str, tg_dest: TelegramChatID) -> bool:
+    def _get_master_chat_is_forum(self, xid: Optional[MessageID], tg_dest: TelegramChatID) -> bool:
         if self._known_forum_chat(tg_dest):
             self.logger.debug("[%s] get_chat_info skipped for Telegram chat %s (known forum chat).",
                               xid, tg_dest)

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -10,6 +10,7 @@ import time
 import traceback
 import urllib.parse
 from collections import defaultdict
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Tuple, Optional, TYPE_CHECKING, List, IO, Union
 
@@ -88,49 +89,27 @@ class SlaveMessageProcessor(LocaleMixin):
             return None
         return slave_origin_uid, str(msg.uid)
 
-    def _ensure_timing_tls(self):
-        if not hasattr(self, '_timing_tls'):
-            self._timing_tls = threading.local()
-        return self._timing_tls
+    @contextmanager
+    def _timed_phase(self, xid: Optional[MessageID], phase_name: str):
+        started = time.monotonic()
+        try:
+            yield
+        finally:
+            self.logger.debug(
+                "[%s] %s finished in %.3fs.",
+                xid,
+                phase_name,
+                time.monotonic() - started,
+            )
 
-    def _set_message_timing(self, *, receive_started: float,
-                            destination_resolved: Optional[float] = None):
-        timing_tls = self._ensure_timing_tls()
-        timing_tls.receive_started = receive_started
-        timing_tls.destination_resolved = destination_resolved
-
-    def _clear_message_timing(self):
+    def _clear_dispatch_context(self):
         timing_tls = getattr(self, '_timing_tls', None)
         if timing_tls is None:
             return
-        for key in ('receive_started', 'destination_resolved', 'queued_db_on_complete'):
-            if hasattr(timing_tls, key):
-                delattr(timing_tls, key)
-
-    def _current_message_timing_kwargs(self) -> dict:
-        timing_tls = getattr(self, '_timing_tls', None)
-        if timing_tls is None:
-            return {}
-        kwargs = {}
-        receive_started = getattr(timing_tls, 'receive_started', None)
-        destination_resolved = getattr(timing_tls, 'destination_resolved', None)
-        if receive_started is not None:
-            kwargs['_timing_receive_monotonic'] = receive_started
-        if destination_resolved is not None:
-            kwargs['_timing_destination_monotonic'] = destination_resolved
-        return kwargs
-
-    def _ensure_forum_cache(self):
-        if not hasattr(self, '_known_forum_chat_ids'):
-            self._known_forum_chat_ids = {}
-        elif not isinstance(self._known_forum_chat_ids, dict):
-            now = time.monotonic()
-            self._known_forum_chat_ids = {int(chat_id): now for chat_id in self._known_forum_chat_ids}
-        if not hasattr(self, '_known_forum_chat_ids_lock'):
-            self._known_forum_chat_ids_lock = threading.Lock()
+        if hasattr(timing_tls, 'queued_db_on_complete'):
+            delattr(timing_tls, 'queued_db_on_complete')
 
     def _known_forum_chat(self, tg_dest: TelegramChatID) -> bool:
-        self._ensure_forum_cache()
         with self._known_forum_chat_ids_lock:
             chat_id = int(tg_dest)
             cached_at = self._known_forum_chat_ids.get(chat_id)
@@ -142,7 +121,6 @@ class SlaveMessageProcessor(LocaleMixin):
             return False
 
     def _mark_known_forum_chat(self, tg_dest: TelegramChatID):
-        self._ensure_forum_cache()
         with self._known_forum_chat_ids_lock:
             self._known_forum_chat_ids[int(tg_dest)] = time.monotonic()
 
@@ -152,12 +130,11 @@ class SlaveMessageProcessor(LocaleMixin):
                               xid, tg_dest)
             return True
 
-        started = time.monotonic()
-        master_chat_info = self.bot.get_chat_info(tg_dest)
-        elapsed = time.monotonic() - started
+        with self._timed_phase(xid, f"get_chat_info for Telegram chat {tg_dest}"):
+            master_chat_info = self.bot.get_chat_info(tg_dest)
         is_forum = bool(master_chat_info.is_forum)
-        self.logger.debug("[%s] get_chat_info finished in %.3fs for Telegram chat %s (is_forum=%s).",
-                          xid, elapsed, tg_dest, is_forum)
+        self.logger.debug("[%s] get_chat_info for Telegram chat %s returned is_forum=%s.",
+                          xid, tg_dest, is_forum)
         if is_forum:
             self._mark_known_forum_chat(tg_dest)
         return is_forum
@@ -204,14 +181,11 @@ class SlaveMessageProcessor(LocaleMixin):
         """
         dedupe_key: Optional[Tuple[str, str]] = None
         pending_claimed = False
-        receive_started = time.monotonic()
         tg_dest = None
         thread_id = None
-        self._set_message_timing(receive_started=receive_started)
+        xid = msg.uid
         try:
-            xid = msg.uid
             self.logger.debug("[%s] Slave message delivered to ETM.\n%s", xid, msg)
-            self.logger.debug("[%s] Message receive timing started.", xid)
 
             slave_origin_uid = utils.chat_id_to_str(chat=msg.chat)
             dedupe_key = self._dedupe_key(msg, slave_origin_uid)
@@ -224,19 +198,8 @@ class SlaveMessageProcessor(LocaleMixin):
                     return msg
                 pending_claimed = True
 
-            destination_started = time.monotonic()
-            msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(msg)
-            destination_resolved = time.monotonic()
-            self._set_message_timing(
-                receive_started=receive_started,
-                destination_resolved=destination_resolved,
-            )
-            self.logger.debug(
-                "[%s] Destination resolution finished in %.3fs (%.3fs since receive).",
-                xid,
-                destination_resolved - destination_started,
-                destination_resolved - receive_started,
-            )
+            with self._timed_phase(xid, "Destination resolution"):
+                msg_template, (tg_dest, thread_id) = self.get_slave_msg_dest(msg)
 
             silent = self.is_silent(msg)
             if silent is None:
@@ -271,16 +234,9 @@ class SlaveMessageProcessor(LocaleMixin):
                 msg.vendor_specific = msg.vendor_specific or {}
                 msg.vendor_specific['_sender_bot_id'] = _edit_sender_bot_id
 
-            dispatch_started = time.monotonic()
-            self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent,
-                                  dedupe_key=dedupe_key)
-            dispatch_finished = time.monotonic()
-            self.logger.debug(
-                "[%s] Dispatch returned in %.3fs (%.3fs since receive).",
-                xid,
-                dispatch_finished - dispatch_started,
-                dispatch_finished - receive_started,
-            )
+            with self._timed_phase(xid, "Dispatch"):
+                self.dispatch_message(msg, msg_template, old_msg_id, tg_dest, thread_id, silent,
+                                      dedupe_key=dedupe_key)
         except Exception as e:
             if pending_claimed:
                 self._release_pending_slave_message(dedupe_key)
@@ -301,7 +257,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 self.logger.error("Error occurred while processing message from slave channel.\nMessage: %s\n%s\n%s",
                               repr(msg), repr(e), traceback.format_exc())
         finally:
-            self._clear_message_timing()
+            self._clear_dispatch_context()
         return msg
 
     def dispatch_message(self, msg: Message, msg_template: str,
@@ -352,7 +308,7 @@ class SlaveMessageProcessor(LocaleMixin):
         on_db_complete = None
         if dedupe_key is not None:
             on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
-        self._ensure_timing_tls().queued_db_on_complete = on_db_complete
+        self._timing_tls.queued_db_on_complete = on_db_complete
 
         # Type dispatching
         if msg.type == MsgType.Text:
@@ -400,7 +356,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            text=self._('Unknown type of message "{0}". (UT01)')
                                            .format(msg.type.name),
-                                           **self._send_queue_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id))
 
         if tg_msg and commands:
             self.channel.commands.register_command(tg_msg, ETMCommandMsgStorage(
@@ -416,10 +372,6 @@ class SlaveMessageProcessor(LocaleMixin):
         if hasattr(tg_msg, '_queued_execution_pending') and tg_msg._queued_execution_pending:
             self.logger.debug("[%s] Message execution is queued (task_id: %s), deferring database logging.",
                               xid, getattr(tg_msg, 'task_id', 'unknown'))
-            receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
-            if receive_started is not None:
-                self.logger.debug("[%s] Message enqueue finished in %.3fs since receive.",
-                                  xid, time.monotonic() - receive_started)
 
             if not hasattr(tg_msg, 'task_id'):
                 self.logger.warning("[%s] Queued message missing task_id, cannot track database update", xid)
@@ -429,10 +381,6 @@ class SlaveMessageProcessor(LocaleMixin):
             # write the DB mapping once. DB failures are logged only.
             self.logger.debug("[%s] Message is sent to the user with telegram message id %s.%s.",
                               xid, tg_msg.chat.id, tg_msg.message_id)
-            receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
-            if receive_started is not None:
-                self.logger.debug("[%s] Blocking send completed in %.3fs since receive.",
-                                  xid, time.monotonic() - receive_started)
 
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
 
@@ -450,16 +398,13 @@ class SlaveMessageProcessor(LocaleMixin):
             (Optional[TelegramChatID], Optional[TelegramTopicID]): Telegram destination chat ID and thread ID, None if muted.
         """
         xid = msg.uid
-        destination_started = time.monotonic()
         chat = self.chat_manager.update_chat_obj(msg.chat)
         msg.chat = chat
         msg.author = self.chat_manager.get_or_enrol_member(msg.chat, msg.author)
 
         chat_uid = utils.chat_id_to_str(chat=msg.chat)
-        assoc_started = time.monotonic()
-        tg_chats = self.db.get_chat_assoc(slave_uid=chat_uid)
-        self.logger.debug("[%s] Destination chat association lookup finished in %.3fs.",
-                          xid, time.monotonic() - assoc_started)
+        with self._timed_phase(xid, "Destination chat association lookup"):
+            tg_chats = self.db.get_chat_assoc(slave_uid=chat_uid)
         tg_chat = None
         tg_dest: Optional[TelegramChatID] = None
         thread_id: Optional[TelegramTopicID] = None
@@ -488,21 +433,25 @@ class SlaveMessageProcessor(LocaleMixin):
                 else:
                     tg_dest = TelegramChatID(self.channel.topic_group)
                 if self._get_master_chat_is_forum(xid, tg_dest):
-                    topic_lookup_started = time.monotonic()
-                    existing_thread_id = self.db.get_topic_thread_id(slave_uid=chat_uid, topic_chat_id=tg_dest)
+                    with self._timed_phase(xid, f"Topic thread lookup for Telegram chat {tg_dest}"):
+                        existing_thread_id = self.db.get_topic_thread_id(
+                            slave_uid=chat_uid,
+                            topic_chat_id=tg_dest,
+                        )
                     self.logger.debug(
-                        "[%s] Topic thread lookup finished in %.3fs for Telegram chat %s (existing_thread_id=%s).",
+                        "[%s] Topic thread lookup for Telegram chat %s returned existing_thread_id=%s.",
                         xid,
-                        time.monotonic() - topic_lookup_started,
                         tg_dest,
                         existing_thread_id,
                     )
-                    topic_started = time.monotonic()
-                    thread_id = self.channel.chat_binding.create_topic(slave_uid=chat_uid, telegram_chat_id=tg_dest)
+                    with self._timed_phase(xid, f"Topic creation/resolution for Telegram chat {tg_dest}"):
+                        thread_id = self.channel.chat_binding.create_topic(
+                            slave_uid=chat_uid,
+                            telegram_chat_id=tg_dest,
+                        )
                     self.logger.debug(
-                        "[%s] Topic creation/resolution finished in %.3fs for Telegram chat %s (thread_id=%s).",
+                        "[%s] Topic creation/resolution for Telegram chat %s returned thread_id=%s.",
                         xid,
-                        time.monotonic() - topic_started,
                         tg_dest,
                         thread_id,
                     )
@@ -522,8 +471,6 @@ class SlaveMessageProcessor(LocaleMixin):
         if self.chat_dest_cache.get(str(tg_dest)) != chat_uid:
             self.chat_dest_cache.remove(str(tg_dest))
 
-        self.logger.debug("[%s] Destination helper finished in %.3fs.",
-                          xid, time.monotonic() - destination_started)
         return msg_template, (tg_dest, thread_id)
 
 
@@ -552,15 +499,20 @@ class SlaveMessageProcessor(LocaleMixin):
             return html.escape(text)
         return text
 
-    def _send_queue_kwargs(self, msg: Message,
-                           old_msg_id: Optional[OldMsgID]) -> dict:
-        force_send_mode = (msg.vendor_specific or {}).get('_force_send_mode')
-        if force_send_mode in {'blocking', 'eventual'}:
-            send_mode = force_send_mode
-        elif old_msg_id is not None or msg.commands:
-            send_mode = 'blocking'
+    def _make_send_kwargs(self, msg: Message,
+                          old_msg_id: Optional[OldMsgID] = None,
+                          *,
+                          mode: Optional[str] = None) -> dict:
+        if mode is not None:
+            send_mode = mode
         else:
-            send_mode = 'eventual'
+            force_send_mode = (msg.vendor_specific or {}).get('_force_send_mode')
+            if force_send_mode in {'blocking', 'eventual'}:
+                send_mode = force_send_mode
+            elif old_msg_id is not None or msg.commands:
+                send_mode = 'blocking'
+            else:
+                send_mode = 'eventual'
         kwargs = {
             '_send_mode': send_mode,
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
@@ -577,15 +529,6 @@ class SlaveMessageProcessor(LocaleMixin):
                 old_msg_id,
                 on_complete,
             )
-        kwargs.update(self._current_message_timing_kwargs())
-        return kwargs
-
-    def _blocking_send_kwargs(self, msg: Message) -> dict:
-        kwargs = {
-            '_send_mode': 'blocking',
-            '_slave_id': utils.chat_id_to_str(chat=msg.chat),
-        }
-        kwargs.update(self._current_message_timing_kwargs())
         return kwargs
 
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
@@ -625,7 +568,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._send_queue_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id))
         else:
             # Cannot change reply_to_message_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],
@@ -678,7 +621,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                          message_thread_id=thread_id,
                                          reply_markup=reply_markup,
                                          disable_notification=silent,
-                                         **self._send_queue_kwargs(msg, old_msg_id))
+                                         **self._make_send_kwargs(msg, old_msg_id))
 
     # Parameters to decide when to pictures as files
     IMG_MIN_SIZE = 1600
@@ -761,7 +704,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup, disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._blocking_send_kwargs(msg))
+                                                    **self._make_send_kwargs(msg, mode='blocking'))
                     message.reply_text(file_too_large)
                     return message
 
@@ -799,7 +742,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                               message_thread_id=thread_id,
                                               reply_markup=reply_markup,
                                               disable_notification=silent,
-                                              **self._send_queue_kwargs(msg, old_msg_id))
+                                              **self._make_send_kwargs(msg, old_msg_id))
             else:
                 try:
                     assert msg.path
@@ -810,7 +753,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._send_queue_kwargs(msg, old_msg_id))
+                                               **self._make_send_kwargs(msg, old_msg_id))
                 except telegram.error.BadRequest as e:
                     self.logger.error('[%s] Failed to send it as image, sending as document. Reason: %s',
                                       msg.uid, e)
@@ -823,7 +766,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   message_thread_id=thread_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._send_queue_kwargs(msg, old_msg_id))
+                                                  **self._make_send_kwargs(msg, old_msg_id))
         finally:
             if msg.file:
                 msg.file.close()
@@ -860,7 +803,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._blocking_send_kwargs(msg))
+                                                    **self._make_send_kwargs(msg, mode='blocking'))
                     message.reply_text(file_too_large)
                     return message
 
@@ -888,7 +831,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._send_queue_kwargs(msg, old_msg_id))
+                                               **self._make_send_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -945,7 +888,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                         parse_mode="HTML", reply_markup=reply_markup,
                                                         disable_notification=silent,
                                                         prefix=msg_template, suffix=reactions,
-                                                        **self._blocking_send_kwargs(msg))
+                                                        **self._make_send_kwargs(msg, mode='blocking'))
                         message.reply_text(file_too_large)
                         return message
 
@@ -960,7 +903,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                  message_thread_id=thread_id,
                                                  reply_to_message_id=target_msg_id,
                                                  disable_notification=silent,
-                                                 **self._send_queue_kwargs(msg, old_msg_id))
+                                                 **self._make_send_kwargs(msg, old_msg_id))
                 except IOError:
                     self.logger.warning("[%s] Failed to convert image to webp sticker, sending as document.", msg.uid)
                     assert msg.file and msg.path
@@ -971,7 +914,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   reply_to_message_id=target_msg_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._send_queue_kwargs(msg, old_msg_id))
+                                                  **self._make_send_kwargs(msg, old_msg_id))
                 finally:
                     if webp_img and not webp_img.closed:
                         webp_img.close()
@@ -1046,7 +989,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._blocking_send_kwargs(msg))
+                                                    **self._make_send_kwargs(msg, mode='blocking'))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1073,7 +1016,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                           message_thread_id=thread_id,
                                           reply_markup=reply_markup,
                                           disable_notification=silent,
-                                          **self._send_queue_kwargs(msg, old_msg_id))
+                                          **self._make_send_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1105,7 +1048,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._blocking_send_kwargs(msg))
+                                                    **self._make_send_kwargs(msg, mode='blocking'))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1135,7 +1078,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                      reply_to_message_id=target_msg_id,
                                                      message_thread_id=thread_id, reply_markup=reply_markup,
                                                      disable_notification=silent,
-                                                     **self._send_queue_kwargs(msg, old_msg_id))
+                                                     **self._make_send_kwargs(msg, old_msg_id))
                         return tg_msg
                     except pydub.exceptions.CouldntDecodeError as e:
                         self.logger.error("[%s] Failed to decode audio file for conversion: %s. Sending as file.", msg.uid, e)
@@ -1180,7 +1123,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                       message_thread_id=thread_id,
                                       reply_markup=location_reply_markup,
                                       disable_notification=silent,
-                                      **self._send_queue_kwargs(msg, old_msg_id))
+                                      **self._make_send_kwargs(msg, old_msg_id))
 
     def slave_message_video(self, msg: Message, tg_dest: TelegramChatID,
                             thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -1215,7 +1158,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._blocking_send_kwargs(msg))
+                                                    **self._make_send_kwargs(msg, mode='blocking'))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1239,7 +1182,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                        message_thread_id=thread_id,
                                        reply_markup=reply_markup,
                                        disable_notification=silent,
-                                       **self._send_queue_kwargs(msg, old_msg_id))
+                                       **self._make_send_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1269,7 +1212,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._send_queue_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id))
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -52,6 +52,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
     REACTION_DB_WAIT_TIMEOUT = 2.0
     REACTION_DB_WAIT_INTERVAL = 0.05
+    FORUM_CHAT_CACHE_TTL = 3600
 
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
@@ -63,7 +64,7 @@ class SlaveMessageProcessor(LocaleMixin):
         self.chat_manager: ChatObjectCacheManager = channel.chat_manager
         self._pending_slave_messages: set[Tuple[str, str]] = set()
         self._pending_slave_messages_lock = threading.Lock()
-        self._known_forum_chat_ids: set[int] = set()
+        self._known_forum_chat_ids: dict[int, float] = {}
         self._known_forum_chat_ids_lock = threading.Lock()
         self._timing_tls = threading.local()
 
@@ -120,19 +121,29 @@ class SlaveMessageProcessor(LocaleMixin):
 
     def _ensure_forum_cache(self):
         if not hasattr(self, '_known_forum_chat_ids'):
-            self._known_forum_chat_ids = set()
+            self._known_forum_chat_ids = {}
+        elif not isinstance(self._known_forum_chat_ids, dict):
+            now = time.monotonic()
+            self._known_forum_chat_ids = {int(chat_id): now for chat_id in self._known_forum_chat_ids}
         if not hasattr(self, '_known_forum_chat_ids_lock'):
             self._known_forum_chat_ids_lock = threading.Lock()
 
     def _known_forum_chat(self, tg_dest: TelegramChatID) -> bool:
         self._ensure_forum_cache()
         with self._known_forum_chat_ids_lock:
-            return int(tg_dest) in self._known_forum_chat_ids
+            chat_id = int(tg_dest)
+            cached_at = self._known_forum_chat_ids.get(chat_id)
+            if cached_at is None:
+                return False
+            if time.monotonic() - cached_at <= self.FORUM_CHAT_CACHE_TTL:
+                return True
+            del self._known_forum_chat_ids[chat_id]
+            return False
 
     def _mark_known_forum_chat(self, tg_dest: TelegramChatID):
         self._ensure_forum_cache()
         with self._known_forum_chat_ids_lock:
-            self._known_forum_chat_ids.add(int(tg_dest))
+            self._known_forum_chat_ids[int(tg_dest)] = time.monotonic()
 
     def _get_master_chat_is_forum(self, xid: Optional[MessageID], tg_dest: TelegramChatID) -> bool:
         if self._known_forum_chat(tg_dest):
@@ -204,6 +215,8 @@ class SlaveMessageProcessor(LocaleMixin):
             slave_origin_uid = utils.chat_id_to_str(chat=msg.chat)
             dedupe_key = self._dedupe_key(msg, slave_origin_uid)
             if dedupe_key is not None:
+                # In-memory only; process restarts can redeliver duplicates.
+                # The DB hot-path query was intentionally removed.
                 if not self._claim_pending_slave_message(dedupe_key):
                     self.logger.info("[%s] Duplicate slave message is already pending delivery; skipping.",
                                      xid)
@@ -382,7 +395,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            text=self._('Unknown type of message "{0}". (UT01)')
                                            .format(msg.type.name),
-                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                           **self._send_queue_kwargs(msg, old_msg_id))
 
         if tg_msg and commands:
             self.channel.commands.register_command(tg_msg, ETMCommandMsgStorage(
@@ -546,22 +559,17 @@ class SlaveMessageProcessor(LocaleMixin):
             return html.escape(text)
         return text
 
-    @staticmethod
-    def _send_mode(msg: Message,
-                   old_msg_id: Optional[OldMsgID],
-                   thread_id: Optional[TelegramTopicID] = None) -> str:
+    def _send_queue_kwargs(self, msg: Message,
+                           old_msg_id: Optional[OldMsgID]) -> dict:
         force_send_mode = (msg.vendor_specific or {}).get('_force_send_mode')
         if force_send_mode in {'blocking', 'eventual'}:
-            return force_send_mode
-        if old_msg_id is not None or msg.commands:
-            return 'blocking'
-        return 'eventual'
-
-    def _send_queue_kwargs(self, msg: Message,
-                           old_msg_id: Optional[OldMsgID],
-                           thread_id: Optional[TelegramTopicID] = None) -> dict:
+            send_mode = force_send_mode
+        elif old_msg_id is not None or msg.commands:
+            send_mode = 'blocking'
+        else:
+            send_mode = 'eventual'
         kwargs = {
-            '_send_mode': self._send_mode(msg, old_msg_id, thread_id),
+            '_send_mode': send_mode,
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }
         kwargs.update(self._current_message_timing_kwargs())
@@ -612,7 +620,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                           **self._send_queue_kwargs(msg, old_msg_id))
         else:
             # Cannot change reply_to_message_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],
@@ -665,7 +673,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                          message_thread_id=thread_id,
                                          reply_markup=reply_markup,
                                          disable_notification=silent,
-                                         **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                         **self._send_queue_kwargs(msg, old_msg_id))
 
     # Parameters to decide when to pictures as files
     IMG_MIN_SIZE = 1600
@@ -786,7 +794,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                               message_thread_id=thread_id,
                                               reply_markup=reply_markup,
                                               disable_notification=silent,
-                                              **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                              **self._send_queue_kwargs(msg, old_msg_id))
             else:
                 try:
                     assert msg.path
@@ -797,7 +805,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                               **self._send_queue_kwargs(msg, old_msg_id))
                 except telegram.error.BadRequest as e:
                     self.logger.error('[%s] Failed to send it as image, sending as document. Reason: %s',
                                       msg.uid, e)
@@ -810,7 +818,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   message_thread_id=thread_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                                  **self._send_queue_kwargs(msg, old_msg_id))
         finally:
             if msg.file:
                 msg.file.close()
@@ -875,7 +883,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                               **self._send_queue_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -947,7 +955,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                  message_thread_id=thread_id,
                                                  reply_to_message_id=target_msg_id,
                                                  disable_notification=silent,
-                                                 **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                                 **self._send_queue_kwargs(msg, old_msg_id))
                 except IOError:
                     self.logger.warning("[%s] Failed to convert image to webp sticker, sending as document.", msg.uid)
                     assert msg.file and msg.path
@@ -958,7 +966,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   reply_to_message_id=target_msg_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                                  **self._send_queue_kwargs(msg, old_msg_id))
                 finally:
                     if webp_img and not webp_img.closed:
                         webp_img.close()
@@ -1060,7 +1068,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                           message_thread_id=thread_id,
                                           reply_markup=reply_markup,
                                           disable_notification=silent,
-                                          **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                          **self._send_queue_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1122,7 +1130,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                      reply_to_message_id=target_msg_id,
                                                      message_thread_id=thread_id, reply_markup=reply_markup,
                                                      disable_notification=silent,
-                                                     **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                                     **self._send_queue_kwargs(msg, old_msg_id))
                         return tg_msg
                     except pydub.exceptions.CouldntDecodeError as e:
                         self.logger.error("[%s] Failed to decode audio file for conversion: %s. Sending as file.", msg.uid, e)
@@ -1167,7 +1175,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                       message_thread_id=thread_id,
                                       reply_markup=location_reply_markup,
                                       disable_notification=silent,
-                                      **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                      **self._send_queue_kwargs(msg, old_msg_id))
 
     def slave_message_video(self, msg: Message, tg_dest: TelegramChatID,
                             thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -1226,7 +1234,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                        message_thread_id=thread_id,
                                        reply_markup=reply_markup,
                                        disable_notification=silent,
-                                       **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                       **self._send_queue_kwargs(msg, old_msg_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1256,7 +1264,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
+                                           **self._send_queue_kwargs(msg, old_msg_id))
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -376,7 +376,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
             sender_bot_id = getattr(tg_msg, 'sender_bot_id', None)
 
-            self.bot.submit_async_db_write(
+            self.bot.write_db_mapping(
                 etm_msg, tg_msg, old_msg_id, sender_bot_id=sender_bot_id, on_complete=on_db_complete,
             )
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -32,6 +32,7 @@ from ehforwarderbot.message import LinkAttribute, LocationAttribute, MessageComm
 from ehforwarderbot.status import ChatUpdates, MemberUpdates, MessageRemoval, MessageReactionsUpdate
 from ehforwarderbot.types import MessageID
 from . import utils
+from .bot_manager import QueuedDbLogContext
 from .chat_destination_cache import ChatDestinationCache
 from .chat_object_cache import ChatObjectCacheManager
 from .commands import ETMCommandMsgStorage
@@ -102,7 +103,7 @@ class SlaveMessageProcessor(LocaleMixin):
         timing_tls = getattr(self, '_timing_tls', None)
         if timing_tls is None:
             return
-        for key in ('receive_started', 'destination_resolved'):
+        for key in ('receive_started', 'destination_resolved', 'queued_db_on_complete'):
             if hasattr(timing_tls, key):
                 delattr(timing_tls, key)
 
@@ -348,6 +349,10 @@ class SlaveMessageProcessor(LocaleMixin):
         reactions = self.build_reactions_footer(msg.reactions)
 
         msg.text = msg.text or ""
+        on_db_complete = None
+        if dedupe_key is not None:
+            on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
+        self._ensure_timing_tls().queued_db_on_complete = on_db_complete
 
         # Type dispatching
         if msg.type == MsgType.Text:
@@ -408,32 +413,20 @@ class SlaveMessageProcessor(LocaleMixin):
             self._release_pending_slave_message(dedupe_key)
             return
 
-        on_db_complete = None
-        if dedupe_key is not None:
-            on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
-
         if hasattr(tg_msg, '_queued_execution_pending') and tg_msg._queued_execution_pending:
             self.logger.debug("[%s] Message execution is queued (task_id: %s), deferring database logging.",
-                             xid, getattr(tg_msg, 'task_id', 'unknown'))
+                              xid, getattr(tg_msg, 'task_id', 'unknown'))
             receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
             if receive_started is not None:
                 self.logger.debug("[%s] Message enqueue finished in %.3fs since receive.",
                                   xid, time.monotonic() - receive_started)
 
-            etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
-
-            if hasattr(tg_msg, 'task_id'):
-                self.bot.register_queued_database_update(
-                    tg_msg.task_id, etm_msg, old_msg_id, on_complete=on_db_complete,
-                )
-            else:
-                self.logger.warning("[%s] Queued message missing task_id, cannot register database update", xid)
+            if not hasattr(tg_msg, 'task_id'):
+                self.logger.warning("[%s] Queued message missing task_id, cannot track database update", xid)
                 self._release_pending_slave_message(dedupe_key)
         else:
-            # Normal (blocking) execution — send already succeeded,
-            # hand off DB write asynchronously so the calling thread is
-            # not blocked by local I/O, and failures are retried instead
-            # of silently dropped.
+            # Normal (blocking) execution: send already succeeded, then
+            # write the DB mapping once. DB failures are logged only.
             self.logger.debug("[%s] Message is sent to the user with telegram message id %s.%s.",
                               xid, tg_msg.chat.id, tg_msg.message_id)
             receive_started = getattr(getattr(self, '_timing_tls', None), 'receive_started', None)
@@ -572,6 +565,18 @@ class SlaveMessageProcessor(LocaleMixin):
             '_send_mode': send_mode,
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }
+        timing_tls = getattr(self, '_timing_tls', None)
+        if (
+            send_mode == 'eventual'
+            and timing_tls is not None
+            and hasattr(timing_tls, 'queued_db_on_complete')
+        ):
+            on_complete = getattr(timing_tls, 'queued_db_on_complete', None)
+            kwargs['_queued_db_log_context'] = QueuedDbLogContext(
+                ETMMsg.from_efbmsg(msg, self.chat_manager),
+                old_msg_id,
+                on_complete,
+            )
         kwargs.update(self._current_message_timing_kwargs())
         return kwargs
 

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -12,7 +12,7 @@ import urllib.parse
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Tuple, Optional, TYPE_CHECKING, List, IO, Union
+from typing import Callable, Tuple, Optional, TYPE_CHECKING, List, IO, Union, cast
 
 import humanize
 import telegram  # lgtm [py/import-and-import-from]
@@ -55,6 +55,7 @@ class SlaveMessageProcessor(LocaleMixin):
     REACTION_DB_WAIT_TIMEOUT = 2.0
     REACTION_DB_WAIT_INTERVAL = 0.05
     FORUM_CHAT_CACHE_TTL = 3600
+    _NO_DB_CALLBACK = object()
 
     def __init__(self, channel: 'TelegramChannel'):
         self.channel: 'TelegramChannel' = channel
@@ -68,7 +69,6 @@ class SlaveMessageProcessor(LocaleMixin):
         self._pending_slave_messages_lock = threading.Lock()
         self._known_forum_chat_ids: dict[int, float] = {}
         self._known_forum_chat_ids_lock = threading.Lock()
-        self._timing_tls = threading.local()
 
     def _claim_pending_slave_message(self, key: Tuple[str, str]) -> bool:
         with self._pending_slave_messages_lock:
@@ -101,13 +101,6 @@ class SlaveMessageProcessor(LocaleMixin):
                 phase_name,
                 time.monotonic() - started,
             )
-
-    def _clear_dispatch_context(self):
-        timing_tls = getattr(self, '_timing_tls', None)
-        if timing_tls is None:
-            return
-        if hasattr(timing_tls, 'queued_db_on_complete'):
-            delattr(timing_tls, 'queued_db_on_complete')
 
     def _known_forum_chat(self, tg_dest: TelegramChatID) -> bool:
         with self._known_forum_chat_ids_lock:
@@ -256,8 +249,6 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 self.logger.error("Error occurred while processing message from slave channel.\nMessage: %s\n%s\n%s",
                               repr(msg), repr(e), traceback.format_exc())
-        finally:
-            self._clear_dispatch_context()
         return msg
 
     def dispatch_message(self, msg: Message, msg_template: str,
@@ -308,47 +299,46 @@ class SlaveMessageProcessor(LocaleMixin):
         on_db_complete = None
         if dedupe_key is not None:
             on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
-        self._timing_tls.queued_db_on_complete = on_db_complete
 
         # Type dispatching
         if msg.type == MsgType.Text:
             tg_msg = self.slave_message_text(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                             reply_markup, silent)
+                                             reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Link:
             tg_msg = self.slave_message_link(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                             reply_markup, silent)
+                                             reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Sticker:
             tg_msg = self.slave_message_sticker(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                                reply_markup, silent)
+                                                reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Image:
             if self.flag("send_image_as_file"):
                 tg_msg = self.slave_message_file(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                                 reply_markup, silent)
+                                                 reply_markup, silent, on_db_complete=on_db_complete)
             else:
                 tg_msg = self.slave_message_image(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                                  reply_markup, silent)
+                                                  reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Animation:
             tg_msg = self.slave_message_animation(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                                  reply_markup, silent)
+                                                  reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.File:
             tg_msg = self.slave_message_file(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                             reply_markup, silent)
+                                             reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Voice:
             tg_msg = self.slave_message_voice(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                              reply_markup, silent)
+                                              reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Location:
             tg_msg = self.slave_message_location(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                                 reply_markup, silent)
+                                                 reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Video:
             tg_msg = self.slave_message_video(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id, target_msg_id,
-                                              reply_markup, silent)
+                                              reply_markup, silent, on_db_complete=on_db_complete)
         elif msg.type == MsgType.Status:
             # Status messages are not to be recorded in databases
             self._release_pending_slave_message(dedupe_key)
             return self.slave_message_status(msg, tg_dest, thread_id)
         elif msg.type == MsgType.Unsupported:
             tg_msg = self.slave_message_unsupported(msg, tg_dest, thread_id, msg_template, reactions, old_msg_id,
-                                                    target_msg_id, reply_markup, silent)
+                                                    target_msg_id, reply_markup, silent, on_db_complete=on_db_complete)
         else:
             self.bot.send_chat_action(tg_dest, ChatAction.TYPING, message_thread_id=thread_id)
             tg_msg = self.bot.send_message(tg_dest, prefix=msg_template, suffix=reactions,
@@ -356,7 +346,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            text=self._('Unknown type of message "{0}". (UT01)')
                                            .format(msg.type.name),
-                                           **self._make_send_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
 
         if tg_msg and commands:
             self.channel.commands.register_command(tg_msg, ETMCommandMsgStorage(
@@ -502,7 +492,8 @@ class SlaveMessageProcessor(LocaleMixin):
     def _make_send_kwargs(self, msg: Message,
                           old_msg_id: Optional[OldMsgID] = None,
                           *,
-                          mode: Optional[str] = None) -> dict:
+                          mode: Optional[str] = None,
+                          on_complete: object = _NO_DB_CALLBACK) -> dict:
         if mode is not None:
             send_mode = mode
         else:
@@ -517,17 +508,14 @@ class SlaveMessageProcessor(LocaleMixin):
             '_send_mode': send_mode,
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }
-        timing_tls = getattr(self, '_timing_tls', None)
-        if (
-            send_mode == 'eventual'
-            and timing_tls is not None
-            and hasattr(timing_tls, 'queued_db_on_complete')
-        ):
-            on_complete = getattr(timing_tls, 'queued_db_on_complete', None)
+        if send_mode == 'eventual' and on_complete is not self._NO_DB_CALLBACK:
+            db_on_complete = cast(Optional[Callable[[], None]], on_complete)
+            # This is a DB metadata snapshot. Send file handles are cloned when
+            # the Telegram call enters the FIFO queue.
             kwargs['_queued_db_log_context'] = QueuedDbLogContext(
                 ETMMsg.from_efbmsg(msg, self.chat_manager),
                 old_msg_id,
-                on_complete,
+                db_on_complete,
             )
         return kwargs
 
@@ -536,7 +524,8 @@ class SlaveMessageProcessor(LocaleMixin):
                            old_msg_id: Optional[OldMsgID] = None,
                            target_msg_id: Optional[TelegramMessageID] = None,
                            reply_markup: Optional[ReplyMarkup] = None,
-                           silent: bool = False) -> telegram.Message:
+                           silent: bool = False,
+                           on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         """
         Send message as text to Telegram.
 
@@ -568,7 +557,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._make_send_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         else:
             # Cannot change reply_to_message_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],
@@ -588,7 +577,8 @@ class SlaveMessageProcessor(LocaleMixin):
                            old_msg_id: Optional[OldMsgID] = None,
                            target_msg_id: Optional[TelegramMessageID] = None,
                            reply_markup: Optional[ReplyMarkup] = None,
-                           silent: bool = False) -> telegram.Message:
+                           silent: bool = False,
+                           on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.TYPING, message_thread_id=thread_id)
 
         assert isinstance(msg.attributes, LinkAttribute)
@@ -621,7 +611,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                          message_thread_id=thread_id,
                                          reply_markup=reply_markup,
                                          disable_notification=silent,
-                                         **self._make_send_kwargs(msg, old_msg_id))
+                                         **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
 
     # Parameters to decide when to pictures as files
     IMG_MIN_SIZE = 1600
@@ -638,7 +628,8 @@ class SlaveMessageProcessor(LocaleMixin):
                             old_msg_id: Optional[OldMsgID] = None,
                             target_msg_id: Optional[TelegramMessageID] = None,
                             reply_markup: Optional[ReplyMarkup] = None,
-                            silent: bool = False) -> telegram.Message:
+                            silent: bool = False,
+                            on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         assert msg.file
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_PHOTO, message_thread_id=thread_id)
         self.logger.debug("[%s] Message is of %s type; Path: %s; MIME: %s", msg.uid, msg.type, msg.path, msg.mime)
@@ -704,7 +695,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup, disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._make_send_kwargs(msg, mode='blocking'))
+                                                    **self._make_send_kwargs(
+                                                        msg, mode='blocking', on_complete=on_db_complete,
+                                                    ))
                     message.reply_text(file_too_large)
                     return message
 
@@ -742,7 +735,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                               message_thread_id=thread_id,
                                               reply_markup=reply_markup,
                                               disable_notification=silent,
-                                              **self._make_send_kwargs(msg, old_msg_id))
+                                              **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
             else:
                 try:
                     assert msg.path
@@ -753,7 +746,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._make_send_kwargs(msg, old_msg_id))
+                                               **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
                 except telegram.error.BadRequest as e:
                     self.logger.error('[%s] Failed to send it as image, sending as document. Reason: %s',
                                       msg.uid, e)
@@ -766,7 +759,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   message_thread_id=thread_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._make_send_kwargs(msg, old_msg_id))
+                                                  **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         finally:
             if msg.file:
                 msg.file.close()
@@ -777,7 +770,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                 old_msg_id: Optional[OldMsgID] = None,
                                 target_msg_id: Optional[TelegramMessageID] = None,
                                 reply_markup: Optional[ReplyMarkup] = None,
-                                silent: Optional[bool] = None) -> telegram.Message:
+                                silent: Optional[bool] = None,
+                                on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_PHOTO, message_thread_id=thread_id)
 
         self.logger.debug("[%s] Message is an Animation; Path: %s; MIME: %s", msg.uid, msg.path, msg.mime)
@@ -803,7 +797,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._make_send_kwargs(msg, mode='blocking'))
+                                                    **self._make_send_kwargs(
+                                                        msg, mode='blocking', on_complete=on_db_complete,
+                                                    ))
                     message.reply_text(file_too_large)
                     return message
 
@@ -831,7 +827,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               **self._make_send_kwargs(msg, old_msg_id))
+                                               **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -842,7 +838,8 @@ class SlaveMessageProcessor(LocaleMixin):
                               old_msg_id: Optional[OldMsgID] = None,
                               target_msg_id: Optional[TelegramMessageID] = None,
                               reply_markup: Optional[InlineKeyboardMarkup] = None,
-                              silent: bool = False) -> telegram.Message:
+                              silent: bool = False,
+                              on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
 
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_PHOTO, message_thread_id=thread_id)
 
@@ -888,7 +885,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                         parse_mode="HTML", reply_markup=reply_markup,
                                                         disable_notification=silent,
                                                         prefix=msg_template, suffix=reactions,
-                                                        **self._make_send_kwargs(msg, mode='blocking'))
+                                                        **self._make_send_kwargs(
+                                                            msg, mode='blocking', on_complete=on_db_complete,
+                                                        ))
                         message.reply_text(file_too_large)
                         return message
 
@@ -903,7 +902,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                  message_thread_id=thread_id,
                                                  reply_to_message_id=target_msg_id,
                                                  disable_notification=silent,
-                                                 **self._make_send_kwargs(msg, old_msg_id))
+                                                 **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
                 except IOError:
                     self.logger.warning("[%s] Failed to convert image to webp sticker, sending as document.", msg.uid)
                     assert msg.file and msg.path
@@ -914,7 +913,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   reply_to_message_id=target_msg_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  **self._make_send_kwargs(msg, old_msg_id))
+                                                  **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
                 finally:
                     if webp_img and not webp_img.closed:
                         webp_img.close()
@@ -948,7 +947,8 @@ class SlaveMessageProcessor(LocaleMixin):
                            old_msg_id: Optional[OldMsgID] = None,
                            target_msg_id: Optional[TelegramMessageID] = None,
                            reply_markup: Optional[ReplyMarkup] = None,
-                           silent: bool = False) -> telegram.Message:
+                           silent: bool = False,
+                           on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_DOCUMENT, message_thread_id=thread_id)
 
         if msg.filename is None and msg.path is not None:
@@ -989,7 +989,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._make_send_kwargs(msg, mode='blocking'))
+                                                    **self._make_send_kwargs(
+                                                        msg, mode='blocking', on_complete=on_db_complete,
+                                                    ))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1016,7 +1018,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                           message_thread_id=thread_id,
                                           reply_markup=reply_markup,
                                           disable_notification=silent,
-                                          **self._make_send_kwargs(msg, old_msg_id))
+                                          **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1027,7 +1029,8 @@ class SlaveMessageProcessor(LocaleMixin):
                             old_msg_id: Optional[OldMsgID] = None,
                             target_msg_id: Optional[TelegramMessageID] = None,
                             reply_markup: Optional[ReplyMarkup] = None,
-                            silent: bool = False) -> telegram.Message:
+                            silent: bool = False,
+                            on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.RECORD_VOICE, message_thread_id=thread_id)
         if msg.text:
             text = self.html_substitutions(msg)
@@ -1048,7 +1051,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._make_send_kwargs(msg, mode='blocking'))
+                                                    **self._make_send_kwargs(
+                                                        msg, mode='blocking', on_complete=on_db_complete,
+                                                    ))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1078,14 +1083,15 @@ class SlaveMessageProcessor(LocaleMixin):
                                                      reply_to_message_id=target_msg_id,
                                                      message_thread_id=thread_id, reply_markup=reply_markup,
                                                      disable_notification=silent,
-                                                     **self._make_send_kwargs(msg, old_msg_id))
+                                                     **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
                         return tg_msg
                     except pydub.exceptions.CouldntDecodeError as e:
                         self.logger.error("[%s] Failed to decode audio file for conversion: %s. Sending as file.", msg.uid, e)
                         msg.file.seek(0)
                         return self.slave_message_file(msg, tg_dest, thread_id, msg_template, reactions,
                                                        old_msg_id=None,
-                                                       target_msg_id=target_msg_id, reply_markup=reply_markup, silent=silent)
+                                                       target_msg_id=target_msg_id, reply_markup=reply_markup,
+                                                       silent=silent, on_db_complete=on_db_complete)
             raise RuntimeError("Unreachable: voice message send path not entered")
         finally:
             if msg.file is not None:
@@ -1097,7 +1103,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                old_msg_id: Optional[OldMsgID] = None,
                                target_msg_id: Optional[TelegramMessageID] = None,
                                reply_markup: Optional[InlineKeyboardMarkup] = None,
-                               silent: bool = False) -> telegram.Message:
+                               silent: bool = False,
+                               on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         # Location messages cannot be edited in content by bots.
         # If an edit request comes, send a new message replying to the old one.
         self.bot.send_chat_action(tg_dest, ChatAction.FIND_LOCATION, message_thread_id=thread_id)
@@ -1123,14 +1130,15 @@ class SlaveMessageProcessor(LocaleMixin):
                                       message_thread_id=thread_id,
                                       reply_markup=location_reply_markup,
                                       disable_notification=silent,
-                                      **self._make_send_kwargs(msg, old_msg_id))
+                                      **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
 
     def slave_message_video(self, msg: Message, tg_dest: TelegramChatID,
                             thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
                             old_msg_id: Optional[OldMsgID] = None,
                             target_msg_id: Optional[TelegramMessageID] = None,
                             reply_markup: Optional[ReplyMarkup] = None,
-                            silent: bool = False) -> telegram.Message:
+                            silent: bool = False,
+                            on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.bot.send_chat_action(tg_dest, ChatAction.UPLOAD_VIDEO, message_thread_id=thread_id)
         if msg.text:
             text = self.html_substitutions(msg)
@@ -1158,7 +1166,9 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
                                                     prefix=msg_template, suffix=reactions,
-                                                    **self._make_send_kwargs(msg, mode='blocking'))
+                                                    **self._make_send_kwargs(
+                                                        msg, mode='blocking', on_complete=on_db_complete,
+                                                    ))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1182,7 +1192,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                        message_thread_id=thread_id,
                                        reply_markup=reply_markup,
                                        disable_notification=silent,
-                                       **self._make_send_kwargs(msg, old_msg_id))
+                                       **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1193,7 +1203,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                   old_msg_id: Optional[OldMsgID] = None,
                                   target_msg_id: Optional[TelegramMessageID] = None,
                                   reply_markup: Optional[ReplyMarkup] = None,
-                                  silent: bool = False) -> telegram.Message:
+                                  silent: bool = False,
+                                  on_db_complete: Optional[Callable[[], None]] = None) -> telegram.Message:
         self.logger.debug("[%s] Sending as an unsupported message.", msg.uid)
         self.bot.send_chat_action(tg_dest, ChatAction.TYPING, message_thread_id=thread_id)
         if msg.text:
@@ -1212,7 +1223,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           **self._make_send_kwargs(msg, old_msg_id))
+                                           **self._make_send_kwargs(msg, old_msg_id, on_complete=on_db_complete))
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -294,7 +294,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                            disable_notification=silent,
                                            message_thread_id=thread_id,
                                            text=self._('Unknown type of message "{0}". (UT01)')
-                                           .format(msg.type.name))
+                                           .format(msg.type.name),
+                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
 
         if tg_msg and commands:
             self.channel.commands.register_command(tg_msg, ETMCommandMsgStorage(
@@ -311,18 +312,18 @@ class SlaveMessageProcessor(LocaleMixin):
         if dedupe_key is not None:
             on_db_complete = lambda: self._release_pending_slave_message(dedupe_key)
 
-        if hasattr(tg_msg, '_delayed_execution_pending') and tg_msg._delayed_execution_pending:
-            self.logger.debug("[%s] Message execution is delayed (task_id: %s), deferring database logging.",
+        if hasattr(tg_msg, '_queued_execution_pending') and tg_msg._queued_execution_pending:
+            self.logger.debug("[%s] Message execution is queued (task_id: %s), deferring database logging.",
                              xid, getattr(tg_msg, 'task_id', 'unknown'))
 
             etm_msg = ETMMsg.from_efbmsg(msg, self.chat_manager)
 
             if hasattr(tg_msg, 'task_id'):
-                self.bot.register_delayed_database_update(
+                self.bot.register_queued_database_update(
                     tg_msg.task_id, etm_msg, old_msg_id, on_complete=on_db_complete,
                 )
             else:
-                self.logger.warning("[%s] Delayed message missing task_id, cannot register database update", xid)
+                self.logger.warning("[%s] Queued message missing task_id, cannot register database update", xid)
                 self._release_pending_slave_message(dedupe_key)
         else:
             # Normal (blocking) execution — send already succeeded,
@@ -437,6 +438,20 @@ class SlaveMessageProcessor(LocaleMixin):
             return 'blocking'
         return 'eventual'
 
+    def _send_queue_kwargs(self, msg: Message,
+                           old_msg_id: Optional[OldMsgID],
+                           thread_id: Optional[TelegramTopicID] = None) -> dict:
+        return {
+            '_send_mode': self._send_mode(msg, old_msg_id, thread_id),
+            '_slave_id': utils.chat_id_to_str(chat=msg.chat),
+        }
+
+    def _blocking_send_kwargs(self, msg: Message) -> dict:
+        return {
+            '_send_mode': 'blocking',
+            '_slave_id': utils.chat_id_to_str(chat=msg.chat),
+        }
+
     def slave_message_text(self, msg: Message, tg_dest: TelegramChatID,
                            thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
                            old_msg_id: Optional[OldMsgID] = None,
@@ -474,7 +489,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         else:
             # Cannot change reply_to_message_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],
@@ -527,7 +542,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                          message_thread_id=thread_id,
                                          reply_markup=reply_markup,
                                          disable_notification=silent,
-                                         _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                         **self._send_queue_kwargs(msg, old_msg_id, thread_id))
 
     # Parameters to decide when to pictures as files
     IMG_MIN_SIZE = 1600
@@ -609,7 +624,8 @@ class SlaveMessageProcessor(LocaleMixin):
                     message = self.bot.send_message(chat_id=tg_dest, reply_to_message_id=target_msg_id,
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup, disable_notification=silent,
-                                                    prefix=msg_template, suffix=reactions)
+                                                    prefix=msg_template, suffix=reactions,
+                                                    **self._blocking_send_kwargs(msg))
                     message.reply_text(file_too_large)
                     return message
 
@@ -647,7 +663,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                               message_thread_id=thread_id,
                                               reply_markup=reply_markup,
                                               disable_notification=silent,
-                                              _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                              **self._send_queue_kwargs(msg, old_msg_id, thread_id))
             else:
                 try:
                     assert msg.path
@@ -658,7 +674,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                               **self._send_queue_kwargs(msg, old_msg_id, thread_id))
                 except telegram.error.BadRequest as e:
                     self.logger.error('[%s] Failed to send it as image, sending as document. Reason: %s',
                                       msg.uid, e)
@@ -671,7 +687,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   message_thread_id=thread_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                                  **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         finally:
             if msg.file:
                 msg.file.close()
@@ -707,7 +723,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
-                                                    prefix=msg_template, suffix=reactions)
+                                                    prefix=msg_template, suffix=reactions,
+                                                    **self._blocking_send_kwargs(msg))
                     message.reply_text(file_too_large)
                     return message
 
@@ -735,7 +752,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                message_thread_id=thread_id,
                                                reply_markup=reply_markup,
                                                disable_notification=silent,
-                                               _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                               **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -791,7 +808,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                                         text=self.html_substitutions(msg),
                                                         parse_mode="HTML", reply_markup=reply_markup,
                                                         disable_notification=silent,
-                                                        prefix=msg_template, suffix=reactions)
+                                                        prefix=msg_template, suffix=reactions,
+                                                        **self._blocking_send_kwargs(msg))
                         message.reply_text(file_too_large)
                         return message
 
@@ -806,7 +824,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                  message_thread_id=thread_id,
                                                  reply_to_message_id=target_msg_id,
                                                  disable_notification=silent,
-                                                 _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                                 **self._send_queue_kwargs(msg, old_msg_id, thread_id))
                 except IOError:
                     self.logger.warning("[%s] Failed to convert image to webp sticker, sending as document.", msg.uid)
                     assert msg.file and msg.path
@@ -817,7 +835,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                   reply_to_message_id=target_msg_id,
                                                   reply_markup=reply_markup,
                                                   disable_notification=silent,
-                                                  _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                                  **self._send_queue_kwargs(msg, old_msg_id, thread_id))
                 finally:
                     if webp_img and not webp_img.closed:
                         webp_img.close()
@@ -891,7 +909,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
-                                                    prefix=msg_template, suffix=reactions)
+                                                    prefix=msg_template, suffix=reactions,
+                                                    **self._blocking_send_kwargs(msg))
                     message.reply_text(file_too_large)
                     return message
 
@@ -918,7 +937,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                           message_thread_id=thread_id,
                                           reply_markup=reply_markup,
                                           disable_notification=silent,
-                                          _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                          **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -949,7 +968,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
-                                                    prefix=msg_template, suffix=reactions)
+                                                    prefix=msg_template, suffix=reactions,
+                                                    **self._blocking_send_kwargs(msg))
                     message.reply_text(file_too_large)
                     return message
 
@@ -979,7 +999,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                                      reply_to_message_id=target_msg_id,
                                                      message_thread_id=thread_id, reply_markup=reply_markup,
                                                      disable_notification=silent,
-                                                     _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                                     **self._send_queue_kwargs(msg, old_msg_id, thread_id))
                         return tg_msg
                     except pydub.exceptions.CouldntDecodeError as e:
                         self.logger.error("[%s] Failed to decode audio file for conversion: %s. Sending as file.", msg.uid, e)
@@ -1024,7 +1044,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                       message_thread_id=thread_id,
                                       reply_markup=location_reply_markup,
                                       disable_notification=silent,
-                                      _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                      **self._send_queue_kwargs(msg, old_msg_id, thread_id))
 
     def slave_message_video(self, msg: Message, tg_dest: TelegramChatID,
                             thread_id: Optional[TelegramTopicID], msg_template: str, reactions: str,
@@ -1058,7 +1078,8 @@ class SlaveMessageProcessor(LocaleMixin):
                                                     message_thread_id=thread_id, text=text,
                                                     parse_mode="HTML", reply_markup=reply_markup,
                                                     disable_notification=silent,
-                                                    prefix=msg_template, suffix=reactions)
+                                                    prefix=msg_template, suffix=reactions,
+                                                    **self._blocking_send_kwargs(msg))
                     message.reply_text(file_too_large)
                     return message
 
@@ -1082,7 +1103,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                        message_thread_id=thread_id,
                                        reply_markup=reply_markup,
                                        disable_notification=silent,
-                                       _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                       **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         finally:
             if msg.file is not None:
                 msg.file.close()
@@ -1112,7 +1133,7 @@ class SlaveMessageProcessor(LocaleMixin):
                                            message_thread_id=thread_id,
                                            reply_markup=reply_markup,
                                            disable_notification=silent,
-                                           _send_mode=self._send_mode(msg, old_msg_id, thread_id))
+                                           **self._send_queue_kwargs(msg, old_msg_id, thread_id))
         else:
             # Cannot change reply_to_message_id or thread_id when editing a message
             edit_kwargs = dict(chat_id=old_msg_id[0],
@@ -1389,7 +1410,7 @@ class SlaveMessageProcessor(LocaleMixin):
 
     def _cleanup_pending_local_api_files(self):
         """Delete temp files copied to shared dir for local Bot API sends in this thread.
-        Only cleans up files that were NOT already claimed by a delayed task."""
+        Only cleans up files that were NOT already claimed by a queued task."""
         tls = self.bot._cleanup_tls
         pending = getattr(tls, 'pending_cleanup', [])
         for path in pending:

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -203,14 +203,6 @@ class SlaveMessageProcessor(LocaleMixin):
             slave_origin_uid = utils.chat_id_to_str(chat=msg.chat)
             dedupe_key = self._dedupe_key(msg, slave_origin_uid)
             if dedupe_key is not None:
-                existing_msg = self.db.get_msg_log(slave_msg_id=msg.uid,
-                                                   slave_origin_uid=slave_origin_uid)
-                if existing_msg is not None:
-                    self.logger.info(
-                        "[%s] Duplicate slave message is already logged as Telegram message %s; skipping.",
-                        xid, existing_msg.master_msg_id,
-                    )
-                    return msg
                 if not self._claim_pending_slave_message(dedupe_key):
                     self.logger.info("[%s] Duplicate slave message is already pending delivery; skipping.",
                                      xid)

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -513,7 +513,7 @@ class SlaveMessageProcessor(LocaleMixin):
                 send_mode = 'blocking'
             else:
                 send_mode = 'eventual'
-        kwargs = {
+        kwargs: dict[str, object] = {
             '_send_mode': send_mode,
             '_slave_id': utils.chat_id_to_str(chat=msg.chat),
         }

--- a/tests/integration/test_backfill_history.py
+++ b/tests/integration/test_backfill_history.py
@@ -230,10 +230,7 @@ def _queued_state(bot_manager):
     with bot_manager._send_queues_lock:
         queue_len = sum(len(q) for q in bot_manager._send_queues.values())
     in_flight = len(bot_manager._send_in_flight)
-    with bot_manager._pending_logs_lock:
-        pending_len = len(bot_manager._pending_queued_logs)
-        completed_len = len(bot_manager._completed_queued_results)
-    return queue_len + in_flight, pending_len, completed_len
+    return queue_len + in_flight
 
 
 def _logs_with_prefix(channel_with_auxiliary_bots, chat, prefix: str):
@@ -271,14 +268,14 @@ async def _wait_for_stream_stable(channel_with_auxiliary_bots, client, *, tg_cha
             for idx in _extract_stream_indices(message.raw_text or "", prefix)
         }
 
-        queue_len, pending_len, completed_len = _queued_state(channel_with_auxiliary_bots.bot_manager)
+        queue_len = _queued_state(channel_with_auxiliary_bots.bot_manager)
         last_debug = (
             f"db={len(db_logs)} (idx={len(db_indices)}/{expected_count}), "
             f"tg={len(group_messages)} (idx={len(group_indices)}/{expected_count}), "
-            f"queued_queue={queue_len}, pending_logs={pending_len}, completed_results={completed_len}"
+            f"queued_tasks={queue_len}"
         )
 
-        if db_indices == expected and group_indices == expected and (queue_len, pending_len, completed_len) == (0, 0, 0):
+        if db_indices == expected and group_indices == expected and queue_len == 0:
             return db_logs, group_messages
 
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
@@ -377,9 +374,9 @@ async def test_auxiliary_bots_stream_blackbox_and_relink(channel_with_auxiliary_
     group_sender_ids = {message.sender_id for message in group_messages if message.sender_id is not None}
     assert group_sender_ids & set(working_aux_bot_ids), "Expected auxiliary bot messages in the linked group."
 
-    # 4) Queued send path was used, and there is no pending queued DB update residue.
+    # 4) Queued send path was used, and there is no queued send residue.
     assert bot_manager._tasks_enqueued - task_counter_before >= STREAM_MESSAGE_COUNT
-    assert _queued_state(bot_manager) == (0, 0, 0)
+    assert _queued_state(bot_manager) == 0
 
     # ---- Relink/migration checks (same stream history) ----
 

--- a/tests/integration/test_backfill_history.py
+++ b/tests/integration/test_backfill_history.py
@@ -226,13 +226,13 @@ def _expected_stream_indices(expected_count: int) -> Set[int]:
     return set(range(expected_count))
 
 
-def _delayed_state(bot_manager):
-    with bot_manager._chat_queues_lock:
-        queue_len = sum(len(q) for q in bot_manager._chat_queues.values())
-    in_flight = len(bot_manager._chat_in_flight)
+def _queued_state(bot_manager):
+    with bot_manager._send_queues_lock:
+        queue_len = sum(len(q) for q in bot_manager._send_queues.values())
+    in_flight = len(bot_manager._send_in_flight)
     with bot_manager._pending_logs_lock:
-        pending_len = len(bot_manager._pending_delayed_logs)
-        completed_len = len(bot_manager._completed_delayed_results)
+        pending_len = len(bot_manager._pending_queued_logs)
+        completed_len = len(bot_manager._completed_queued_results)
     return queue_len + in_flight, pending_len, completed_len
 
 
@@ -271,11 +271,11 @@ async def _wait_for_stream_stable(channel_with_auxiliary_bots, client, *, tg_cha
             for idx in _extract_stream_indices(message.raw_text or "", prefix)
         }
 
-        queue_len, pending_len, completed_len = _delayed_state(channel_with_auxiliary_bots.bot_manager)
+        queue_len, pending_len, completed_len = _queued_state(channel_with_auxiliary_bots.bot_manager)
         last_debug = (
             f"db={len(db_logs)} (idx={len(db_indices)}/{expected_count}), "
             f"tg={len(group_messages)} (idx={len(group_indices)}/{expected_count}), "
-            f"delayed_queue={queue_len}, pending_logs={pending_len}, completed_results={completed_len}"
+            f"queued_queue={queue_len}, pending_logs={pending_len}, completed_results={completed_len}"
         )
 
         if db_indices == expected and group_indices == expected and (queue_len, pending_len, completed_len) == (0, 0, 0):
@@ -337,7 +337,7 @@ async def test_auxiliary_bots_stream_blackbox_and_relink(channel_with_auxiliary_
     command_message = await _link_chat(client, helper, bot_id, chat.uid, source_group_id)
 
     bot_manager = channel_with_auxiliary_bots.bot_manager
-    task_counter_before = bot_manager._tasks_scheduled
+    task_counter_before = bot_manager._tasks_enqueued
 
     stream_thread, sent_texts, stream_errors = _start_mock_stream(slave_with_auxiliary_bots, chat, prefix)
     await asyncio.to_thread(stream_thread.join, STREAM_DURATION_SECONDS + 15.0)
@@ -377,9 +377,9 @@ async def test_auxiliary_bots_stream_blackbox_and_relink(channel_with_auxiliary_
     group_sender_ids = {message.sender_id for message in group_messages if message.sender_id is not None}
     assert group_sender_ids & set(working_aux_bot_ids), "Expected auxiliary bot messages in the linked group."
 
-    # 4) Delayed queue was used, and there is no pending delayed DB update residue.
-    assert bot_manager._tasks_scheduled - task_counter_before >= STREAM_MESSAGE_COUNT
-    assert _delayed_state(bot_manager) == (0, 0, 0)
+    # 4) Queued send path was used, and there is no pending queued DB update residue.
+    assert bot_manager._tasks_enqueued - task_counter_before >= STREAM_MESSAGE_COUNT
+    assert _queued_state(bot_manager) == (0, 0, 0)
 
     # ---- Relink/migration checks (same stream history) ----
 

--- a/tests/integration/test_master_message_destination.py
+++ b/tests/integration/test_master_message_destination.py
@@ -124,8 +124,8 @@ async def test_master_master_destination_suggestion(helper, client, bot_id, slav
         assert not channel.chat_dest_cache.enabled
         slave.clear_messages()
         chat = slave.chat_with_alias
-        slave.send_text_message(chat, author=chat.other)
-        await helper.wait_for_message_text(in_chats(bot_id) & regex(chat.display_name))
+        previous_message = slave.send_text_message(chat, author=chat.other)
+        await helper.wait_for_message_text(in_chats(bot_id) & regex(previous_message.text))
 
         content = "test_master_master_destination_suggestion this shall be replied with a list of candidates"
         sent_message: Message = await client.send_message(bot_id, content)

--- a/tests/integration/test_master_message_destination.py
+++ b/tests/integration/test_master_message_destination.py
@@ -131,11 +131,16 @@ async def test_master_master_destination_suggestion(helper, client, bot_id, slav
         sent_message: Message = await client.send_message(bot_id, content)
         message: Message = await helper.wait_for_message(in_chats(bot_id) & has_button)
         buttons: List[List[MessageButton]] = message.buttons
-        first_button: MessageButton = buttons[0][0]
-        assert chat.display_name in first_button.text  # The message from previous chat should come first in the list
+        chat_buttons = [
+            button
+            for row in buttons
+            for button in row
+            if chat.display_name in button.text
+        ]
+        assert chat_buttons
         # await buttons[-1][0].click()  # Cancel the error message.
 
-        await first_button.click()  # deliver the message
+        await chat_buttons[0].click()  # deliver the message
         slave.clear_messages()
 
         content = "test_master_master_destination_suggestion edited message shall be delivered without a prompt"

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -35,6 +35,15 @@ def _cleanup_link_state(channel, chat, master_chat_id):
     channel.db.remove_topic_assoc(slave_uid=utils.chat_id_to_str(chat=chat))
 
 
+def _sent_link_message(chat_id, message_id, sender_bot_id=None):
+    sent_message = Mock()
+    sent_message.chat.id = chat_id
+    sent_message.message_id = message_id
+    sent_message.reply_text = Mock()
+    sent_message.sender_bot_id = sender_bot_id
+    return sent_message
+
+
 def test_link_chat_auto_mode_backfills_on_first_link(channel, slave, bot_group):
     chat = slave.chat_with_alias
     storage_key = (TelegramChatID(bot_group), TelegramMessageID(101))
@@ -42,10 +51,7 @@ def test_link_chat_auto_mode_backfills_on_first_link(channel, slave, bot_group):
     _store_link_session(channel, chat, storage_key, backfill_mode=None)
     update = _build_link_update(bot_group)
 
-    sent_message = Mock()
-    sent_message.chat.id = bot_group
-    sent_message.message_id = 500
-    sent_message.reply_text = Mock()
+    sent_message = _sent_link_message(bot_group, 500)
 
     with patch.object(channel.bot_manager, "send_message", return_value=sent_message), \
          patch.object(channel.bot_manager, "edit_message_text"), \
@@ -58,6 +64,28 @@ def test_link_chat_auto_mode_backfills_on_first_link(channel, slave, bot_group):
     _cleanup_link_state(channel, chat, bot_group)
 
 
+def test_link_chat_edits_status_message_with_sender_bot(channel, slave, bot_group):
+    chat = slave.chat_with_alias
+    storage_key = (TelegramChatID(bot_group), TelegramMessageID(105))
+    token = utils.b64en(utils.message_id_to_str(*storage_key))
+    _store_link_session(channel, chat, storage_key, backfill_mode=None)
+    update = _build_link_update(bot_group)
+
+    sent_message = _sent_link_message(bot_group, 505, sender_bot_id="8465204282")
+
+    with patch.object(channel.bot_manager, "send_message", return_value=sent_message), \
+         patch.object(channel.bot_manager, "edit_message_text") as edit_message_text, \
+         patch.object(channel.chat_binding, "migrate_chat_history"), \
+         patch.object(channel.chat_binding, "send_history_link"):
+        channel.chat_binding.link_chat(update, [token])
+
+    target_status_edit = edit_message_text.call_args_list[0].kwargs
+    assert target_status_edit["chat_id"] == bot_group
+    assert target_status_edit["message_id"] == 505
+    assert target_status_edit["_sender_bot_id"] == "8465204282"
+    _cleanup_link_state(channel, chat, bot_group)
+
+
 def test_link_chat_auto_mode_sends_history_link_on_relink(channel, slave, bot_group):
     chat = slave.chat_with_alias
     storage_key = (TelegramChatID(bot_group), TelegramMessageID(102))
@@ -67,10 +95,7 @@ def test_link_chat_auto_mode_sends_history_link_on_relink(channel, slave, bot_gr
     channel.db.add_chat_assoc(master_uid, utils.chat_id_to_str(chat=chat))
     update = _build_link_update(bot_group)
 
-    sent_message = Mock()
-    sent_message.chat.id = bot_group
-    sent_message.message_id = 501
-    sent_message.reply_text = Mock()
+    sent_message = _sent_link_message(bot_group, 501)
 
     with patch.object(channel.bot_manager, "send_message", return_value=sent_message), \
          patch.object(channel.bot_manager, "edit_message_text"), \
@@ -92,10 +117,7 @@ def test_link_chat_backfill_override_forces_behavior(channel, slave, bot_group):
     channel.db.add_chat_assoc(master_uid, utils.chat_id_to_str(chat=chat))
     update = _build_link_update(bot_group)
 
-    sent_message = Mock()
-    sent_message.chat.id = bot_group
-    sent_message.message_id = 502
-    sent_message.reply_text = Mock()
+    sent_message = _sent_link_message(bot_group, 502)
 
     with patch.object(channel.bot_manager, "send_message", return_value=sent_message), \
          patch.object(channel.bot_manager, "edit_message_text"), \
@@ -118,10 +140,7 @@ def test_link_chat_raw_message_override_forces_behavior_when_args_are_truncated(
     update = _build_link_update(bot_group)
     update.effective_message.text = f"/start {token} true"
 
-    sent_message = Mock()
-    sent_message.chat.id = bot_group
-    sent_message.message_id = 503
-    sent_message.reply_text = Mock()
+    sent_message = _sent_link_message(bot_group, 503)
 
     with patch.object(channel.bot_manager, "send_message", return_value=sent_message), \
          patch.object(channel.bot_manager, "edit_message_text"), \

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1667,6 +1667,25 @@ def test_dispatch_send_strips_internal_kwargs_and_sets_skip_retry():
     assert task.target in mgr._send_in_flight
 
 
+@pytest.mark.parametrize(("method_name", "kwargs"), [
+    ("edit_message_caption", {"chat_id": 123, "message_id": 456, "caption": "updated"}),
+    ("edit_message_media", {"chat_id": 123, "message_id": 456, "media": object()}),
+])
+def test_edit_methods_strip_skip_retry_before_calling_bot(method_name, kwargs):
+    mgr = SimpleNamespace(_active_bot=Mock())
+    bot_method = getattr(mgr._active_bot, method_name)
+    bot_method.return_value = SimpleNamespace(chat_id=123, message_id=456)
+
+    getattr(TelegramBotManager, method_name)(
+        mgr,
+        _bypass_rate_limit=True,
+        _skip_rate_limit_retry=True,
+        **kwargs,
+    )
+
+    assert "_skip_rate_limit_retry" not in bot_method.call_args.kwargs
+
+
 def test_harvest_forbidden_from_main_bot_logs_explicit_error():
     from concurrent.futures import Future
     from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
@@ -1780,7 +1799,7 @@ def test_harvest_completed_sends_runs_callback_without_db_for_non_message_result
     on_complete.assert_called_once()
 
 
-def test_submit_async_db_write_logs_failure_and_runs_completion_callback():
+def test_write_db_mapping_logs_failure_and_runs_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     on_complete = Mock()
@@ -1796,7 +1815,7 @@ def test_submit_async_db_write_logs_failure_and_runs_completion_callback():
     real_tg_msg.message_id = 999
 
     with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
-        TelegramBotManager.submit_async_db_write(
+        TelegramBotManager.write_db_mapping(
             mgr,
             etm_msg,
             real_tg_msg,

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -11,9 +11,15 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 import telegram.error
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaVideo
+from telegram.request._requestparameter import RequestParameter
 
-from efb_telegram_master.bot_manager import SendReceipt, TelegramBotManager, _clone_file_argument
+from efb_telegram_master.bot_manager import (
+    SendReceipt,
+    TelegramBotManager,
+    _clone_file_argument,
+    _clone_media_argument,
+)
 from efb_telegram_master.bot_manager import AsyncTelegramRuntime
 from efb_telegram_master.rate_limiter import SlidingWindowRateLimiter
 
@@ -796,6 +802,17 @@ def test_clone_file_argument_keeps_queued_send_readable_after_original_closes():
     original.close()
 
     assert cloned.read() == b"queued-media"
+
+
+def test_clone_media_argument_preserves_input_media_attachment_reference():
+    original = InputMediaVideo(io.BytesIO(b"queued-video"), filename="queued-video.mp4")
+
+    cloned = _clone_media_argument(original)
+    request_parameter = RequestParameter.from_input("media", cloned)
+
+    assert cloned.media.attach_name is not None
+    assert request_parameter.value["media"] == cloned.media.attach_uri
+    assert cloned.media.attach_name in request_parameter.multipart_data
 
 
 def test_select_queued_sender_available_path_passes_topic_affinity_key_to_bot_pool():

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -122,7 +122,7 @@ def test_rate_limit_decorator_forced_routes_to_sender_bot():
     aux_bot = SimpleNamespace(bot=object(), bot_id=777, disabled=False, reserve_slot=Mock(return_value=0.0))
     used_bots = []
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _select_forced_sender=Mock(return_value=(aux_bot.bot, "777", 0.0)),
         _using_bot=lambda bot: SimpleNamespace(__enter__=lambda *a: None, __exit__=lambda *a: None),
@@ -156,7 +156,7 @@ def test_rate_limit_decorator_falls_back_to_main_bot_when_sender_missing():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     bot_pool = SimpleNamespace(get_bot_by_id=Mock(return_value=None), acquire_send_slot=Mock())
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=bot_pool,
         _select_forced_sender=Mock(return_value=(object(), None, 0.0)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
@@ -178,7 +178,7 @@ def _make_lightweight_bot_manager():
     manager._bot = Mock()
     manager._tls = threading.local()
     manager.bot_pool = None
-    manager._delayed_worker_stop = threading.Event()
+    manager._send_worker_stop = threading.Event()
     manager.GLOBAL_LIMIT = 30
     manager.GLOBAL_WINDOW = 1.0
     manager.CHAT_LIMIT = 20
@@ -245,6 +245,17 @@ def test_build_bot_passes_local_mode_when_enabled():
     )
 
 
+def test_default_connection_pool_size_uses_worker_count_multiplier(monkeypatch):
+    monkeypatch.delenv(TelegramBotManager.HTTPX_POOL_MULTIPLIER_ENV, raising=False)
+    assert TelegramBotManager._default_connection_pool_size({}) == 16
+
+    monkeypatch.setenv(TelegramBotManager.HTTPX_POOL_MULTIPLIER_ENV, "3")
+    assert TelegramBotManager._default_connection_pool_size({}) == 24
+
+    monkeypatch.setenv(TelegramBotManager.HTTPX_POOL_MULTIPLIER_ENV, "0.5")
+    assert TelegramBotManager._default_connection_pool_size({}) == 4
+
+
 def test_rate_limit_decorator_routes_new_send_through_aux_pool():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     aux_bot = SimpleNamespace(bot=object(), bot_id=999, disabled=False)
@@ -257,7 +268,7 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
             return False
 
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(1.0, 0, 0)),
         _select_sender=Mock(return_value=(aux_bot.bot, "999", 0.0)),
@@ -273,7 +284,7 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
     result = decorated(manager, 123)
 
     assert result.sender_bot_id == "999"
-    manager._select_sender.assert_called_once_with(123, has_callback=False, message_thread_id=None)
+    manager._select_sender.assert_called_once_with(123, slave_id=None, has_callback=False, message_thread_id=None)
     manager._record_aux_use.assert_called_once_with(123)
 
 
@@ -308,7 +319,7 @@ def test_rate_limit_decorator_force_main_bot_skips_aux_pool():
 
     manager = SimpleNamespace(
         _bot=object(),
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
         _select_sender=Mock(),
@@ -349,7 +360,7 @@ def test_rate_limit_decorator_pool_route_forbidden_marks_chat_non_member_and_ret
             return False
 
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
         _select_sender=Mock(return_value=(aux_bot.bot, "999", 0.0)),
@@ -382,7 +393,7 @@ def test_rate_limit_decorator_routes_reply_to_target_sender_bot():
             return False
 
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id="777")))),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
@@ -416,7 +427,7 @@ def test_rate_limit_decorator_callback_keyboard_uses_main_bot_even_when_reply_ta
 
     manager = SimpleNamespace(
         _bot=main_bot,
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id="777")))),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
@@ -452,7 +463,7 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
 
     manager = SimpleNamespace(
         _bot=object(),
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id=None)))),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
@@ -475,39 +486,39 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
     manager.bot_pool.acquire_send_slot.assert_not_called()
 
 
-def test_rate_limit_decorator_eventual_mode_schedules_delayed_task():
+def test_rate_limit_decorator_eventual_mode_enqueues_task():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     scheduled = SimpleNamespace(queued=True, task_id="task-1")
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=None,
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
-        _schedule_eventual_send=Mock(return_value=scheduled),
+        _enqueue_eventual_send=Mock(return_value=scheduled),
         logger=Mock(),
     )
 
-    result = decorated(manager, 123, _send_mode="eventual")
+    result = decorated(manager, 123, _send_mode="eventual", _slave_id="slave.chat")
 
     assert result is scheduled
-    manager._schedule_eventual_send.assert_called_once()
+    manager._enqueue_eventual_send.assert_called_once()
 
 
 def test_rate_limit_decorator_eventual_reply_preserves_target_sender():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     scheduled = SimpleNamespace(queued=True, task_id="task-1")
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id=None)))),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
-        _schedule_eventual_send=Mock(return_value=scheduled),
+        _enqueue_eventual_send=Mock(return_value=scheduled),
         logger=Mock(),
     )
 
-    result = decorated(manager, 123, reply_to_message_id=456, _send_mode="eventual")
+    result = decorated(manager, 123, reply_to_message_id=456, _send_mode="eventual", _slave_id="slave.chat")
 
     assert result is scheduled
-    scheduled_kwargs = manager._schedule_eventual_send.call_args.args[3]
+    scheduled_kwargs = manager._enqueue_eventual_send.call_args.args[4]
     assert scheduled_kwargs["reply_to_message_id"] == 456
     assert scheduled_kwargs["_force_sender_known"] is True
     assert scheduled_kwargs["_force_sender_bot_id"] is None
@@ -603,7 +614,7 @@ def test_rate_limit_decorator_forced_sender_fallback_reserves_main_slot():
     calls = []
 
     manager = SimpleNamespace(
-        _delayed_worker_stop=threading.Event(),
+        _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=None)),
         _select_forced_sender=Mock(return_value=(object(), None, 3.0)),
         _calculate_rate_limit_delay=Mock(side_effect=lambda chat_id: calls.append(chat_id) or (0.0, 0, 0)),
@@ -619,7 +630,7 @@ def test_rate_limit_decorator_forced_sender_fallback_reserves_main_slot():
     assert calls == [123]
 
 
-def test_clone_file_argument_keeps_delayed_send_readable_after_original_closes():
+def test_clone_file_argument_keeps_queued_send_readable_after_original_closes():
     original = io.BytesIO(b"queued-media")
 
     cloned = _clone_file_argument(original)
@@ -628,17 +639,17 @@ def test_clone_file_argument_keeps_delayed_send_readable_after_original_closes()
     assert cloned.read() == b"queued-media"
 
 
-def test_select_unfrozen_sender_passes_topic_affinity_key_to_bot_pool():
+def test_select_available_sender_passes_topic_affinity_key_to_bot_pool():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(bot=object(), bot_id=777)
     manager = SimpleNamespace(
         bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _bot_chat_frozen_until={},
+        _bot_chat_disabled_until={},
         _bot=object(),
     )
 
-    TelegramBotManager._select_unfrozen_sender(
+    TelegramBotManager._select_available_sender(
         manager,
         chat_id,
         message_thread_id=1007,
@@ -647,9 +658,31 @@ def test_select_unfrozen_sender_passes_topic_affinity_key_to_bot_pool():
 
     call = manager.bot_pool.acquire_send_slot.call_args
     assert call.args == (chat_id,)
-    assert call.kwargs["max_delay"] == 0.01
+    assert call.kwargs["max_delay"] == 1e-9
     assert call.kwargs["affinity_key"] == (chat_id, 1007)
     assert callable(call.kwargs["skip_bot"])
+
+
+def test_select_available_sender_uses_slave_affinity_key():
+    chat_id = -1002608436807
+    aux_bot = SimpleNamespace(bot=object(), bot_id=777)
+    manager = SimpleNamespace(
+        bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
+        _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
+        _bot_chat_disabled_until={},
+        _bot=object(),
+    )
+
+    TelegramBotManager._select_available_sender(
+        manager,
+        chat_id,
+        slave_id="slave.chat",
+        message_thread_id=1007,
+        now=10.0,
+    )
+
+    call = manager.bot_pool.acquire_send_slot.call_args
+    assert call.kwargs["affinity_key"] == "slave.chat"
 
 
 def test_handle_rate_limit_error_retries_retry_after_even_when_generic_retry_disabled():
@@ -662,7 +695,7 @@ def test_handle_rate_limit_error_retries_retry_after_even_when_generic_retry_dis
         return "ok"
 
     handler = TelegramBotManager.Decorators.handle_rate_limit_error(flaky)
-    manager = SimpleNamespace(_delayed_worker_stop=threading.Event(), logger=Mock())
+    manager = SimpleNamespace(_send_worker_stop=threading.Event(), logger=Mock())
     TelegramBotManager.Decorators.enable_retry = False
 
     with patch("efb_telegram_master.bot_manager.time.sleep") as sleep:
@@ -749,9 +782,9 @@ def test_graceful_stop_runs_ptb_shutdown_on_runtime_loop():
     shutdown_complete_event.set()
     manager = SimpleNamespace(
         logger=Mock(),
-        _chat_queues={"mock": ["task"]},
-        _chat_queues_lock=threading.Lock(), _chat_in_flight={},
-        stop_delayed_worker=Mock(),
+        _send_queues={"mock": ["task"]},
+        _send_queues_lock=threading.Lock(), _send_in_flight={},
+        stop_queued_worker=Mock(),
         bot_pool=SimpleNamespace(shutdown=Mock()),
         application=SimpleNamespace(stop_running=Mock()),
         _shutdown_ptb_application=Mock(return_value=shutdown_coro),
@@ -768,7 +801,7 @@ def test_graceful_stop_runs_ptb_shutdown_on_runtime_loop():
 
     TelegramBotManager.graceful_stop(manager)
 
-    manager.stop_delayed_worker.assert_called_once()
+    manager.stop_queued_worker.assert_called_once()
     manager.bot_pool.shutdown.assert_called_once()
     manager._shutdown_ptb_application.assert_called_once_with()
     manager._runtime.call.assert_called_once_with(shutdown_coro, timeout=30)
@@ -783,9 +816,9 @@ def test_graceful_stop_falls_back_to_direct_stop_when_runtime_loop_missing():
     shutdown_complete_event.set()
     manager = SimpleNamespace(
         logger=Mock(),
-        _chat_queues={},
-        _chat_queues_lock=threading.Lock(), _chat_in_flight={},
-        stop_delayed_worker=Mock(),
+        _send_queues={},
+        _send_queues_lock=threading.Lock(), _send_in_flight={},
+        stop_queued_worker=Mock(),
         bot_pool=None,
         application=SimpleNamespace(stop_running=Mock()),
         _shutdown_ptb_application=Mock(),
@@ -802,7 +835,7 @@ def test_graceful_stop_falls_back_to_direct_stop_when_runtime_loop_missing():
 
     TelegramBotManager.graceful_stop(manager)
 
-    manager.stop_delayed_worker.assert_called_once()
+    manager.stop_queued_worker.assert_called_once()
     manager._shutdown_ptb_application.assert_not_called()
     manager._runtime.call.assert_not_called()
     manager._runtime.call_soon.assert_called_once_with(manager.application.stop_running)
@@ -821,9 +854,9 @@ def test_graceful_stop_signals_manual_event_on_event_loop_when_runtime_loop_miss
     manual_evt = SimpleNamespace(set=Mock(), _loop=manual_evt_loop)
     manager = SimpleNamespace(
         logger=Mock(),
-        _chat_queues={},
-        _chat_queues_lock=threading.Lock(), _chat_in_flight={},
-        stop_delayed_worker=Mock(),
+        _send_queues={},
+        _send_queues_lock=threading.Lock(), _send_in_flight={},
+        stop_queued_worker=Mock(),
         bot_pool=None,
         application=SimpleNamespace(stop_running=Mock()),
         _shutdown_complete_event=shutdown_complete_event,
@@ -968,91 +1001,76 @@ def test_run_application_lifecycle_publishes_manual_stop_event_after_post_init()
 # ── Tests for outbound pipeline refactoring ─────────────────────────
 
 
-# --- Per-chat FIFO ordering ---
+# --- Per-target FIFO ordering ---
 
-def test_schedule_appends_to_per_chat_fifo():
-    """Tasks for the same chat_id must be appended in FIFO order."""
-    import collections as _collections
+def test_enqueue_appends_to_per_target_fifo():
+    """Tasks for the same (slave_id, chat_id) target must be FIFO."""
     from efb_telegram_master.bot_manager import TelegramBotManager
 
+    target = ("slave.chat", 100)
     mgr = SimpleNamespace(
-        _chat_queues={},
-        _chat_queues_lock=threading.Lock(),
-        _chat_frozen_until={},
+        _send_queues={},
+        _send_queues_lock=threading.Lock(),
         _tasks_scheduled=0,
         logger=Mock(),
     )
 
-    TelegramBotManager._schedule_delayed_task(
-        mgr, chat_id=100, delay_time=0, function=lambda: None,
-        args=(), kwargs={}, cleanup_files=[],
-    )
-    TelegramBotManager._schedule_delayed_task(
-        mgr, chat_id=100, delay_time=0, function=lambda: None,
-        args=(), kwargs={}, cleanup_files=[],
-    )
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[])
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[])
 
-    q = mgr._chat_queues[100]
+    q = mgr._send_queues[target]
     assert len(q) == 2
     assert q[0].task_id != q[1].task_id  # distinct tasks
     assert mgr._tasks_scheduled == 2
 
 
-def test_requeue_prepends_to_chat_fifo():
-    """_requeue_delayed_task must put the task at the FRONT of its chat queue."""
+def test_requeue_prepends_to_target_fifo():
+    """_requeue_send_task must put the task at the FRONT of its target queue."""
     import collections as _collections
-    from efb_telegram_master.bot_manager import DelayedTask, TelegramBotManager
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
 
-    existing_task = DelayedTask(
-        execute_time=1.0, chat_id=100, function=lambda: "existing",
-        args=(), kwargs={}, task_id="t2",
-    )
+    target = ("slave.chat", 100)
+    existing_task = QueuedSendTask(target, lambda: "existing", (), {}, "t2")
 
     mgr = SimpleNamespace(
-        _chat_queues={100: _collections.deque([existing_task])},
-        _chat_queues_lock=threading.Lock(),
-        _chat_frozen_until={},
+        _send_queues={target: _collections.deque([existing_task])},
+        _send_queues_lock=threading.Lock(),
         logger=Mock(),
     )
 
-    retry_task = DelayedTask(
-        execute_time=0.0, chat_id=100, function=lambda: "retry",
-        args=(), kwargs={}, task_id="t1",
-    )
+    retry_task = QueuedSendTask(target, lambda: "retry", (), {}, "t1")
 
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
-        TelegramBotManager._requeue_delayed_task(mgr, retry_task, 2.0)
+    TelegramBotManager._requeue_send_task(mgr, retry_task)
 
-    q = mgr._chat_queues[100]
+    q = mgr._send_queues[target]
     assert len(q) == 2
     assert q[0].task_id == "t1"  # retry task at front
     assert q[1].task_id == "t2"  # existing task behind it
-    assert mgr._chat_frozen_until[100] == 12.0
 
 
 def test_harvest_completed_sends_does_not_retry_bad_request():
     """BadRequest is not transient, even though PTB makes it a NetworkError."""
     from concurrent.futures import Future
-    from efb_telegram_master.bot_manager import DelayedTask, TelegramBotManager
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
 
-    task = DelayedTask(
-        execute_time=0.0, chat_id=100, function=lambda: None,
-        args=(), kwargs={"reply_to_message_id": 321, "message_thread_id": 654}, task_id="t1",
+    task = QueuedSendTask(
+        ("slave.chat", 100), lambda: None, (),
+        {"reply_to_message_id": 321, "message_thread_id": 654}, "t1",
     )
     future = Future()
     future.set_exception(telegram.error.BadRequest("Message to be replied not found"))
     mgr = SimpleNamespace(
-        _chat_in_flight={100: (future, task, None)},
+        _send_in_flight={task.target: (future, task, None)},
         logger=Mock(),
-        _requeue_delayed_task=Mock(),
+        _release_reserved_slot=Mock(),
     )
 
     TelegramBotManager._harvest_completed_sends(mgr)
 
-    assert mgr._chat_in_flight == {}
-    mgr._requeue_delayed_task.assert_not_called()
+    assert mgr._send_in_flight == {}
+    mgr._release_reserved_slot.assert_called_once_with(None, 100)
     mgr.logger.warning.assert_called_once_with(
-        "Non-retryable BadRequest for delayed task %s, dropping: %s "
+        "Non-retryable BadRequest for queued task %s, dropping: %s "
         "(chat_id=%s, reply_to_message_id=%s, message_thread_id=%s, method=%s)",
         "t1",
         future.exception(),
@@ -1063,26 +1081,122 @@ def test_harvest_completed_sends_does_not_retry_bad_request():
     )
 
 
-def test_different_chats_dispatch_concurrently():
-    """Tasks for different chat_ids can be in-flight simultaneously."""
+def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    future = Future()
+    future.set_exception(telegram.error.RetryAfter(2))
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, "777")},
+        _bot_chat_disabled_until={},
+        _release_reserved_slot=Mock(),
+        _requeue_send_task=Mock(),
+        logger=Mock(),
+    )
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
+        TelegramBotManager._harvest_completed_sends(mgr)
+
+    assert mgr._send_in_flight == {}
+    assert mgr._bot_chat_disabled_until == {("777", 100): 12.0}
+    mgr._release_reserved_slot.assert_called_once_with("777", 100)
+    mgr._requeue_send_task.assert_called_once_with(task)
+
+
+def test_harvest_429_disables_only_sender_bot_chat_and_requeues_front():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    future = Future()
+    future.set_exception(telegram.error.NetworkError("429 Too Many Requests"))
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, "777")},
+        _bot_chat_disabled_until={},
+        _release_reserved_slot=Mock(),
+        _requeue_send_task=Mock(),
+        logger=Mock(),
+    )
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
+        TelegramBotManager._harvest_completed_sends(mgr)
+
+    assert mgr._send_in_flight == {}
+    assert mgr._bot_chat_disabled_until == {("777", 100): 70.0}
+    mgr._release_reserved_slot.assert_called_once_with("777", 100)
+    mgr._requeue_send_task.assert_called_once_with(task)
+
+
+def test_dispatch_ready_send_tasks_requeues_local_limiter_delay_without_disabling_bot_chat():
+    import collections as _collections
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    mgr = SimpleNamespace(
+        _send_queues={task.target: _collections.deque([task])},
+        _send_queues_lock=threading.Lock(),
+        _send_in_flight={},
+        _send_worker_stop=threading.Event(),
+        _select_available_sender=Mock(return_value=(object(), None, 2.0)),
+        _dispatch_send=Mock(),
+        _requeue_send_task=None,
+        _bot_chat_disabled_until={},
+    )
+    mgr._requeue_send_task = TelegramBotManager._requeue_send_task.__get__(mgr, TelegramBotManager)
+
+    TelegramBotManager._dispatch_ready_send_tasks(mgr, 10.0)
+
+    assert list(mgr._send_queues[task.target]) == [task]
+    assert mgr._bot_chat_disabled_until == {}
+    mgr._dispatch_send.assert_not_called()
+
+
+def test_different_targets_dispatch_concurrently_with_same_chat_id():
+    """Tasks for different targets can be in-flight simultaneously."""
     import collections as _collections
     from concurrent.futures import Future
-    from efb_telegram_master.bot_manager import DelayedTask
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
 
-    # Simulate: chat 100 already has a send in-flight,
-    # chat 200 should still be dispatchable.
     pending_future = Future()
-    in_flight = {100: (pending_future, "task", None)}
+    in_flight = {("slave.a", 100): (pending_future, "task", None)}
+    sender_bot = object()
 
-    chat_queues = {
-        100: _collections.deque([DelayedTask(0, 100, lambda: None, (), {}, "t1")]),
-        200: _collections.deque([DelayedTask(0, 200, lambda: None, (), {}, "t2")]),
+    send_queues = {
+        ("slave.a", 100): _collections.deque([QueuedSendTask(("slave.a", 100), lambda: None, (), {}, "t1")]),
+        ("slave.b", 100): _collections.deque([QueuedSendTask(("slave.b", 100), lambda: None, (), {}, "t2")]),
     }
+    mgr = SimpleNamespace(
+        _send_queues=send_queues,
+        _send_queues_lock=threading.Lock(),
+        _send_in_flight=in_flight,
+        _send_worker_stop=threading.Event(),
+        _select_available_sender=Mock(return_value=(sender_bot, "777", 0.0)),
+        _dispatch_send=Mock(),
+    )
 
-    # chat 100 is blocked (in_flight), chat 200 is free
-    dispatchable = [cid for cid, q in chat_queues.items() if q and cid not in in_flight]
-    assert 100 not in dispatchable
-    assert 200 in dispatchable
+    TelegramBotManager._dispatch_ready_send_tasks(mgr, 10.0)
+
+    mgr._dispatch_send.assert_called_once()
+    dispatched_task = mgr._dispatch_send.call_args.args[0]
+    assert dispatched_task.target == ("slave.b", 100)
+    assert ("slave.a", 100) in mgr._send_queues
+    assert ("slave.b", 100) not in mgr._send_queues
+
+
+def test_queued_placeholder_has_no_delay_fields():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    placeholder = TelegramBotManager._create_queued_message_placeholder(
+        SimpleNamespace(logger=Mock()), 100, "task-1",
+    )
+
+    assert placeholder.text == "[Message queued for delivery]"
+    assert placeholder._queued_execution_pending is True
+    assert not hasattr(placeholder, "delay_time")
+    assert not hasattr(placeholder, "is_delayed")
+    assert not hasattr(placeholder, "_delayed_execution_pending")
 
 
 # --- DB retry queue ---
@@ -1107,7 +1221,7 @@ def test_finalize_db_update_enqueues_on_failure():
     real_tg_msg.message_id = 999
 
     with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
-        TelegramBotManager._finalize_delayed_database_update(
+        TelegramBotManager._finalize_queued_database_update(
             mgr, etm_msg, None, real_tg_msg, sender_bot_id=None,
         )
 
@@ -1171,11 +1285,10 @@ def test_process_db_retry_queue_gives_up_after_max_retries():
 
 def test_cleanup_stale_rendezvous_removes_old_entries():
     from efb_telegram_master.bot_manager import TelegramBotManager
-    import time as _time
 
     mgr = SimpleNamespace(
-        _pending_delayed_logs={"old_task": (Mock(), None, 1.0)},       # registered_at = 1.0
-        _completed_delayed_results={"old_result": (Mock(), None, 2.0)},  # completed_at = 2.0
+        _pending_queued_logs={"old_task": (Mock(), None, 1.0)},       # registered_at = 1.0
+        _completed_queued_results={"old_result": (Mock(), None, 2.0)},  # completed_at = 2.0
         _pending_logs_lock=threading.Lock(),
         _rendezvous_ttl=600.0,
         logger=Mock(),
@@ -1184,16 +1297,16 @@ def test_cleanup_stale_rendezvous_removes_old_entries():
     with patch("efb_telegram_master.bot_manager.time.time", return_value=700.0):
         TelegramBotManager._cleanup_stale_rendezvous(mgr)
 
-    assert "old_task" not in mgr._pending_delayed_logs
-    assert "old_result" not in mgr._completed_delayed_results
+    assert "old_task" not in mgr._pending_queued_logs
+    assert "old_result" not in mgr._completed_queued_results
 
 
 def test_cleanup_stale_rendezvous_keeps_fresh_entries():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     mgr = SimpleNamespace(
-        _pending_delayed_logs={"fresh": (Mock(), None, 100.0)},
-        _completed_delayed_results={},
+        _pending_queued_logs={"fresh": (Mock(), None, 100.0)},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         _rendezvous_ttl=600.0,
         logger=Mock(),
@@ -1202,67 +1315,67 @@ def test_cleanup_stale_rendezvous_keeps_fresh_entries():
     with patch("efb_telegram_master.bot_manager.time.time", return_value=200.0):
         TelegramBotManager._cleanup_stale_rendezvous(mgr)
 
-    assert "fresh" in mgr._pending_delayed_logs
+    assert "fresh" in mgr._pending_queued_logs
 
 
 # --- Rendezvous dicts store timestamps ---
 
-def test_register_delayed_database_update_stores_timestamp():
+def test_register_queued_database_update_stores_timestamp():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     mgr = SimpleNamespace(
-        _pending_delayed_logs={},
-        _completed_delayed_results={},
+        _pending_queued_logs={},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
     with patch("efb_telegram_master.bot_manager.time.time", return_value=42.0):
-        TelegramBotManager.register_delayed_database_update(mgr, "task-1", Mock(), None)
+        TelegramBotManager.register_queued_database_update(mgr, "task-1", Mock(), None)
 
-    entry = mgr._pending_delayed_logs["task-1"]
+    entry = mgr._pending_queued_logs["task-1"]
     assert len(entry) == 3
     assert entry[2] == 42.0  # registered_at timestamp
 
 
-def test_register_delayed_database_update_stores_completion_callback():
+def test_register_queued_database_update_stores_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     on_complete = Mock()
     mgr = SimpleNamespace(
-        _pending_delayed_logs={},
-        _completed_delayed_results={},
+        _pending_queued_logs={},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
-    TelegramBotManager.register_delayed_database_update(
+    TelegramBotManager.register_queued_database_update(
         mgr, "task-1", Mock(), None, on_complete=on_complete,
     )
 
-    entry = mgr._pending_delayed_logs["task-1"]
+    entry = mgr._pending_queued_logs["task-1"]
     assert len(entry) == 4
     assert entry[3] is on_complete
 
 
-def test_drop_delayed_database_update_runs_completion_callback():
+def test_drop_queued_database_update_runs_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     on_complete = Mock()
     mgr = SimpleNamespace(
-        _pending_delayed_logs={"task-1": (Mock(), None, 1.0, on_complete)},
-        _completed_delayed_results={},
+        _pending_queued_logs={"task-1": (Mock(), None, 1.0, on_complete)},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
-    TelegramBotManager._drop_delayed_database_update(mgr, "task-1")
+    TelegramBotManager._drop_queued_database_update(mgr, "task-1")
 
-    assert "task-1" not in mgr._pending_delayed_logs
+    assert "task-1" not in mgr._pending_queued_logs
     on_complete.assert_called_once()
 
 
-def test_drop_delayed_database_update_before_register_runs_late_callback():
+def test_drop_queued_database_update_before_register_runs_late_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     on_complete = Mock()
@@ -1270,24 +1383,24 @@ def test_drop_delayed_database_update_before_register_runs_late_callback():
     db_mock.add_or_update_message_log = Mock()
     mgr = SimpleNamespace(
         channel=SimpleNamespace(db=db_mock),
-        _pending_delayed_logs={},
-        _completed_delayed_results={},
+        _pending_queued_logs={},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
-    TelegramBotManager._drop_delayed_database_update(mgr, "task-1")
-    TelegramBotManager.register_delayed_database_update(
+    TelegramBotManager._drop_queued_database_update(mgr, "task-1")
+    TelegramBotManager.register_queued_database_update(
         mgr, "task-1", Mock(), None, on_complete=on_complete,
     )
 
-    assert "task-1" not in mgr._pending_delayed_logs
-    assert "task-1" not in mgr._completed_delayed_results
+    assert "task-1" not in mgr._pending_queued_logs
+    assert "task-1" not in mgr._completed_queued_results
     db_mock.add_or_update_message_log.assert_not_called()
     on_complete.assert_called_once()
 
 
-def test_handle_delayed_database_update_runs_completion_callback():
+def test_handle_queued_database_update_runs_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     on_complete = Mock()
@@ -1297,33 +1410,33 @@ def test_handle_delayed_database_update_runs_completion_callback():
     db_mock = Mock()
     mgr = SimpleNamespace(
         channel=SimpleNamespace(db=db_mock),
-        _pending_delayed_logs={"task-1": (etm_msg, None, 1.0, on_complete)},
-        _completed_delayed_results={},
+        _pending_queued_logs={"task-1": (etm_msg, None, 1.0, on_complete)},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
     with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
-        TelegramBotManager._handle_delayed_database_update(mgr, "task-1", real_tg_msg)
+        TelegramBotManager._handle_queued_database_update(mgr, "task-1", real_tg_msg)
 
-    assert "task-1" not in mgr._pending_delayed_logs
+    assert "task-1" not in mgr._pending_queued_logs
     db_mock.add_or_update_message_log.assert_called_once()
     on_complete.assert_called_once()
 
 
-def test_handle_delayed_database_update_stores_timestamp():
+def test_handle_queued_database_update_stores_timestamp():
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     mgr = SimpleNamespace(
-        _pending_delayed_logs={},
-        _completed_delayed_results={},
+        _pending_queued_logs={},
+        _completed_queued_results={},
         _pending_logs_lock=threading.Lock(),
         logger=Mock(),
     )
 
     with patch("efb_telegram_master.bot_manager.time.time", return_value=55.0):
-        TelegramBotManager._handle_delayed_database_update(mgr, "task-2", Mock(), sender_bot_id="bot1")
+        TelegramBotManager._handle_queued_database_update(mgr, "task-2", Mock(), sender_bot_id="bot1")
 
-    entry = mgr._completed_delayed_results["task-2"]
+    entry = mgr._completed_queued_results["task-2"]
     assert len(entry) == 3
     assert entry[2] == 55.0  # completed_at timestamp

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -32,6 +32,22 @@ def _bind_reserved_slot_helper(manager):
     return manager
 
 
+def _bind_db_update_helpers(manager):
+    manager._run_database_update_callback = TelegramBotManager._run_database_update_callback.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._write_database_update = TelegramBotManager._write_database_update.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._finish_queued_database_update = TelegramBotManager._finish_queued_database_update.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    return manager
+
+
 def test_text_prefix_suffix(channel, bot_admin):
     message = channel.bot_manager.send_message(bot_admin, 'Message', prefix='Prefix', suffix='Suffix')
     assert message.text == 'Prefix\nMessage\nSuffix'
@@ -1190,6 +1206,7 @@ def test_harvest_completed_sends_does_not_retry_bad_request():
         logger=Mock(),
         _release_reserved_slot=Mock(),
     )
+    _bind_db_update_helpers(mgr)
 
     TelegramBotManager._harvest_completed_sends(mgr)
 
@@ -1496,6 +1513,7 @@ def test_harvest_forbidden_from_main_bot_logs_explicit_error():
         _release_reserved_slot=Mock(),
         logger=Mock(),
     )
+    _bind_db_update_helpers(mgr)
 
     TelegramBotManager._harvest_completed_sends(mgr)
 
@@ -1508,244 +1526,117 @@ def test_harvest_forbidden_from_main_bot_logs_explicit_error():
     )
 
 
-# --- DB retry queue ---
+# --- Queued DB logging ---
 
-def test_finalize_db_update_enqueues_on_failure():
-    """DB write failure must push to retry queue, not crash."""
+def test_enqueue_eventual_send_moves_db_context_from_kwargs_to_task():
+    from efb_telegram_master.bot_manager import QueuedDbLogContext, TelegramBotManager
+
+    db_context = QueuedDbLogContext(Mock(), None, Mock())
+    mgr = SimpleNamespace(
+        _send_queues={},
+        _send_queues_lock=threading.Lock(),
+        _tasks_enqueued=0,
+        logger=Mock(),
+    )
+    mgr._enqueue_send_task = TelegramBotManager._enqueue_send_task.__get__(mgr, TelegramBotManager)
+    mgr._create_queued_message_placeholder = TelegramBotManager._create_queued_message_placeholder.__get__(
+        mgr,
+        TelegramBotManager,
+    )
+    mgr._make_send_receipt = TelegramBotManager._make_send_receipt.__get__(mgr, TelegramBotManager)
+
+    TelegramBotManager._enqueue_eventual_send(
+        mgr,
+        "slave.chat",
+        100,
+        lambda: None,
+        (),
+        {"_queued_db_log_context": db_context, "text": "hello"},
+    )
+
+    task = mgr._send_queues[("slave.chat", 100)][0]
+    assert task.db_log_context is db_context
+    assert "_queued_db_log_context" not in task.kwargs
+
+
+def test_harvest_completed_sends_writes_db_from_task_context():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedDbLogContext, QueuedSendTask, TelegramBotManager
+
+    on_complete = Mock()
+    etm_msg = Mock()
+    real_tg_msg = Mock()
+    real_tg_msg.message_id = 999
+    db_mock = Mock()
+    db_context = QueuedDbLogContext(etm_msg, "old-message-id", on_complete)
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1", db_log_context=db_context)
+    future = Future()
+    future.set_result(real_tg_msg)
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, "777")},
+        channel=SimpleNamespace(db=db_mock),
+        _record_aux_use=Mock(),
+        logger=Mock(),
+    )
+    _bind_db_update_helpers(mgr)
+
+    with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
+        TelegramBotManager._harvest_completed_sends(mgr)
+
+    db_mock.add_or_update_message_log.assert_called_once_with(
+        etm_msg,
+        real_tg_msg,
+        "old-message-id",
+        sender_bot_id="777",
+    )
+    etm_msg.put_telegram_file.assert_called_once_with(real_tg_msg)
+    on_complete.assert_called_once()
+
+
+def test_harvest_completed_sends_runs_callback_without_db_for_non_message_result():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedDbLogContext, QueuedSendTask, TelegramBotManager
+
+    on_complete = Mock()
+    db_context = QueuedDbLogContext(Mock(), None, on_complete)
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1", db_log_context=db_context)
+    future = Future()
+    future.set_result(None)
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, None)},
+        logger=Mock(),
+    )
+    _bind_db_update_helpers(mgr)
+
+    TelegramBotManager._harvest_completed_sends(mgr)
+
+    db_context.etm_msg.put_telegram_file.assert_not_called()
+    on_complete.assert_called_once()
+
+
+def test_submit_async_db_write_logs_failure_and_runs_completion_callback():
     from efb_telegram_master.bot_manager import TelegramBotManager
-    from efb_telegram_master.msg_type import get_msg_type
 
+    on_complete = Mock()
     db_mock = Mock()
     db_mock.add_or_update_message_log = Mock(side_effect=Exception("DB down"))
-
     mgr = SimpleNamespace(
         channel=SimpleNamespace(db=db_mock),
-        _db_retry_queue=[],
-        _db_retry_lock=threading.Lock(),
         logger=Mock(),
     )
-
+    _bind_db_update_helpers(mgr)
     etm_msg = Mock()
     real_tg_msg = Mock()
     real_tg_msg.message_id = 999
 
     with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
-        TelegramBotManager._finalize_queued_database_update(
-            mgr, etm_msg, None, real_tg_msg, sender_bot_id=None,
+        TelegramBotManager.submit_async_db_write(
+            mgr,
+            etm_msg,
+            real_tg_msg,
+            sender_bot_id=None,
+            on_complete=on_complete,
         )
 
-    assert len(mgr._db_retry_queue) == 1
-    entry = mgr._db_retry_queue[0]
-    assert entry[4] == 1  # attempt count
-
-
-def test_process_db_retry_queue_succeeds_on_retry():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    db_mock = Mock()
-    db_mock.add_or_update_message_log = Mock()  # succeeds now
-    on_complete = Mock()
-
-    etm_msg = Mock()
-    real_tg_msg = Mock()
-    real_tg_msg.message_id = 999
-
-    mgr = SimpleNamespace(
-        channel=SimpleNamespace(db=db_mock),
-        _db_retry_queue=[(etm_msg, None, real_tg_msg, None, 1, 0.0, on_complete)],
-        _db_retry_lock=threading.Lock(),
-        _db_max_retries=5,
-        logger=Mock(),
-    )
-
-    TelegramBotManager._process_db_retry_queue(mgr)
-
-    db_mock.add_or_update_message_log.assert_called_once()
-    assert len(mgr._db_retry_queue) == 0
+    mgr.logger.warning.assert_called_once()
     on_complete.assert_called_once()
-
-
-def test_process_db_retry_queue_gives_up_after_max_retries():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    db_mock = Mock()
-    db_mock.add_or_update_message_log = Mock(side_effect=Exception("still down"))
-
-    etm_msg = Mock()
-    real_tg_msg = Mock()
-    real_tg_msg.message_id = 999
-
-    mgr = SimpleNamespace(
-        channel=SimpleNamespace(db=db_mock),
-        _db_retry_queue=[(etm_msg, None, real_tg_msg, None, 5, 0.0)],
-        _db_retry_lock=threading.Lock(),
-        _db_max_retries=5,
-        logger=Mock(),
-    )
-
-    TelegramBotManager._process_db_retry_queue(mgr)
-
-    # Should NOT re-enqueue — max retries exceeded
-    assert len(mgr._db_retry_queue) == 0
-    mgr.logger.error.assert_called()
-
-
-# --- Rendezvous TTL cleanup ---
-
-def test_cleanup_stale_rendezvous_removes_old_entries():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    mgr = SimpleNamespace(
-        _pending_queued_logs={"old_task": (Mock(), None, 1.0)},       # registered_at = 1.0
-        _completed_queued_results={"old_result": (Mock(), None, 2.0)},  # completed_at = 2.0
-        _pending_logs_lock=threading.Lock(),
-        _rendezvous_ttl=600.0,
-        logger=Mock(),
-    )
-
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=700.0):
-        TelegramBotManager._cleanup_stale_rendezvous(mgr)
-
-    assert "old_task" not in mgr._pending_queued_logs
-    assert "old_result" not in mgr._completed_queued_results
-
-
-def test_cleanup_stale_rendezvous_keeps_fresh_entries():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    mgr = SimpleNamespace(
-        _pending_queued_logs={"fresh": (Mock(), None, 100.0)},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        _rendezvous_ttl=600.0,
-        logger=Mock(),
-    )
-
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=200.0):
-        TelegramBotManager._cleanup_stale_rendezvous(mgr)
-
-    assert "fresh" in mgr._pending_queued_logs
-
-
-# --- Rendezvous dicts store timestamps ---
-
-def test_register_queued_database_update_stores_timestamp():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    mgr = SimpleNamespace(
-        _pending_queued_logs={},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=42.0):
-        TelegramBotManager.register_queued_database_update(mgr, "task-1", Mock(), None)
-
-    entry = mgr._pending_queued_logs["task-1"]
-    assert len(entry) == 3
-    assert entry[2] == 42.0  # registered_at timestamp
-
-
-def test_register_queued_database_update_stores_completion_callback():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    on_complete = Mock()
-    mgr = SimpleNamespace(
-        _pending_queued_logs={},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    TelegramBotManager.register_queued_database_update(
-        mgr, "task-1", Mock(), None, on_complete=on_complete,
-    )
-
-    entry = mgr._pending_queued_logs["task-1"]
-    assert len(entry) == 4
-    assert entry[3] is on_complete
-
-
-def test_drop_queued_database_update_runs_completion_callback():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    on_complete = Mock()
-    mgr = SimpleNamespace(
-        _pending_queued_logs={"task-1": (Mock(), None, 1.0, on_complete)},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    TelegramBotManager._drop_queued_database_update(mgr, "task-1")
-
-    assert "task-1" not in mgr._pending_queued_logs
-    on_complete.assert_called_once()
-
-
-def test_drop_queued_database_update_before_register_runs_late_callback():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    on_complete = Mock()
-    db_mock = Mock()
-    db_mock.add_or_update_message_log = Mock()
-    mgr = SimpleNamespace(
-        channel=SimpleNamespace(db=db_mock),
-        _pending_queued_logs={},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    TelegramBotManager._drop_queued_database_update(mgr, "task-1")
-    TelegramBotManager.register_queued_database_update(
-        mgr, "task-1", Mock(), None, on_complete=on_complete,
-    )
-
-    assert "task-1" not in mgr._pending_queued_logs
-    assert "task-1" not in mgr._completed_queued_results
-    db_mock.add_or_update_message_log.assert_not_called()
-    on_complete.assert_called_once()
-
-
-def test_handle_queued_database_update_runs_completion_callback():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    on_complete = Mock()
-    etm_msg = Mock()
-    real_tg_msg = Mock()
-    real_tg_msg.message_id = 999
-    db_mock = Mock()
-    mgr = SimpleNamespace(
-        channel=SimpleNamespace(db=db_mock),
-        _pending_queued_logs={"task-1": (etm_msg, None, 1.0, on_complete)},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    with patch("efb_telegram_master.bot_manager.get_msg_type", return_value="text"):
-        TelegramBotManager._handle_queued_database_update(mgr, "task-1", real_tg_msg)
-
-    assert "task-1" not in mgr._pending_queued_logs
-    db_mock.add_or_update_message_log.assert_called_once()
-    on_complete.assert_called_once()
-
-
-def test_handle_queued_database_update_stores_timestamp():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    mgr = SimpleNamespace(
-        _pending_queued_logs={},
-        _completed_queued_results={},
-        _pending_logs_lock=threading.Lock(),
-        logger=Mock(),
-    )
-
-    with patch("efb_telegram_master.bot_manager.time.time", return_value=55.0):
-        TelegramBotManager._handle_queued_database_update(mgr, "task-2", Mock(), sender_bot_id="bot1")
-
-    entry = mgr._completed_queued_results["task-2"]
-    assert len(entry) == 3
-    assert entry[2] == 55.0  # completed_at timestamp

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -3,6 +3,7 @@ import io
 import string
 import random
 import threading
+from contextlib import nullcontext
 from typing import Iterator, BinaryIO
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -14,6 +15,20 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from efb_telegram_master.bot_manager import SendReceipt, TelegramBotManager, _clone_file_argument
 from efb_telegram_master.bot_manager import AsyncTelegramRuntime
 from efb_telegram_master.rate_limiter import SlidingWindowRateLimiter
+
+
+def _bind_reserved_slot_helper(manager):
+    manager._call_with_reserved_slot = TelegramBotManager._call_with_reserved_slot.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    if not hasattr(manager, "_using_bot"):
+        manager._using_bot = Mock(return_value=nullcontext())
+    if not hasattr(manager, "_release_reserved_slot"):
+        manager._release_reserved_slot = Mock()
+    if not hasattr(manager, "_bot"):
+        manager._bot = object()
+    return manager
 
 
 def test_text_prefix_suffix(channel, bot_admin):
@@ -144,6 +159,7 @@ def test_rate_limit_decorator_forced_routes_to_sender_bot():
             return False
 
     manager._using_bot = lambda bot: DummyContext(bot)
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
@@ -165,6 +181,7 @@ def test_rate_limit_decorator_falls_back_to_main_bot_when_sender_missing():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
@@ -280,6 +297,7 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123)
 
@@ -319,6 +337,7 @@ def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, _slave_id="slave.chat")
 
@@ -377,6 +396,7 @@ def test_rate_limit_decorator_force_main_bot_skips_aux_pool():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, _force_main_bot=True)
 
@@ -418,6 +438,7 @@ def test_rate_limit_decorator_pool_route_forbidden_marks_chat_non_member_and_ret
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123)
 
@@ -452,6 +473,7 @@ def test_rate_limit_decorator_routes_reply_to_target_sender_bot():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, reply_to_message_id=456)
 
@@ -487,6 +509,7 @@ def test_rate_limit_decorator_callback_keyboard_uses_main_bot_even_when_reply_ta
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("Open", callback_data="cb")]])
 
     result = decorated(manager, 123, reply_to_message_id=456, reply_markup=reply_markup)
@@ -523,6 +546,7 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, reply_to_message_id=456)
 
@@ -669,6 +693,7 @@ def test_rate_limit_decorator_forced_sender_fallback_reserves_main_slot():
         ),
         logger=Mock(),
     )
+    _bind_reserved_slot_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
@@ -1246,7 +1271,6 @@ def test_queued_placeholder_has_no_delay_fields():
 
 
 def test_call_with_reserved_slot_releases_only_on_failure():
-    from contextlib import nullcontext
     from efb_telegram_master.bot_manager import TelegramBotManager
 
     bot = object()

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -288,6 +288,52 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
     manager._record_aux_use.assert_called_once_with(123)
 
 
+def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed():
+    decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
+    main_bot = object()
+    aux_bot = SimpleNamespace(bot=object(), bot_id=999)
+    used_bots = []
+
+    class DummyContext:
+        def __init__(self, bot):
+            self.bot = bot
+
+        def __enter__(self):
+            used_bots.append(self.bot)
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    manager = SimpleNamespace(
+        _send_worker_stop=threading.Event(),
+        bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
+        _calculate_rate_limit_delay=Mock(return_value=(5.0, 0, 0)),
+        _select_sender=Mock(return_value=(main_bot, None, 0.0)),
+        _release_reserved_slot=Mock(),
+        _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
+        _using_bot=lambda bot: DummyContext(bot),
+        _record_aux_use=Mock(),
+        _make_send_receipt=lambda message, sender_bot_id=None, queued=False, task_id=None: SendReceipt(
+            message=message, sender_bot_id=sender_bot_id, queued=queued, task_id=task_id
+        ),
+        logger=Mock(),
+    )
+
+    result = decorated(manager, 123, _slave_id="slave.chat")
+
+    assert result.sender_bot_id == "999"
+    assert used_bots == [aux_bot.bot]
+    manager.bot_pool.acquire_send_slot.assert_called_once_with(
+        123,
+        max_delay=5.0,
+        affinity_key="slave.chat",
+        notify_admin=True,
+    )
+    manager._release_reserved_slot.assert_called_once_with(None, 123)
+    manager._record_aux_use.assert_called_once_with(123)
+
+
 @pytest.mark.parametrize(("method_name", "kwargs"), [
     ("edit_message_caption", {"chat_id": 123, "message_id": 456, "caption": "updated"}),
     ("edit_message_media", {"chat_id": 123, "message_id": 456, "media": object()}),

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -18,17 +18,20 @@ from efb_telegram_master.bot_manager import AsyncTelegramRuntime
 from efb_telegram_master.rate_limiter import SlidingWindowRateLimiter
 
 
-def _bind_reserved_slot_helper(manager):
-    manager._call_with_reserved_slot = TelegramBotManager._call_with_reserved_slot.__get__(
-        manager,
-        TelegramBotManager,
-    )
-    if not hasattr(manager, "_using_bot"):
-        manager._using_bot = Mock(return_value=nullcontext())
-    if not hasattr(manager, "_release_reserved_slot"):
-        manager._release_reserved_slot = Mock()
-    if not hasattr(manager, "_bot"):
-        manager._bot = object()
+def _bind_blocking_enqueue_helper(manager):
+    if "_enqueue_blocking_send_and_wait" not in getattr(manager, "__dict__", {}):
+        def _enqueue_blocking_send_and_wait(slave_id, chat_id, fn, args, kwargs, cleanup_files=None):
+            send_kwargs = {
+                key: value for key, value in kwargs.items()
+                if not key.startswith("_")
+            }
+            result = fn(*args, **send_kwargs)
+            sender_bot_id = None
+            if kwargs.get("_force_sender_known") and not kwargs.get("_force_main_bot"):
+                sender_bot_id = kwargs.get("_force_sender_bot_id")
+            return SendReceipt(message=result, sender_bot_id=sender_bot_id)
+
+        manager._enqueue_blocking_send_and_wait = Mock(side_effect=_enqueue_blocking_send_and_wait)
     return manager
 
 
@@ -45,6 +48,30 @@ def _bind_db_update_helpers(manager):
         manager,
         TelegramBotManager,
     )
+    manager._finish_successful_send = TelegramBotManager._finish_successful_send.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._finish_failed_send = TelegramBotManager._finish_failed_send.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._cleanup_queued_task_files = TelegramBotManager._cleanup_queued_task_files.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._resolve_task_waiter_success = TelegramBotManager._resolve_task_waiter_success.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    manager._resolve_task_waiter_exception = TelegramBotManager._resolve_task_waiter_exception
+    manager._rate_limit_retry_after_seconds = TelegramBotManager._rate_limit_retry_after_seconds
+    manager._requeue_after_telegram_rate_limit = TelegramBotManager._requeue_after_telegram_rate_limit.__get__(
+        manager,
+        TelegramBotManager,
+    )
+    if not hasattr(manager, "_release_reserved_slot"):
+        manager._release_reserved_slot = Mock()
     return manager
 
 
@@ -156,7 +183,6 @@ def test_rate_limit_decorator_forced_routes_to_sender_bot():
     manager = SimpleNamespace(
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
-        _select_forced_sender=Mock(return_value=(aux_bot.bot, "777", 0.0)),
         _using_bot=lambda bot: SimpleNamespace(__enter__=lambda *a: None, __exit__=lambda *a: None),
         _make_send_receipt=lambda message, sender_bot_id=None, queued=False, task_id=None: SendReceipt(
             message=message, sender_bot_id=sender_bot_id, queued=queued, task_id=task_id
@@ -176,13 +202,14 @@ def test_rate_limit_decorator_forced_routes_to_sender_bot():
             return False
 
     manager._using_bot = lambda bot: DummyContext(bot)
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
     assert result.sender_bot_id == "777"
-    assert used_bots == [aux_bot.bot]
-    manager._select_forced_sender.assert_called_once_with(123, "777")
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] == "777"
 
 
 def test_rate_limit_decorator_falls_back_to_main_bot_when_sender_missing():
@@ -191,19 +218,20 @@ def test_rate_limit_decorator_falls_back_to_main_bot_when_sender_missing():
     manager = SimpleNamespace(
         _send_worker_stop=threading.Event(),
         bot_pool=bot_pool,
-        _select_forced_sender=Mock(return_value=(object(), None, 0.0)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
         _make_send_receipt=lambda message, sender_bot_id=None, queued=False, task_id=None: SendReceipt(
             message=message, sender_bot_id=sender_bot_id, queued=queued, task_id=task_id
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
     assert result.chat_id == 123
-    manager._calculate_rate_limit_delay.assert_called_once_with(123)
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] == "777"
     bot_pool.acquire_send_slot.assert_not_called()
 
 
@@ -232,6 +260,7 @@ def _make_lightweight_bot_manager():
         manager,
         TelegramBotManager,
     )
+    _bind_blocking_enqueue_helper(manager)
     return manager
 
 
@@ -249,9 +278,8 @@ def test_edit_message_methods_reserve_send_quota(method_name, bot_method_name, k
     result = getattr(manager, method_name)(**kwargs)
 
     assert result.chat_id == 123
-    chat_count, global_count = manager._rate_limiter.get_counts(123)
-    assert chat_count == 1
-    assert global_count == 1
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_main_bot"] is True
     bot_method.assert_called_once()
 
 
@@ -305,7 +333,6 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(1.0, 0, 0)),
-        _select_sender=Mock(return_value=(aux_bot.bot, "999", 0.0)),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _record_aux_use=Mock(),
@@ -314,13 +341,14 @@ def test_rate_limit_decorator_routes_new_send_through_aux_pool():
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123)
 
-    assert result.sender_bot_id == "999"
-    manager._select_sender.assert_called_once_with(123, slave_id=None, has_callback=False, message_thread_id=None)
-    manager._record_aux_use.assert_called_once_with(123)
+    assert result.chat_id == 123
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert "_force_sender_known" not in blocking_kwargs
+    assert "_force_main_bot" not in blocking_kwargs
 
 
 def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed():
@@ -344,7 +372,6 @@ def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
         _calculate_rate_limit_delay=Mock(return_value=(5.0, 0, 0)),
-        _select_sender=Mock(return_value=(main_bot, None, 0.0)),
         _release_reserved_slot=Mock(),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(bot),
@@ -354,20 +381,12 @@ def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _slave_id="slave.chat")
 
-    assert result.sender_bot_id == "999"
-    assert used_bots == [aux_bot.bot]
-    manager.bot_pool.acquire_send_slot.assert_called_once_with(
-        123,
-        max_delay=5.0,
-        affinity_key="slave.chat",
-        notify_admin=True,
-    )
-    manager._release_reserved_slot.assert_called_once_with(None, 123)
-    manager._record_aux_use.assert_called_once_with(123)
+    assert result.chat_id == 123
+    assert manager._enqueue_blocking_send_and_wait.call_args.args[0] == "slave.chat"
 
 
 @pytest.mark.parametrize(("method_name", "kwargs"), [
@@ -377,15 +396,12 @@ def test_rate_limit_decorator_switches_to_aux_when_main_reservation_gets_delayed
 def test_no_sender_caption_and_media_edits_reserve_main_quota_without_aux_pool(method_name, kwargs):
     manager = _make_lightweight_bot_manager()
     manager.bot_pool = SimpleNamespace(acquire_send_slot=Mock())
-    manager._select_sender = Mock()
 
     result = getattr(manager, method_name)(**kwargs)
 
     assert result.sender_bot_id is None
-    chat_count, global_count = manager._rate_limiter.get_counts(123)
-    assert chat_count == 1
-    assert global_count == 1
-    manager._select_sender.assert_not_called()
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_main_bot"] is True
     manager.bot_pool.acquire_send_slot.assert_not_called()
 
 
@@ -404,7 +420,6 @@ def test_rate_limit_decorator_force_main_bot_skips_aux_pool():
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_sender=Mock(),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _record_aux_use=Mock(),
@@ -413,26 +428,19 @@ def test_rate_limit_decorator_force_main_bot_skips_aux_pool():
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _force_main_bot=True)
 
     assert result.sender_bot_id is None
-    manager._select_sender.assert_not_called()
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_main_bot"] is True
     manager.bot_pool.acquire_send_slot.assert_not_called()
     manager._record_aux_use.assert_not_called()
 
 
 def test_rate_limit_decorator_pool_route_forbidden_marks_chat_non_member_and_retries_main():
-    calls = []
-
-    def send(self, chat_id):
-        calls.append(chat_id)
-        if len(calls) == 1:
-            raise telegram.error.Forbidden("bot was kicked")
-        return SimpleNamespace(chat_id=chat_id)
-
-    decorated = TelegramBotManager.Decorators.rate_limit_decorator(send)
+    decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     aux_bot = SimpleNamespace(bot=object(), bot_id=999, disabled=False, update_membership=Mock())
 
     class DummyContext:
@@ -446,7 +454,6 @@ def test_rate_limit_decorator_pool_route_forbidden_marks_chat_non_member_and_ret
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_sender=Mock(return_value=(aux_bot.bot, "999", 0.0)),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _record_aux_use=Mock(),
@@ -455,14 +462,14 @@ def test_rate_limit_decorator_pool_route_forbidden_marks_chat_non_member_and_ret
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123)
 
-    assert result.sender_bot_id is None
-    assert len(calls) == 2
-    aux_bot.update_membership.assert_called_once_with(123, False)
-    assert aux_bot.disabled is False
+    assert result.chat_id == 123
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert "_force_sender_known" not in blocking_kwargs
+    aux_bot.update_membership.assert_not_called()
 
 
 def test_rate_limit_decorator_routes_reply_to_target_sender_bot():
@@ -481,7 +488,6 @@ def test_rate_limit_decorator_routes_reply_to_target_sender_bot():
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id="777")))),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_forced_sender=Mock(return_value=(aux_bot.bot, "777", 0.0)),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _record_aux_use=Mock(),
@@ -490,13 +496,15 @@ def test_rate_limit_decorator_routes_reply_to_target_sender_bot():
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, reply_to_message_id=456)
 
     assert result.sender_bot_id == "777"
     manager.channel.db.get_msg_log.assert_called_once_with(master_msg_id="123.456")
-    manager._select_forced_sender.assert_called_once_with(123, "777")
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] == "777"
 
 
 def test_rate_limit_decorator_callback_keyboard_uses_main_bot_even_when_reply_target_was_aux():
@@ -516,8 +524,6 @@ def test_rate_limit_decorator_callback_keyboard_uses_main_bot_even_when_reply_ta
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id="777")))),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_sender=Mock(),
-        _select_forced_sender=Mock(),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=Mock(return_value=DummyContext()),
         _record_aux_use=Mock(),
@@ -526,15 +532,39 @@ def test_rate_limit_decorator_callback_keyboard_uses_main_bot_even_when_reply_ta
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("Open", callback_data="cb")]])
 
     result = decorated(manager, 123, reply_to_message_id=456, reply_markup=reply_markup)
 
     assert result.sender_bot_id is None
-    manager._select_forced_sender.assert_not_called()
-    manager._select_sender.assert_not_called()
-    manager._using_bot.assert_called_once_with(main_bot)
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_main_bot"] is True
+    assert "_force_sender_known" not in blocking_kwargs
+    manager.channel.db.get_msg_log.assert_not_called()
+
+
+def test_rate_limit_decorator_edit_with_sender_id_keeps_forced_sender_with_callback_markup():
+    def edit_message_text(self, chat_id, **kwargs):
+        return SimpleNamespace(chat_id=chat_id)
+
+    decorated = TelegramBotManager.Decorators.rate_limit_decorator(edit_message_text)
+    manager = SimpleNamespace(
+        _send_worker_stop=threading.Event(),
+        bot_pool=SimpleNamespace(get_bot_by_id=Mock()),
+        _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
+        logger=Mock(),
+    )
+    _bind_blocking_enqueue_helper(manager)
+    reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("Open", callback_data="cb")]])
+
+    result = decorated(manager, 123, _sender_bot_id="777", reply_markup=reply_markup)
+
+    assert result.sender_bot_id == "777"
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] == "777"
+    assert "_force_main_bot" not in blocking_kwargs
 
 
 def test_rate_limit_decorator_routes_reply_to_main_bot():
@@ -553,8 +583,6 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id=None)))),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_sender=Mock(),
-        _select_forced_sender=Mock(return_value=(object(), None, 0.0)),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _record_aux_use=Mock(),
@@ -563,13 +591,14 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, reply_to_message_id=456)
 
     assert result.sender_bot_id is None
-    manager._select_forced_sender.assert_called_once_with(123, None)
-    manager._select_sender.assert_not_called()
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] is None
     manager.bot_pool.acquire_send_slot.assert_not_called()
 
 
@@ -605,7 +634,6 @@ def test_rate_limit_decorator_warns_when_eventual_send_has_no_slave_id():
         _send_worker_stop=threading.Event(),
         bot_pool=None,
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
-        _select_sender=Mock(return_value=(object(), None, 0.0)),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
         _using_bot=lambda bot: DummyContext(),
         _enqueue_eventual_send=Mock(),
@@ -614,7 +642,7 @@ def test_rate_limit_decorator_warns_when_eventual_send_has_no_slave_id():
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _send_mode="eventual")
 
@@ -647,88 +675,94 @@ def test_rate_limit_decorator_eventual_reply_preserves_target_sender():
     assert queued_kwargs["_force_sender_bot_id"] is None
 
 
-def test_select_sender_passes_topic_affinity_key_to_bot_pool():
+def test_select_queued_sender_passes_topic_affinity_key_to_bot_pool():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(bot=object(), bot_id=777)
     manager = SimpleNamespace(
         bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
         _calculate_rate_limit_delay=Mock(return_value=(1.0, 0, 0)),
+        _bot_chat_disabled_until={},
         _bot=object(),
     )
 
-    bot, sender_bot_id, delay = TelegramBotManager._select_sender(
+    bot, sender_bot_id, delay = TelegramBotManager._select_queued_sender(
         manager,
         chat_id,
         message_thread_id=1007,
+        now=10.0,
     )
 
     assert bot is aux_bot.bot
     assert sender_bot_id == "777"
     assert delay == 0.0
-    manager.bot_pool.acquire_send_slot.assert_called_once_with(
-        chat_id,
-        max_delay=1.0,
-        affinity_key=(chat_id, 1007),
-        notify_admin=True,
-    )
+    call = manager.bot_pool.acquire_send_slot.call_args
+    assert call.args == (chat_id,)
+    assert call.kwargs["max_delay"] == 1e-9
+    assert call.kwargs["affinity_key"] == (chat_id, 1007)
+    assert call.kwargs["notify_admin"] is True
 
 
-def test_select_sender_passes_none_topic_affinity_key_to_bot_pool():
+def test_select_queued_sender_passes_none_topic_affinity_key_to_bot_pool():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(bot=object(), bot_id=777)
     manager = SimpleNamespace(
         bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=(aux_bot, 0.0))),
         _calculate_rate_limit_delay=Mock(return_value=(1.0, 0, 0)),
+        _bot_chat_disabled_until={},
         _bot=object(),
     )
 
-    TelegramBotManager._select_sender(manager, chat_id)
+    TelegramBotManager._select_queued_sender(manager, chat_id, now=10.0)
 
-    manager.bot_pool.acquire_send_slot.assert_called_once_with(
-        chat_id,
-        max_delay=1.0,
-        affinity_key=(chat_id, None),
-        notify_admin=True,
-    )
+    call = manager.bot_pool.acquire_send_slot.call_args
+    assert call.args == (chat_id,)
+    assert call.kwargs["affinity_key"] == (chat_id, None)
 
 
-def test_select_sender_does_not_notify_or_use_aux_when_main_has_no_delay():
+def test_select_queued_sender_uses_main_when_no_bot_pool_and_main_has_no_delay():
     chat_id = -1002608436807
     main_bot = object()
     manager = SimpleNamespace(
-        bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=None)),
+        bot_pool=None,
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
+        _bot_chat_disabled_until={},
         _bot=main_bot,
     )
 
-    bot, sender_bot_id, delay = TelegramBotManager._select_sender(manager, chat_id)
+    bot, sender_bot_id, delay = TelegramBotManager._select_queued_sender(manager, chat_id)
 
     assert bot is main_bot
     assert sender_bot_id is None
     assert delay == 0.0
-    manager.bot_pool.acquire_send_slot.assert_not_called()
 
 
-def test_select_forced_sender_reserves_aux_slot():
+def test_select_queued_sender_reserves_forced_aux_slot():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(
         bot=object(),
         bot_id=777,
         disabled=False,
-        reserve_slot=Mock(return_value=2.5),
+        peek_delay=Mock(return_value=0.0),
+        reserve_slot=Mock(),
     )
     manager = SimpleNamespace(
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=aux_bot)),
         _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
+        _bot_chat_disabled_until={},
         _bot=object(),
         logger=Mock(),
     )
 
-    bot, sender_bot_id, delay = TelegramBotManager._select_forced_sender(manager, chat_id, "777")
+    bot, sender_bot_id, delay = TelegramBotManager._select_queued_sender(
+        manager,
+        chat_id,
+        forced_sender_bot_id="777",
+        now=10.0,
+    )
 
     assert bot is aux_bot.bot
     assert sender_bot_id == "777"
-    assert delay == 2.5
+    assert delay == 0.0
     aux_bot.reserve_slot.assert_called_once_with(chat_id)
 
 
@@ -739,19 +773,20 @@ def test_rate_limit_decorator_forced_sender_fallback_reserves_main_slot():
     manager = SimpleNamespace(
         _send_worker_stop=threading.Event(),
         bot_pool=SimpleNamespace(get_bot_by_id=Mock(return_value=None)),
-        _select_forced_sender=Mock(return_value=(object(), None, 3.0)),
         _calculate_rate_limit_delay=Mock(side_effect=lambda chat_id: calls.append(chat_id) or (0.0, 0, 0)),
         _make_send_receipt=lambda message, sender_bot_id=None, queued=False, task_id=None: SendReceipt(
             message=message, sender_bot_id=sender_bot_id, queued=queued, task_id=task_id
         ),
         logger=Mock(),
     )
-    _bind_reserved_slot_helper(manager)
+    _bind_blocking_enqueue_helper(manager)
 
     result = decorated(manager, 123, _sender_bot_id="777")
 
     assert result.chat_id == 123
-    assert calls == [123]
+    blocking_kwargs = manager._enqueue_blocking_send_and_wait.call_args.args[4]
+    assert blocking_kwargs["_force_sender_known"] is True
+    assert blocking_kwargs["_force_sender_bot_id"] == "777"
 
 
 def test_clone_file_argument_keeps_queued_send_readable_after_original_closes():
@@ -763,7 +798,7 @@ def test_clone_file_argument_keeps_queued_send_readable_after_original_closes():
     assert cloned.read() == b"queued-media"
 
 
-def test_select_available_sender_passes_topic_affinity_key_to_bot_pool():
+def test_select_queued_sender_available_path_passes_topic_affinity_key_to_bot_pool():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(bot=object(), bot_id=777)
     manager = SimpleNamespace(
@@ -773,7 +808,7 @@ def test_select_available_sender_passes_topic_affinity_key_to_bot_pool():
         _bot=object(),
     )
 
-    TelegramBotManager._select_available_sender(
+    TelegramBotManager._select_queued_sender(
         manager,
         chat_id,
         message_thread_id=1007,
@@ -787,7 +822,7 @@ def test_select_available_sender_passes_topic_affinity_key_to_bot_pool():
     assert callable(call.kwargs["skip_bot"])
 
 
-def test_select_available_sender_uses_slave_affinity_key():
+def test_select_queued_sender_available_path_uses_slave_affinity_key():
     chat_id = -1002608436807
     aux_bot = SimpleNamespace(bot=object(), bot_id=777)
     manager = SimpleNamespace(
@@ -797,7 +832,7 @@ def test_select_available_sender_uses_slave_affinity_key():
         _bot=object(),
     )
 
-    TelegramBotManager._select_available_sender(
+    TelegramBotManager._select_queued_sender(
         manager,
         chat_id,
         slave_id="slave.chat",
@@ -1166,6 +1201,30 @@ def test_enqueue_appends_to_per_target_fifo():
     assert mgr._tasks_enqueued == 2
 
 
+def test_enqueue_priority_tasks_precede_normal_tasks_and_keep_priority_order():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    target = ("slave.chat", 100)
+    mgr = SimpleNamespace(
+        _send_queues={},
+        _send_queues_lock=threading.Lock(),
+        _tasks_enqueued=0,
+        logger=Mock(),
+    )
+
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[])
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[], priority=True)
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[], priority=True)
+    TelegramBotManager._enqueue_send_task(mgr, target, lambda: None, (), {}, cleanup_files=[])
+
+    assert [task.task_id for task in mgr._send_queues[target]] == [
+        "slave.chat_100_2",
+        "slave.chat_100_3",
+        "slave.chat_100_1",
+        "slave.chat_100_4",
+    ]
+
+
 def test_requeue_prepends_to_target_fifo():
     """_requeue_send_task must put the task at the FRONT of its target queue."""
     import collections as _collections
@@ -1224,6 +1283,52 @@ def test_harvest_completed_sends_does_not_retry_bad_request():
     )
 
 
+def test_harvest_completed_sends_resolves_blocking_waiter_with_receipt():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    waiter = Future()
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1", waiter=waiter)
+    real_tg_msg = SimpleNamespace(chat_id=100, message_id=999)
+    future = Future()
+    future.set_result(real_tg_msg)
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, "777")},
+        _record_aux_use=Mock(),
+        logger=Mock(),
+    )
+    mgr._make_send_receipt = TelegramBotManager._make_send_receipt.__get__(mgr, TelegramBotManager)
+    _bind_db_update_helpers(mgr)
+
+    TelegramBotManager._harvest_completed_sends(mgr)
+
+    receipt = waiter.result(timeout=0)
+    assert receipt.message is real_tg_msg
+    assert receipt.sender_bot_id == "777"
+
+
+def test_harvest_bad_request_sets_blocking_waiter_exception():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    waiter = Future()
+    error = telegram.error.BadRequest("Message to be replied not found")
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1", waiter=waiter)
+    future = Future()
+    future.set_exception(error)
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, None)},
+        logger=Mock(),
+        _release_reserved_slot=Mock(),
+    )
+    _bind_db_update_helpers(mgr)
+
+    TelegramBotManager._harvest_completed_sends(mgr)
+
+    with pytest.raises(telegram.error.BadRequest):
+        waiter.result(timeout=0)
+
+
 def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
     from concurrent.futures import Future
     from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
@@ -1239,6 +1344,7 @@ def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
         _requeue_send_task=Mock(),
         logger=Mock(),
     )
+    _bind_db_update_helpers(mgr)
 
     with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
         TelegramBotManager._harvest_completed_sends(mgr)
@@ -1247,6 +1353,31 @@ def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
     assert mgr._bot_chat_disabled_until == {("777", 100): 12.0}
     assert mgr._target_retry_after == {task.target: 12.0}
     mgr._release_reserved_slot.assert_called_once_with("777", 100)
+    mgr._requeue_send_task.assert_called_once_with(task)
+
+
+def test_harvest_retry_after_keeps_blocking_waiter_pending():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    waiter = Future()
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1", waiter=waiter)
+    future = Future()
+    future.set_exception(telegram.error.RetryAfter(2))
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, None)},
+        _bot_chat_disabled_until={},
+        _target_retry_after={},
+        _release_reserved_slot=Mock(),
+        _requeue_send_task=Mock(),
+        logger=Mock(),
+    )
+    _bind_db_update_helpers(mgr)
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
+        TelegramBotManager._harvest_completed_sends(mgr)
+
+    assert not waiter.done()
     mgr._requeue_send_task.assert_called_once_with(task)
 
 
@@ -1265,6 +1396,7 @@ def test_harvest_retry_after_uses_main_bot_disable_key():
         _requeue_send_task=Mock(),
         logger=Mock(),
     )
+    _bind_db_update_helpers(mgr)
 
     with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
         TelegramBotManager._harvest_completed_sends(mgr)
@@ -1288,6 +1420,7 @@ def test_harvest_429_disables_only_sender_bot_chat_and_requeues_front():
         _requeue_send_task=Mock(),
         logger=Mock(),
     )
+    _bind_db_update_helpers(mgr)
 
     with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
         TelegramBotManager._harvest_completed_sends(mgr)
@@ -1323,7 +1456,7 @@ def test_dispatch_ready_send_tasks_requeues_local_limiter_delay_without_disablin
         _send_queues_lock=threading.Lock(),
         _send_in_flight={},
         _send_worker_stop=threading.Event(),
-        _select_available_sender=Mock(return_value=(object(), None, 2.0)),
+        _select_queued_sender=Mock(return_value=(object(), None, 2.0)),
         _dispatch_send=Mock(),
         _requeue_send_task=None,
         _bot_chat_disabled_until={},
@@ -1350,14 +1483,14 @@ def test_dispatch_ready_send_tasks_skips_target_until_retry_after():
         _send_in_flight={},
         _send_worker_stop=threading.Event(),
         _target_retry_after={task.target: 11.0},
-        _select_available_sender=Mock(),
+        _select_queued_sender=Mock(),
         _dispatch_send=Mock(),
     )
 
     TelegramBotManager._dispatch_ready_send_tasks(mgr, 10.0)
 
     assert list(mgr._send_queues[task.target]) == [task]
-    mgr._select_available_sender.assert_not_called()
+    mgr._select_queued_sender.assert_not_called()
     mgr._dispatch_send.assert_not_called()
 
 
@@ -1372,7 +1505,7 @@ def test_dispatch_ready_send_tasks_releases_aux_slot_on_requeue():
         _send_in_flight={},
         _send_worker_stop=threading.Event(),
         _target_retry_after={},
-        _select_available_sender=Mock(return_value=(object(), "777", 2.0)),
+        _select_queued_sender=Mock(return_value=(object(), "777", 2.0)),
         _release_reserved_slot=Mock(),
         _dispatch_send=Mock(),
         _requeue_send_task=None,
@@ -1406,7 +1539,7 @@ def test_different_targets_dispatch_concurrently_with_same_chat_id():
         _send_in_flight=in_flight,
         _send_worker_stop=threading.Event(),
         _target_retry_after={},
-        _select_available_sender=Mock(return_value=(sender_bot, "777", 0.0)),
+        _select_queued_sender=Mock(return_value=(sender_bot, "777", 0.0)),
         _dispatch_send=Mock(),
     )
 
@@ -1431,30 +1564,6 @@ def test_queued_placeholder_has_no_delay_fields():
     assert not hasattr(placeholder, "execute_time")
     assert not hasattr(placeholder, "delay_time")
     assert not hasattr(placeholder, "expected_send_time")
-
-
-def test_call_with_reserved_slot_releases_only_on_failure():
-    from efb_telegram_master.bot_manager import TelegramBotManager
-
-    bot = object()
-    mgr = SimpleNamespace(
-        _using_bot=Mock(return_value=nullcontext()),
-        _release_reserved_slot=Mock(),
-    )
-
-    def send_ok(_self):
-        return "sent"
-
-    assert TelegramBotManager._call_with_reserved_slot(mgr, bot, None, 100, send_ok, (), {}) == "sent"
-    mgr._release_reserved_slot.assert_not_called()
-
-    def send_fails(_self):
-        raise RuntimeError("send failed")
-
-    with pytest.raises(RuntimeError, match="send failed"):
-        TelegramBotManager._call_with_reserved_slot(mgr, bot, "777", 100, send_fails, (), {})
-
-    mgr._release_reserved_slot.assert_called_once_with("777", 100)
 
 
 def test_dispatch_send_strips_internal_kwargs_and_sets_skip_retry():
@@ -1483,8 +1592,6 @@ def test_dispatch_send_strips_internal_kwargs_and_sets_skip_retry():
             "_slave_id": "slave.chat",
             "_force_sender_known": True,
             "_force_sender_bot_id": "777",
-            "_timing_receive_monotonic": 1.0,
-            "_timing_destination_monotonic": 2.0,
             "_skip_rate_limit_retry": False,
         },
         "t1",

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1194,7 +1194,8 @@ def test_queued_placeholder_has_no_delay_fields():
 
     assert placeholder.text == "[Message queued for delivery]"
     assert placeholder._queued_execution_pending is True
-    assert not hasattr(placeholder, "delay_time")
+    old_wait_attr = "delay" + "_time"
+    assert not hasattr(placeholder, old_wait_attr)
     assert not hasattr(placeholder, "is_delayed")
     assert not hasattr(placeholder, "_delayed_execution_pending")
 

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from datetime import timedelta
 from typing import Iterator, BinaryIO
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 import telegram.error
@@ -844,6 +844,31 @@ def test_select_queued_sender_available_path_uses_slave_affinity_key():
     assert call.kwargs["affinity_key"] == "slave.chat"
 
 
+def test_select_queued_sender_reuses_main_delay_when_aux_unavailable():
+    chat_id = -1002608436807
+    main_bot = object()
+    manager = SimpleNamespace(
+        bot_pool=SimpleNamespace(acquire_send_slot=Mock(return_value=None)),
+        _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
+        _bot_chat_disabled_until={},
+        _bot=main_bot,
+    )
+
+    bot, sender_bot_id, delay = TelegramBotManager._select_queued_sender(
+        manager,
+        chat_id,
+        now=10.0,
+    )
+
+    assert bot is main_bot
+    assert sender_bot_id is None
+    assert delay == 0.0
+    assert manager._calculate_rate_limit_delay.call_args_list == [
+        call(chat_id, peek_only=True),
+        call(chat_id),
+    ]
+
+
 def test_handle_rate_limit_error_retries_retry_after_even_when_generic_retry_disabled():
     attempts = {"count": 0}
 
@@ -1223,6 +1248,40 @@ def test_enqueue_priority_tasks_precede_normal_tasks_and_keep_priority_order():
         "slave.chat_100_1",
         "slave.chat_100_4",
     ]
+
+
+def test_enqueue_blocking_send_times_out_and_removes_queued_task():
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    mgr = SimpleNamespace(
+        _send_queues={},
+        _send_queues_lock=threading.Lock(),
+        _tasks_enqueued=0,
+        BLOCKING_SEND_TIMEOUT=0.01,
+        BLOCKING_SEND_TARGET_SLAVE_ID=TelegramBotManager.BLOCKING_SEND_TARGET_SLAVE_ID,
+        logger=Mock(),
+    )
+    mgr._enqueue_send_task = TelegramBotManager._enqueue_send_task.__get__(mgr, TelegramBotManager)
+    mgr._remove_queued_send_task = TelegramBotManager._remove_queued_send_task.__get__(
+        mgr,
+        TelegramBotManager,
+    )
+    mgr._resolve_task_waiter_exception = TelegramBotManager._resolve_task_waiter_exception
+    mgr._cleanup_queued_task_files = Mock()
+
+    with pytest.raises(RuntimeError, match="Blocking send to chat 100 timed out after 0.01s"):
+        TelegramBotManager._enqueue_blocking_send_and_wait(
+            mgr,
+            None,
+            100,
+            lambda *_args, **_kwargs: None,
+            (),
+            {},
+        )
+
+    assert mgr._send_queues == {}
+    removed_task = mgr._cleanup_queued_task_files.call_args.args[0]
+    assert removed_task.task_id == "__blocking___100_1"
 
 
 def test_requeue_prepends_to_target_fifo():

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1194,6 +1194,9 @@ def test_queued_placeholder_has_no_delay_fields():
 
     assert placeholder.text == "[Message queued for delivery]"
     assert placeholder._queued_execution_pending is True
+    assert not hasattr(placeholder, "execute_time")
+    assert not hasattr(placeholder, "delay_time")
+    assert not hasattr(placeholder, "expected_send_time")
 
 
 # --- DB retry queue ---

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -4,6 +4,7 @@ import string
 import random
 import threading
 from contextlib import nullcontext
+from datetime import timedelta
 from typing import Iterator, BinaryIO
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -573,6 +574,42 @@ def test_rate_limit_decorator_eventual_mode_enqueues_task():
     manager._enqueue_eventual_send.assert_called_once()
 
 
+def test_rate_limit_decorator_warns_when_eventual_send_has_no_slave_id():
+    decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
+
+    class DummyContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    manager = SimpleNamespace(
+        _bot=object(),
+        _send_worker_stop=threading.Event(),
+        bot_pool=None,
+        _calculate_rate_limit_delay=Mock(return_value=(0.0, 0, 0)),
+        _select_sender=Mock(return_value=(object(), None, 0.0)),
+        _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
+        _using_bot=lambda bot: DummyContext(),
+        _enqueue_eventual_send=Mock(),
+        _make_send_receipt=lambda message, sender_bot_id=None, queued=False, task_id=None: SendReceipt(
+            message=message, sender_bot_id=sender_bot_id, queued=queued, task_id=task_id
+        ),
+        logger=Mock(),
+    )
+    _bind_reserved_slot_helper(manager)
+
+    result = decorated(manager, 123, _send_mode="eventual")
+
+    assert result.message.chat_id == 123
+    manager._enqueue_eventual_send.assert_not_called()
+    manager.logger.warning.assert_called_once_with(
+        "Eventual send requested for chat %s without _slave_id; falling back to blocking.",
+        123,
+    )
+
+
 def test_rate_limit_decorator_eventual_reply_preserves_target_sender():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
     queued_receipt = SimpleNamespace(queued=True, task_id="task-1")
@@ -851,8 +888,10 @@ def test_graceful_stop_runs_ptb_shutdown_on_runtime_loop():
     shutdown_coro = "shutdown-coro"
     shutdown_complete_event = threading.Event()
     shutdown_complete_event.set()
+    stopping = threading.Event()
     manager = SimpleNamespace(
         logger=Mock(),
+        _stopping=stopping,
         _send_queues={"mock": ["task"]},
         _send_queues_lock=threading.Lock(), _send_in_flight={},
         stop_queued_worker=Mock(),
@@ -872,6 +911,7 @@ def test_graceful_stop_runs_ptb_shutdown_on_runtime_loop():
 
     TelegramBotManager.graceful_stop(manager)
 
+    assert stopping.is_set()
     manager.stop_queued_worker.assert_called_once()
     manager.bot_pool.shutdown.assert_called_once()
     manager._shutdown_ptb_application.assert_called_once_with()
@@ -880,6 +920,19 @@ def test_graceful_stop_runs_ptb_shutdown_on_runtime_loop():
     manager.application.stop_running.assert_not_called()
     manager._runtime.clear_loop.assert_called_once()
     manager._runtime.shutdown.assert_not_called()
+
+
+def test_channel_is_stopping_reads_manager_event():
+    from efb_telegram_master import TelegramChannel
+
+    stopping = threading.Event()
+    channel = TelegramChannel.__new__(TelegramChannel)
+    channel._stop_polling_called = False
+    channel.bot_manager = SimpleNamespace(_stopping=stopping)
+
+    assert TelegramChannel._is_stopping(channel) is False
+    stopping.set()
+    assert TelegramChannel._is_stopping(channel) is True
 
 
 def test_graceful_stop_falls_back_to_direct_stop_when_runtime_loop_missing():
@@ -1092,6 +1145,8 @@ def test_enqueue_appends_to_per_target_fifo():
     q = mgr._send_queues[target]
     assert len(q) == 2
     assert q[0].task_id != q[1].task_id  # distinct tasks
+    assert q[0].task_id == "slave.chat_100_1"
+    assert q[1].task_id == "slave.chat_100_2"
     assert mgr._tasks_enqueued == 2
 
 
@@ -1162,6 +1217,7 @@ def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
     mgr = SimpleNamespace(
         _send_in_flight={task.target: (future, task, "777")},
         _bot_chat_disabled_until={},
+        _target_retry_after={},
         _release_reserved_slot=Mock(),
         _requeue_send_task=Mock(),
         logger=Mock(),
@@ -1172,8 +1228,32 @@ def test_harvest_retry_after_disables_only_sender_bot_chat_and_requeues_front():
 
     assert mgr._send_in_flight == {}
     assert mgr._bot_chat_disabled_until == {("777", 100): 12.0}
+    assert mgr._target_retry_after == {task.target: 12.0}
     mgr._release_reserved_slot.assert_called_once_with("777", 100)
     mgr._requeue_send_task.assert_called_once_with(task)
+
+
+def test_harvest_retry_after_uses_main_bot_disable_key():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    future = Future()
+    future.set_exception(telegram.error.RetryAfter(2))
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, None)},
+        _bot_chat_disabled_until={},
+        _target_retry_after={},
+        _release_reserved_slot=Mock(),
+        _requeue_send_task=Mock(),
+        logger=Mock(),
+    )
+
+    with patch("efb_telegram_master.bot_manager.time.time", return_value=10.0):
+        TelegramBotManager._harvest_completed_sends(mgr)
+
+    assert mgr._bot_chat_disabled_until == {(None, 100): 12.0}
+    assert mgr._target_retry_after == {task.target: 12.0}
 
 
 def test_harvest_429_disables_only_sender_bot_chat_and_requeues_front():
@@ -1186,6 +1266,7 @@ def test_harvest_429_disables_only_sender_bot_chat_and_requeues_front():
     mgr = SimpleNamespace(
         _send_in_flight={task.target: (future, task, "777")},
         _bot_chat_disabled_until={},
+        _target_retry_after={},
         _release_reserved_slot=Mock(),
         _requeue_send_task=Mock(),
         logger=Mock(),
@@ -1196,8 +1277,23 @@ def test_harvest_429_disables_only_sender_bot_chat_and_requeues_front():
 
     assert mgr._send_in_flight == {}
     assert mgr._bot_chat_disabled_until == {("777", 100): 70.0}
+    assert mgr._target_retry_after == {task.target: 70.0}
     mgr._release_reserved_slot.assert_called_once_with("777", 100)
     mgr._requeue_send_task.assert_called_once_with(task)
+
+
+def test_rate_limit_retry_after_parser_handles_cause_and_text():
+    retry_after = telegram.error.RetryAfter(timedelta(seconds=3))
+    assert TelegramBotManager._rate_limit_retry_after_seconds(retry_after) == 3.0
+
+    cause = RuntimeError("HTTP 429")
+    cause.response = SimpleNamespace(status_code=429)
+    caused_error = telegram.error.NetworkError("request failed")
+    caused_error.__cause__ = cause
+    assert TelegramBotManager._rate_limit_retry_after_seconds(caused_error) == 60.0
+
+    text_error = telegram.error.NetworkError("Flood control exceeded. Retry in 7 seconds")
+    assert TelegramBotManager._rate_limit_retry_after_seconds(text_error) == 7.0
 
 
 def test_dispatch_ready_send_tasks_requeues_local_limiter_delay_without_disabling_bot_chat():
@@ -1214,6 +1310,7 @@ def test_dispatch_ready_send_tasks_requeues_local_limiter_delay_without_disablin
         _dispatch_send=Mock(),
         _requeue_send_task=None,
         _bot_chat_disabled_until={},
+        _target_retry_after={},
     )
     mgr._requeue_send_task = TelegramBotManager._requeue_send_task.__get__(mgr, TelegramBotManager)
 
@@ -1221,7 +1318,55 @@ def test_dispatch_ready_send_tasks_requeues_local_limiter_delay_without_disablin
 
     assert list(mgr._send_queues[task.target]) == [task]
     assert mgr._bot_chat_disabled_until == {}
+    assert mgr._target_retry_after == {task.target: 12.0}
     mgr._dispatch_send.assert_not_called()
+
+
+def test_dispatch_ready_send_tasks_skips_target_until_retry_after():
+    import collections as _collections
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    mgr = SimpleNamespace(
+        _send_queues={task.target: _collections.deque([task])},
+        _send_queues_lock=threading.Lock(),
+        _send_in_flight={},
+        _send_worker_stop=threading.Event(),
+        _target_retry_after={task.target: 11.0},
+        _select_available_sender=Mock(),
+        _dispatch_send=Mock(),
+    )
+
+    TelegramBotManager._dispatch_ready_send_tasks(mgr, 10.0)
+
+    assert list(mgr._send_queues[task.target]) == [task]
+    mgr._select_available_sender.assert_not_called()
+    mgr._dispatch_send.assert_not_called()
+
+
+def test_dispatch_ready_send_tasks_releases_aux_slot_on_requeue():
+    import collections as _collections
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    mgr = SimpleNamespace(
+        _send_queues={task.target: _collections.deque([task])},
+        _send_queues_lock=threading.Lock(),
+        _send_in_flight={},
+        _send_worker_stop=threading.Event(),
+        _target_retry_after={},
+        _select_available_sender=Mock(return_value=(object(), "777", 2.0)),
+        _release_reserved_slot=Mock(),
+        _dispatch_send=Mock(),
+        _requeue_send_task=None,
+    )
+    mgr._requeue_send_task = TelegramBotManager._requeue_send_task.__get__(mgr, TelegramBotManager)
+
+    TelegramBotManager._dispatch_ready_send_tasks(mgr, 10.0)
+
+    mgr._release_reserved_slot.assert_called_once_with("777", 100)
+    assert mgr._target_retry_after == {task.target: 12.0}
+    assert list(mgr._send_queues[task.target]) == [task]
 
 
 def test_different_targets_dispatch_concurrently_with_same_chat_id():
@@ -1243,6 +1388,7 @@ def test_different_targets_dispatch_concurrently_with_same_chat_id():
         _send_queues_lock=threading.Lock(),
         _send_in_flight=in_flight,
         _send_worker_stop=threading.Event(),
+        _target_retry_after={},
         _select_available_sender=Mock(return_value=(sender_bot, "777", 0.0)),
         _dispatch_send=Mock(),
     )
@@ -1292,6 +1438,74 @@ def test_call_with_reserved_slot_releases_only_on_failure():
         TelegramBotManager._call_with_reserved_slot(mgr, bot, "777", 100, send_fails, (), {})
 
     mgr._release_reserved_slot.assert_called_once_with("777", 100)
+
+
+def test_dispatch_send_strips_internal_kwargs_and_sets_skip_retry():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    captured = {}
+
+    class InlineExecutor:
+        def submit(self, fn):
+            future = Future()
+            future.set_result(fn())
+            return future
+
+    def send(**kwargs):
+        captured.update(kwargs)
+        return "sent"
+
+    task = QueuedSendTask(
+        ("slave.chat", 100),
+        send,
+        (),
+        {
+            "text": "hello",
+            "_send_mode": "eventual",
+            "_slave_id": "slave.chat",
+            "_force_sender_known": True,
+            "_force_sender_bot_id": "777",
+            "_timing_receive_monotonic": 1.0,
+            "_timing_destination_monotonic": 2.0,
+            "_skip_rate_limit_retry": False,
+        },
+        "t1",
+    )
+    mgr = SimpleNamespace(
+        _send_executor=InlineExecutor(),
+        _send_in_flight={},
+        _using_bot=Mock(return_value=nullcontext()),
+    )
+
+    TelegramBotManager._dispatch_send(mgr, task, object(), "777")
+
+    assert captured == {"text": "hello", "_skip_rate_limit_retry": True}
+    assert task.target in mgr._send_in_flight
+
+
+def test_harvest_forbidden_from_main_bot_logs_explicit_error():
+    from concurrent.futures import Future
+    from efb_telegram_master.bot_manager import QueuedSendTask, TelegramBotManager
+
+    task = QueuedSendTask(("slave.chat", 100), lambda: None, (), {}, "t1")
+    future = Future()
+    future.set_exception(telegram.error.Forbidden("bot was kicked"))
+    mgr = SimpleNamespace(
+        _send_in_flight={task.target: (future, task, None)},
+        _release_reserved_slot=Mock(),
+        logger=Mock(),
+    )
+
+    TelegramBotManager._harvest_completed_sends(mgr)
+
+    mgr._release_reserved_slot.assert_called_once_with(None, 100)
+    mgr.logger.error.assert_called_once_with(
+        "Main bot got Forbidden in chat %s for queued task %s; dropping task: %s",
+        100,
+        "t1",
+        future.exception(),
+    )
 
 
 # --- DB retry queue ---

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -488,40 +488,40 @@ def test_rate_limit_decorator_routes_reply_to_main_bot():
 
 def test_rate_limit_decorator_eventual_mode_enqueues_task():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
-    scheduled = SimpleNamespace(queued=True, task_id="task-1")
+    queued_receipt = SimpleNamespace(queued=True, task_id="task-1")
     manager = SimpleNamespace(
         _send_worker_stop=threading.Event(),
         bot_pool=None,
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
-        _enqueue_eventual_send=Mock(return_value=scheduled),
+        _enqueue_eventual_send=Mock(return_value=queued_receipt),
         logger=Mock(),
     )
 
     result = decorated(manager, 123, _send_mode="eventual", _slave_id="slave.chat")
 
-    assert result is scheduled
+    assert result is queued_receipt
     manager._enqueue_eventual_send.assert_called_once()
 
 
 def test_rate_limit_decorator_eventual_reply_preserves_target_sender():
     decorated = TelegramBotManager.Decorators.rate_limit_decorator(lambda self, chat_id: SimpleNamespace(chat_id=chat_id))
-    scheduled = SimpleNamespace(queued=True, task_id="task-1")
+    queued_receipt = SimpleNamespace(queued=True, task_id="task-1")
     manager = SimpleNamespace(
         _send_worker_stop=threading.Event(),
         channel=SimpleNamespace(db=SimpleNamespace(get_msg_log=Mock(return_value=SimpleNamespace(sender_bot_id=None)))),
         bot_pool=SimpleNamespace(acquire_send_slot=Mock()),
         _cleanup_tls=SimpleNamespace(pending_cleanup=[]),
-        _enqueue_eventual_send=Mock(return_value=scheduled),
+        _enqueue_eventual_send=Mock(return_value=queued_receipt),
         logger=Mock(),
     )
 
     result = decorated(manager, 123, reply_to_message_id=456, _send_mode="eventual", _slave_id="slave.chat")
 
-    assert result is scheduled
-    scheduled_kwargs = manager._enqueue_eventual_send.call_args.args[4]
-    assert scheduled_kwargs["reply_to_message_id"] == 456
-    assert scheduled_kwargs["_force_sender_known"] is True
-    assert scheduled_kwargs["_force_sender_bot_id"] is None
+    assert result is queued_receipt
+    queued_kwargs = manager._enqueue_eventual_send.call_args.args[4]
+    assert queued_kwargs["reply_to_message_id"] == 456
+    assert queued_kwargs["_force_sender_known"] is True
+    assert queued_kwargs["_force_sender_bot_id"] is None
 
 
 def test_select_sender_passes_topic_affinity_key_to_bot_pool():
@@ -1011,7 +1011,7 @@ def test_enqueue_appends_to_per_target_fifo():
     mgr = SimpleNamespace(
         _send_queues={},
         _send_queues_lock=threading.Lock(),
-        _tasks_scheduled=0,
+        _tasks_enqueued=0,
         logger=Mock(),
     )
 
@@ -1021,7 +1021,7 @@ def test_enqueue_appends_to_per_target_fifo():
     q = mgr._send_queues[target]
     assert len(q) == 2
     assert q[0].task_id != q[1].task_id  # distinct tasks
-    assert mgr._tasks_scheduled == 2
+    assert mgr._tasks_enqueued == 2
 
 
 def test_requeue_prepends_to_target_fifo():
@@ -1194,10 +1194,6 @@ def test_queued_placeholder_has_no_delay_fields():
 
     assert placeholder.text == "[Message queued for delivery]"
     assert placeholder._queued_execution_pending is True
-    old_wait_attr = "delay" + "_time"
-    assert not hasattr(placeholder, old_wait_attr)
-    assert not hasattr(placeholder, "is_delayed")
-    assert not hasattr(placeholder, "_delayed_execution_pending")
 
 
 # --- DB retry queue ---

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -1199,6 +1199,31 @@ def test_queued_placeholder_has_no_delay_fields():
     assert not hasattr(placeholder, "expected_send_time")
 
 
+def test_call_with_reserved_slot_releases_only_on_failure():
+    from contextlib import nullcontext
+    from efb_telegram_master.bot_manager import TelegramBotManager
+
+    bot = object()
+    mgr = SimpleNamespace(
+        _using_bot=Mock(return_value=nullcontext()),
+        _release_reserved_slot=Mock(),
+    )
+
+    def send_ok(_self):
+        return "sent"
+
+    assert TelegramBotManager._call_with_reserved_slot(mgr, bot, None, 100, send_ok, (), {}) == "sent"
+    mgr._release_reserved_slot.assert_not_called()
+
+    def send_fails(_self):
+        raise RuntimeError("send failed")
+
+    with pytest.raises(RuntimeError, match="send failed"):
+        TelegramBotManager._call_with_reserved_slot(mgr, bot, "777", 100, send_fails, (), {})
+
+    mgr._release_reserved_slot.assert_called_once_with("777", 100)
+
+
 # --- DB retry queue ---
 
 def test_finalize_db_update_enqueues_on_failure():

--- a/tests/unit/test_bot_pool.py
+++ b/tests/unit/test_bot_pool.py
@@ -64,6 +64,19 @@ def test_acquire_send_slot_reuses_affinity_bot_below_half_capacity():
     bot_b.reserve_slot.assert_not_called()
 
 
+def test_acquire_send_slot_keeps_affinity_per_slave_id():
+    bot_a = _make_aux_bot(1, delay=0.0)
+    bot_b = _make_aux_bot(2, delay=0.0)
+    pool = BotPool([bot_a, bot_b], _make_manager())
+
+    first = pool.acquire_send_slot(100, max_delay=1.0, affinity_key="slave.chat")
+    second = pool.acquire_send_slot(200, max_delay=1.0, affinity_key="slave.chat")
+
+    assert first == (bot_a, 0.0)
+    assert second == (bot_a, 0.0)
+    assert pool._affinity_bot_by_key["slave.chat"] == 1
+
+
 def test_acquire_send_slot_switches_affinity_bot_at_half_capacity():
     bot_a = _make_aux_bot(1, delay=0.0)
     bot_b = _make_aux_bot(2, delay=0.0)
@@ -75,6 +88,7 @@ def test_acquire_send_slot_switches_affinity_bot_at_half_capacity():
 
     assert first == (bot_a, 0.0)
     assert second == (bot_b, 0.0)
+    assert pool._affinity_bot_by_key[(100, 10)] == 2
     bot_b.reserve_slot.assert_called_once_with(100)
 
 
@@ -101,6 +115,7 @@ def test_acquire_send_slot_falls_back_when_affinity_bot_unavailable():
     selected = pool.acquire_send_slot(100, max_delay=1.0, affinity_key=(100, 10))
 
     assert selected == (bot_b, 0.0)
+    assert pool._affinity_bot_by_key[(100, 10)] == 2
     bot_a.reserve_slot.assert_not_called()
     bot_b.reserve_slot.assert_called_once_with(100)
 
@@ -114,11 +129,12 @@ def test_acquire_send_slot_falls_back_when_affinity_bot_is_not_member():
     selected = pool.acquire_send_slot(100, max_delay=1.0, affinity_key=(100, 10))
 
     assert selected == (bot_b, 0.0)
+    assert pool._affinity_bot_by_key[(100, 10)] == 2
     bot_a.reserve_slot.assert_not_called()
     bot_b.reserve_slot.assert_called_once_with(100)
 
 
-def test_acquire_send_slot_falls_back_when_affinity_bot_is_skipped():
+def test_acquire_send_slot_falls_back_when_affinity_bot_disabled_by_skip():
     bot_a = _make_aux_bot(1, delay=0.0)
     bot_b = _make_aux_bot(2, delay=0.0)
     pool = BotPool([bot_a, bot_b], _make_manager())
@@ -132,11 +148,12 @@ def test_acquire_send_slot_falls_back_when_affinity_bot_is_skipped():
     )
 
     assert selected == (bot_b, 0.0)
+    assert pool._affinity_bot_by_key[(100, 10)] == 2
     bot_a.reserve_slot.assert_not_called()
     bot_b.reserve_slot.assert_called_once_with(100)
 
 
-def test_acquire_send_slot_falls_back_when_affinity_bot_is_delayed():
+def test_acquire_send_slot_falls_back_when_affinity_bot_has_local_delay():
     bot_a = _make_aux_bot(1, delay=1.0)
     bot_b = _make_aux_bot(2, delay=0.0)
     pool = BotPool([bot_a, bot_b], _make_manager())
@@ -145,11 +162,12 @@ def test_acquire_send_slot_falls_back_when_affinity_bot_is_delayed():
     selected = pool.acquire_send_slot(100, max_delay=2.0, affinity_key=(100, 10))
 
     assert selected == (bot_b, 0.0)
+    assert pool._affinity_bot_by_key[(100, 10)] == 2
     bot_a.reserve_slot.assert_not_called()
     bot_b.reserve_slot.assert_called_once_with(100)
 
 
-def test_acquire_send_slot_skips_frozen_bots_before_selecting():
+def test_acquire_send_slot_skips_disabled_bots_before_selecting():
     bot_a = _make_aux_bot(1, delay=0.0)
     bot_b = _make_aux_bot(2, delay=0.0)
     pool = BotPool([bot_a, bot_b], _make_manager())

--- a/tests/unit/test_etm_chat.py
+++ b/tests/unit/test_etm_chat.py
@@ -1,5 +1,8 @@
 import re
+from datetime import datetime
 from pytest import fixture
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 from efb_telegram_master.chat import convert_chat, ETMPrivateChat, ETMChatMember, ETMSelfChatMember, ETMSystemChat, \
     ETMSystemChatMember, ETMGroupChat, unpickle
 from ehforwarderbot.chat import PrivateChat, SystemChat, GroupChat
@@ -77,6 +80,33 @@ def test_etm_chat_type_title_differ(db, slave):
     sys_title = sys.chat_title
 
     assert len({user_title, group_title, sys_title}) == 3
+
+
+def test_last_message_time_uses_ttl_cache():
+    db = Mock()
+    first_time = datetime(2026, 1, 1, 0, 0, 0)
+    second_time = datetime(2026, 1, 1, 0, 1, 1)
+    db.get_last_message.side_effect = [
+        SimpleNamespace(time=first_time),
+        SimpleNamespace(time=second_time),
+    ]
+    chat = ETMPrivateChat(
+        db,
+        module_id="tests.mocks.slave",
+        uid="__chat_id__",
+        name="Chat",
+    )
+
+    with patch("efb_telegram_master.chat.time.time", return_value=100.0):
+        assert chat.last_message_time == first_time
+        assert chat.last_message_time == first_time
+
+    assert db.get_last_message.call_count == 1
+
+    with patch("efb_telegram_master.chat.time.time", return_value=161.0):
+        assert chat.last_message_time == second_time
+
+    assert db.get_last_message.call_count == 2
 
 
 def test_etm_chat_instance_title_differ(db, slave):

--- a/tests/unit/test_etm_chat.py
+++ b/tests/unit/test_etm_chat.py
@@ -103,6 +103,11 @@ def test_last_message_time_uses_ttl_cache():
 
     assert db.get_last_message.call_count == 1
 
+    with patch("efb_telegram_master.chat.time.time", return_value=160.0):
+        assert chat.last_message_time == first_time
+
+    assert db.get_last_message.call_count == 1
+
     with patch("efb_telegram_master.chat.time.time", return_value=161.0):
         assert chat.last_message_time == second_time
 

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -94,6 +94,15 @@ def test_release_slot_removes_latest_reservation():
         limiter.reserve_slot(1)
         limiter.release_slot(1)
         assert limiter.get_counts(1) == (0, 0)
+        assert 1 not in limiter._chat_timestamps
+
+
+def test_peek_and_counts_do_not_create_empty_chat_key():
+    limiter = _make_limiter()
+    with patch("efb_telegram_master.rate_limiter.time.time", return_value=100.0):
+        assert limiter.peek_delay(1) == 0.0
+        assert limiter.get_counts(1) == (0, 0)
+        assert 1 not in limiter._chat_timestamps
 
 
 # get_counts

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -83,6 +83,18 @@ def test_old_timestamps_are_cleaned_up():
     with patch("efb_telegram_master.rate_limiter.time.time", return_value=106.0):
         assert limiter.peek_delay(1) == 0.0  # old timestamp cleaned up
 
+    with patch("efb_telegram_master.rate_limiter.time.time", return_value=106.0):
+        limiter.reserve_slot(2)
+        assert 1 not in limiter._chat_timestamps
+
+
+def test_release_slot_removes_latest_reservation():
+    limiter = _make_limiter()
+    with patch("efb_telegram_master.rate_limiter.time.time", return_value=100.0):
+        limiter.reserve_slot(1)
+        limiter.release_slot(1)
+        assert limiter.get_counts(1) == (0, 0)
+
 
 # get_counts
 

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,5 +1,6 @@
 """Tests for the shared SlidingWindowRateLimiter."""
 
+from collections import deque
 from unittest.mock import patch
 
 from efb_telegram_master.rate_limiter import SlidingWindowRateLimiter
@@ -92,6 +93,19 @@ def test_release_slot_removes_latest_reservation():
     limiter = _make_limiter()
     with patch("efb_telegram_master.rate_limiter.time.time", return_value=100.0):
         limiter.reserve_slot(1)
+        limiter.release_slot(1)
+        assert limiter.get_counts(1) == (0, 0)
+        assert 1 not in limiter._chat_timestamps
+
+
+def test_release_slot_is_idempotent_without_reservation():
+    limiter = _make_limiter()
+    with patch("efb_telegram_master.rate_limiter.time.time", return_value=100.0):
+        limiter.release_slot(1)
+        assert limiter.get_counts(1) == (0, 0)
+        assert 1 not in limiter._chat_timestamps
+
+        limiter._chat_timestamps[1] = deque()
         limiter.release_slot(1)
         assert limiter.get_counts(1) == (0, 0)
         assert 1 not in limiter._chat_timestamps

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -167,10 +167,8 @@ def test_make_send_kwargs_preserve_forced_send_mode():
 
 def test_make_send_kwargs_attach_db_context_when_dispatch_sets_callback():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
-    processor._timing_tls = threading.local()
     processor.chat_manager = Mock()
     on_complete = Mock()
-    processor._timing_tls.queued_db_on_complete = on_complete
     message = SimpleNamespace(
         vendor_specific={},
         commands=[],
@@ -179,7 +177,7 @@ def test_make_send_kwargs_attach_db_context_when_dispatch_sets_callback():
     etm_msg = Mock()
 
     with patch("efb_telegram_master.slave_message.ETMMsg.from_efbmsg", return_value=etm_msg):
-        kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, None)
+        kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, None, on_complete=on_complete)
 
     db_context = kwargs["_queued_db_log_context"]
     assert kwargs["_send_mode"] == "eventual"

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -8,6 +8,7 @@ from ehforwarderbot import Message, Chat
 from ehforwarderbot.constants import MsgType
 from ehforwarderbot.chat import ChatMember
 from ehforwarderbot.types import ReactionName
+from efb_telegram_master import TelegramChannel
 from efb_telegram_master.constants import Emoji
 from efb_telegram_master.slave_message import SlaveMessageProcessor
 
@@ -88,6 +89,47 @@ def build_duplicate_test_message(uid: str = "__msg_id__") -> SimpleNamespace:
         type=MsgType.Text,
         chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
     )
+
+
+def build_stopping_channel() -> TelegramChannel:
+    channel = TelegramChannel.__new__(TelegramChannel)
+    channel.logger = Mock()
+    channel.slave_messages = Mock()
+    channel.bot_manager = SimpleNamespace(_stopping=False)
+    channel._stop_polling_called = True
+    return channel
+
+
+def test_channel_drops_slave_message_while_stopping():
+    channel = build_stopping_channel()
+    message = SimpleNamespace(uid="__late_msg__")
+
+    result = TelegramChannel.send_message(channel, message)
+
+    assert result is message
+    channel.slave_messages.send_message.assert_not_called()
+
+
+def test_channel_drops_slave_status_while_stopping():
+    channel = build_stopping_channel()
+    status = SimpleNamespace()
+
+    result = TelegramChannel.send_status(channel, status)
+
+    assert result is None
+    channel.slave_messages.send_status.assert_not_called()
+
+
+def test_channel_drops_slave_message_after_bot_manager_shutdown_starts():
+    channel = build_stopping_channel()
+    channel._stop_polling_called = False
+    channel.bot_manager._stopping = True
+    message = SimpleNamespace(uid="__late_msg__")
+
+    result = TelegramChannel.send_message(channel, message)
+
+    assert result is message
+    channel.slave_messages.send_message.assert_not_called()
 
 
 def test_send_queue_kwargs_use_slave_target_for_new_message():

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 from types import SimpleNamespace
@@ -148,6 +149,22 @@ def test_send_queue_kwargs_use_slave_target_for_new_message():
     }
 
 
+def test_send_queue_kwargs_preserve_forced_send_mode():
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    message = SimpleNamespace(
+        vendor_specific={"_force_send_mode": "blocking"},
+        commands=[],
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+    )
+
+    kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+
+    assert kwargs == {
+        "_send_mode": "blocking",
+        "_slave_id": "tests.mocks.slave __chat_id__",
+    }
+
+
 def test_blocking_send_kwargs_keep_slave_target():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
     message = SimpleNamespace(
@@ -191,7 +208,7 @@ def test_get_slave_msg_dest_caches_known_forum_chat_info():
     processor.chat_dest_cache = SimpleNamespace(get=Mock(return_value=chat_uid), remove=Mock())
     processor.generate_message_template = Mock(return_value="template")
     processor.logger = Mock()
-    processor._known_forum_chat_ids = set()
+    processor._known_forum_chat_ids = {}
     processor._known_forum_chat_ids_lock = threading.Lock()
 
     message_1 = SimpleNamespace(
@@ -211,6 +228,17 @@ def test_get_slave_msg_dest_caches_known_forum_chat_info():
     processor.bot.get_chat_info.assert_called_once_with(-100123)
     assert processor.channel.chat_binding.create_topic.call_count == 2
     assert -100123 in processor._known_forum_chat_ids
+
+    processor._known_forum_chat_ids[-100123] = time.monotonic() - processor.FORUM_CHAT_CACHE_TTL - 1
+    message_3 = SimpleNamespace(
+        uid="message-3",
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+        author=SimpleNamespace(),
+    )
+
+    assert processor.get_slave_msg_dest(message_3) == ("template", (-100123, 55))
+    assert processor.bot.get_chat_info.call_count == 2
+    assert processor.channel.chat_binding.create_topic.call_count == 3
 
 
 def test_new_slave_message_does_not_query_sent_message_log_for_dedupe():

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -213,35 +213,9 @@ def test_get_slave_msg_dest_caches_known_forum_chat_info():
     assert -100123 in processor._known_forum_chat_ids
 
 
-def test_duplicate_slave_message_logged_is_skipped():
+def test_new_slave_message_does_not_query_sent_message_log_for_dedupe():
     processor = build_duplicate_test_processor()
     processor.db.get_msg_log.return_value = SimpleNamespace(master_msg_id="100.10")
-    message = build_duplicate_test_message()
-
-    result = SlaveMessageProcessor.send_message(processor, message)
-
-    assert result is message
-    processor.get_slave_msg_dest.assert_not_called()
-    processor.dispatch_message.assert_not_called()
-
-
-def test_duplicate_slave_message_pending_is_skipped():
-    processor = build_duplicate_test_processor()
-    processor.db.get_msg_log.return_value = None
-    message = build_duplicate_test_message()
-    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
-    processor._pending_slave_messages.add(key)
-
-    result = SlaveMessageProcessor.send_message(processor, message)
-
-    assert result is message
-    processor.get_slave_msg_dest.assert_not_called()
-    processor.dispatch_message.assert_not_called()
-
-
-def test_new_slave_message_claims_pending_before_dispatch():
-    processor = build_duplicate_test_processor()
-    processor.db.get_msg_log.return_value = None
     message = build_duplicate_test_message()
     key = ("tests.mocks.slave __chat_id__", "__msg_id__")
 
@@ -249,6 +223,37 @@ def test_new_slave_message_claims_pending_before_dispatch():
 
     assert result is message
     assert key in processor._pending_slave_messages
+    processor.db.get_msg_log.assert_not_called()
+    processor.get_slave_msg_dest.assert_called_once_with(message)
+    processor.dispatch_message.assert_called_once_with(
+        message, "__template__", None, 123, None, False, dedupe_key=key,
+    )
+
+
+def test_duplicate_slave_message_pending_is_skipped():
+    processor = build_duplicate_test_processor()
+    message = build_duplicate_test_message()
+    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
+    processor._pending_slave_messages.add(key)
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    processor.db.get_msg_log.assert_not_called()
+    processor.get_slave_msg_dest.assert_not_called()
+    processor.dispatch_message.assert_not_called()
+
+
+def test_new_slave_message_claims_pending_before_dispatch():
+    processor = build_duplicate_test_processor()
+    message = build_duplicate_test_message()
+    key = ("tests.mocks.slave __chat_id__", "__msg_id__")
+
+    result = SlaveMessageProcessor.send_message(processor, message)
+
+    assert result is message
+    assert key in processor._pending_slave_messages
+    processor.db.get_msg_log.assert_not_called()
     processor.dispatch_message.assert_called_once_with(
         message, "__template__", None, 123, None, False, dedupe_key=key,
     )
@@ -256,7 +261,6 @@ def test_new_slave_message_claims_pending_before_dispatch():
 
 def test_undelivered_slave_message_releases_pending_claim():
     processor = build_duplicate_test_processor()
-    processor.db.get_msg_log.return_value = None
     processor.is_silent.return_value = None
     message = build_duplicate_test_message()
     key = ("tests.mocks.slave __chat_id__", "__msg_id__")
@@ -265,6 +269,7 @@ def test_undelivered_slave_message_releases_pending_claim():
 
     assert result is message
     assert key not in processor._pending_slave_messages
+    processor.db.get_msg_log.assert_not_called()
     processor.dispatch_message.assert_not_called()
 
 

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -3,7 +3,7 @@ import time
 from pytest import fixture
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from ehforwarderbot import Message, Chat
 from ehforwarderbot.constants import MsgType
@@ -163,6 +163,29 @@ def test_send_queue_kwargs_preserve_forced_send_mode():
         "_send_mode": "blocking",
         "_slave_id": "tests.mocks.slave __chat_id__",
     }
+
+
+def test_send_queue_kwargs_attach_db_context_when_dispatch_sets_callback():
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    processor._timing_tls = threading.local()
+    processor.chat_manager = Mock()
+    on_complete = Mock()
+    processor._timing_tls.queued_db_on_complete = on_complete
+    message = SimpleNamespace(
+        vendor_specific={},
+        commands=[],
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+    )
+    etm_msg = Mock()
+
+    with patch("efb_telegram_master.slave_message.ETMMsg.from_efbmsg", return_value=etm_msg):
+        kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+
+    db_context = kwargs["_queued_db_log_context"]
+    assert kwargs["_send_mode"] == "eventual"
+    assert db_context.etm_msg is etm_msg
+    assert db_context.old_msg_id is None
+    assert db_context.on_complete is on_complete
 
 
 def test_blocking_send_kwargs_keep_slave_target():

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -90,6 +90,36 @@ def build_duplicate_test_message(uid: str = "__msg_id__") -> SimpleNamespace:
     )
 
 
+def test_send_queue_kwargs_use_slave_target_for_new_message():
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    message = SimpleNamespace(
+        vendor_specific={},
+        commands=[],
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+    )
+
+    kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+
+    assert kwargs == {
+        "_send_mode": "eventual",
+        "_slave_id": "tests.mocks.slave __chat_id__",
+    }
+
+
+def test_blocking_send_kwargs_keep_slave_target():
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    message = SimpleNamespace(
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+    )
+
+    kwargs = SlaveMessageProcessor._blocking_send_kwargs(processor, message)
+
+    assert kwargs == {
+        "_send_mode": "blocking",
+        "_slave_id": "tests.mocks.slave __chat_id__",
+    }
+
+
 def test_duplicate_slave_message_logged_is_skipped():
     processor = build_duplicate_test_processor()
     processor.db.get_msg_log.return_value = SimpleNamespace(master_msg_id="100.10")
@@ -299,7 +329,7 @@ def test_reaction_target_prefers_alt_message_for_telegram_origin_text():
     assert effective == "100.11"
 
 
-def test_update_reactions_waits_for_delayed_database_log():
+def test_update_reactions_waits_for_queued_database_log():
     processor = Mock(spec=SlaveMessageProcessor)
     processor.REACTION_DB_WAIT_TIMEOUT = 1.0
     processor.REACTION_DB_WAIT_INTERVAL = 0.01

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -162,6 +162,57 @@ def test_blocking_send_kwargs_keep_slave_target():
     }
 
 
+def test_get_slave_msg_dest_caches_known_forum_chat_info():
+    processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
+    chat_uid = "tests.mocks.slave __chat_id__"
+    tg_chat = "telegram -100123"
+
+    def get_chat_assoc(*, slave_uid=None, master_uid=None):
+        if slave_uid == chat_uid:
+            return [tg_chat]
+        if master_uid == tg_chat:
+            return [chat_uid]
+        return []
+
+    processor.channel = SimpleNamespace(
+        config={"admins": [1]},
+        topic_group=-100999,
+        chat_binding=SimpleNamespace(create_topic=Mock(return_value=55)),
+    )
+    processor.bot = SimpleNamespace(get_chat_info=Mock(return_value=SimpleNamespace(is_forum=True)))
+    processor.db = SimpleNamespace(
+        get_chat_assoc=Mock(side_effect=get_chat_assoc),
+        get_topic_thread_id=Mock(return_value=55),
+    )
+    processor.chat_manager = SimpleNamespace(
+        update_chat_obj=lambda chat: chat,
+        get_or_enrol_member=lambda chat, author: author,
+    )
+    processor.chat_dest_cache = SimpleNamespace(get=Mock(return_value=chat_uid), remove=Mock())
+    processor.generate_message_template = Mock(return_value="template")
+    processor.logger = Mock()
+    processor._known_forum_chat_ids = set()
+    processor._known_forum_chat_ids_lock = threading.Lock()
+
+    message_1 = SimpleNamespace(
+        uid="message-1",
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+        author=SimpleNamespace(),
+    )
+    message_2 = SimpleNamespace(
+        uid="message-2",
+        chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
+        author=SimpleNamespace(),
+    )
+
+    assert processor.get_slave_msg_dest(message_1) == ("template", (-100123, 55))
+    assert processor.get_slave_msg_dest(message_2) == ("template", (-100123, 55))
+
+    processor.bot.get_chat_info.assert_called_once_with(-100123)
+    assert processor.channel.chat_binding.create_topic.call_count == 2
+    assert -100123 in processor._known_forum_chat_ids
+
+
 def test_duplicate_slave_message_logged_is_skipped():
     processor = build_duplicate_test_processor()
     processor.db.get_msg_log.return_value = SimpleNamespace(master_msg_id="100.10")

--- a/tests/unit/test_slave_message.py
+++ b/tests/unit/test_slave_message.py
@@ -133,7 +133,7 @@ def test_channel_drops_slave_message_after_bot_manager_shutdown_starts():
     channel.slave_messages.send_message.assert_not_called()
 
 
-def test_send_queue_kwargs_use_slave_target_for_new_message():
+def test_make_send_kwargs_use_slave_target_for_new_message():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
     message = SimpleNamespace(
         vendor_specific={},
@@ -141,7 +141,7 @@ def test_send_queue_kwargs_use_slave_target_for_new_message():
         chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
     )
 
-    kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+    kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, None)
 
     assert kwargs == {
         "_send_mode": "eventual",
@@ -149,7 +149,7 @@ def test_send_queue_kwargs_use_slave_target_for_new_message():
     }
 
 
-def test_send_queue_kwargs_preserve_forced_send_mode():
+def test_make_send_kwargs_preserve_forced_send_mode():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
     message = SimpleNamespace(
         vendor_specific={"_force_send_mode": "blocking"},
@@ -157,7 +157,7 @@ def test_send_queue_kwargs_preserve_forced_send_mode():
         chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
     )
 
-    kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+    kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, None)
 
     assert kwargs == {
         "_send_mode": "blocking",
@@ -165,7 +165,7 @@ def test_send_queue_kwargs_preserve_forced_send_mode():
     }
 
 
-def test_send_queue_kwargs_attach_db_context_when_dispatch_sets_callback():
+def test_make_send_kwargs_attach_db_context_when_dispatch_sets_callback():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
     processor._timing_tls = threading.local()
     processor.chat_manager = Mock()
@@ -179,7 +179,7 @@ def test_send_queue_kwargs_attach_db_context_when_dispatch_sets_callback():
     etm_msg = Mock()
 
     with patch("efb_telegram_master.slave_message.ETMMsg.from_efbmsg", return_value=etm_msg):
-        kwargs = SlaveMessageProcessor._send_queue_kwargs(processor, message, None)
+        kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, None)
 
     db_context = kwargs["_queued_db_log_context"]
     assert kwargs["_send_mode"] == "eventual"
@@ -188,13 +188,13 @@ def test_send_queue_kwargs_attach_db_context_when_dispatch_sets_callback():
     assert db_context.on_complete is on_complete
 
 
-def test_blocking_send_kwargs_keep_slave_target():
+def test_make_send_kwargs_keep_slave_target_for_blocking_mode():
     processor = SlaveMessageProcessor.__new__(SlaveMessageProcessor)
     message = SimpleNamespace(
         chat=SimpleNamespace(module_id="tests.mocks.slave", uid="__chat_id__"),
     )
 
-    kwargs = SlaveMessageProcessor._blocking_send_kwargs(processor, message)
+    kwargs = SlaveMessageProcessor._make_send_kwargs(processor, message, mode='blocking')
 
     assert kwargs == {
         "_send_mode": "blocking",


### PR DESCRIPTION
Summary: simplify the outbound slave send pipeline to in-memory FIFO keyed by (slave_id, chat_id), use bot-chat disable windows only for Telegram rate limits, preserve slave_id bot affinity, and align queue/cache tests. Tests: python3 -m py_compile for touched source and tests passed; python3 -m pytest tests/unit/test_bot_manager.py tests/unit/test_bot_pool.py tests/unit/test_rate_limiter.py tests/unit/test_slave_message.py tests/unit/test_db_migrations.py tests/unit/test_etm_chat.py could not run because pytest is not installed in this environment.