### PR TITLE
Restore Prometheus runtime observability

### DIFF
--- a/efb_telegram_master/auxiliary_bot.py
+++ b/efb_telegram_master/auxiliary_bot.py
@@ -164,6 +164,10 @@ class AuxiliaryBot:
         chat_count, _global_count = self._rate_limiter.get_counts(chat_id)
         return chat_count
 
+    def rate_limit_occupancy_snapshot(self) -> Dict[str, float]:
+        """Return aggregate rate-limit occupancy without exposing chat identities."""
+        return self._rate_limiter.occupancy_snapshot()
+
     def get_known_member_chat_ids(self) -> set[int]:
         """Return chat IDs where this bot is currently cached as a member."""
         with self._membership_lock:

--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -340,6 +340,7 @@ class TelegramBotManager(LocaleMixin):
     MEMBERSHIP_RECHECK_SECONDS = 0.25
     SHUTDOWN_DRAIN_TIMEOUT = 5.0
     SHUTDOWN_JOIN_GRACE = 1.0
+    _bot_chat_state_lock_initialization_lock = threading.Lock()
 
     # Type declarations for instance attributes assigned in __init__
     application: Application
@@ -482,22 +483,20 @@ class TelegramBotManager(LocaleMixin):
         from concurrent.futures import ThreadPoolExecutor
 
         self._send_worker_stop = threading.Event()
+        self._bot_chat_state_lock = threading.Lock()
         self._bot_chat_disabled_until: dict[BotChatKey, float] = {}
         self._membership_failure_affinities: dict[BotChatKey, set[str]] = {}
         self._queued_db_log_contexts: dict[int, QueuedDbLogContext] = {}
         self._queued_db_log_context_lock = threading.Lock()
         self._last_metrics_snapshot = 0.0
         from .etm_metrics import Metrics, start_metrics_server
-        _metrics_top_n, metrics_endpoint = self._parse_metrics_config(config.get('metrics'), self.logger)
+        metrics_top_n, metrics_endpoint = self._parse_metrics_config(config.get('metrics'), self.logger)
         self._metrics = Metrics(namespace="etm")
+        channel.db.set_metrics(self._metrics)
+        if self.bot_pool:
+            for auxiliary in self.bot_pool.bots:
+                auxiliary.bind_metrics(self._metrics)
         self._metrics_httpd = None
-        if metrics_endpoint is not None:
-            metrics_host, metrics_port = metrics_endpoint
-            self._metrics_httpd = start_metrics_server(
-                metrics_host,
-                metrics_port,
-                registry=self._metrics.registry,
-            )
 
         self._send_worker_count = self.DEFAULT_SEND_WORKER_COUNT
         self._outbound_queue = OutboundQueue(channel.db._base_path, metrics=self._metrics)
@@ -512,6 +511,15 @@ class TelegramBotManager(LocaleMixin):
             executor=self._send_executor,
             worker_count=self._send_worker_count,
         )
+        self._register_runtime_metric_collectors(metrics_top_n)
+
+        if metrics_endpoint is not None:
+            metrics_host, metrics_port = metrics_endpoint
+            self._metrics_httpd = start_metrics_server(
+                metrics_host,
+                metrics_port,
+                registry=self._metrics.registry,
+            )
 
         self._send_worker_thread = threading.Thread(
             target=self._queued_send_worker,
@@ -930,6 +938,68 @@ class TelegramBotManager(LocaleMixin):
 
         return top_n, (host, port)
 
+    def _register_runtime_metric_collectors(self, top_n: int) -> None:
+        """Bind bounded scrape callbacks after all outbound runtime state exists."""
+        from .etm_metrics import DestinationQueueSnapshot, WorkerSnapshot
+
+        def destination_snapshot() -> list[DestinationQueueSnapshot]:
+            return [
+                DestinationQueueSnapshot(destination, depth, oldest_age)
+                for destination, depth, oldest_age in self._outbound_queue.destination_snapshot()
+            ]
+
+        def worker_snapshot() -> WorkerSnapshot:
+            worker = getattr(self, "_send_worker_thread", None)
+            return WorkerSnapshot(
+                healthy=bool(worker is not None and worker.is_alive()),
+                in_flight=self._outbound_scheduler.in_flight_count(),
+            )
+
+        self._metrics.register_destination_queue_collector(destination_snapshot, top_n)
+        self._metrics.register_worker_collector(worker_snapshot)
+        self._metrics.register_cooldown_collector(self._cooldown_snapshot)
+        self._metrics.register_auxiliary_count_collector(self._auxiliary_count_snapshot)
+        self._metrics.register_membership_cache_collector(self._membership_cache_snapshot)
+        self._metrics.register_rate_limit_occupancy_collector(self._rate_limit_occupancy_snapshot)
+
+    def _get_bot_chat_state_lock(self):
+        lock = getattr(self, "_bot_chat_state_lock", None)
+        if lock is not None:
+            return lock
+        with self._bot_chat_state_lock_initialization_lock:
+            lock = getattr(self, "_bot_chat_state_lock", None)
+            if lock is None:
+                lock = threading.Lock()
+                self._bot_chat_state_lock = lock
+            return lock
+
+    def _cooldown_snapshot(self) -> dict[str, float]:
+        now = time.monotonic()
+        cooldowns = {"main": 0.0, "auxiliary": 0.0}
+        with self._get_bot_chat_state_lock():
+            cooldown_entries = tuple(self._bot_chat_disabled_until.items())
+        for (sender_bot_id, _chat_id), deadline in cooldown_entries:
+            sender_kind = "main" if sender_bot_id is None else "auxiliary"
+            cooldowns[sender_kind] = max(cooldowns[sender_kind], max(0.0, deadline - now))
+        return cooldowns
+
+    def _auxiliary_count_snapshot(self) -> dict[str, int]:
+        if not self.bot_pool:
+            return {"enabled": 0, "disabled": 0}
+        return self.bot_pool.auxiliary_count_snapshot()
+
+    def _membership_cache_snapshot(self) -> dict[str, int]:
+        if not self.bot_pool:
+            return {"member": 0, "not_member": 0, "unknown_probe_pending": 0}
+        return self.bot_pool.membership_cache_snapshot()
+
+    def _rate_limit_occupancy_snapshot(self) -> dict[str, float]:
+        occupancy = self._rate_limiter.occupancy_snapshot()
+        if self.bot_pool:
+            for scope, value in self.bot_pool.rate_limit_occupancy_snapshot().items():
+                occupancy[scope] = max(occupancy[scope], value)
+        return occupancy
+
     def _init_bot_pool(self, aux_configs: list, config: dict, channel: 'TelegramChannel'):
         """Initialize the auxiliary bot pool from config."""
         req_kwargs = {
@@ -1197,7 +1267,8 @@ class TelegramBotManager(LocaleMixin):
     def _select_available_sender(
         self, selection: SenderSelection, chat_id: int, now: float
     ) -> SenderSelectionResult:
-        cooldown_until = self._bot_chat_disabled_until.get((selection.sender_bot_id, chat_id), 0.0)
+        with self._get_bot_chat_state_lock():
+            cooldown_until = self._bot_chat_disabled_until.get((selection.sender_bot_id, chat_id), 0.0)
         limiter_delay = self._sender_limiter_delay(selection, chat_id)
         retry_at = max(cooldown_until, now + limiter_delay)
         if retry_at > now:
@@ -1354,20 +1425,23 @@ class TelegramBotManager(LocaleMixin):
     ) -> QueuedCompletionDecision:
         key = (selection.sender_bot_id, row.telegram_chat_id)
         if selection.sender_bot_id is not None and row.slave_id:
-            affinities = getattr(self, "_membership_failure_affinities", None)
-            if affinities is None:
-                affinities = self._membership_failure_affinities = {}
-            affinities.setdefault(key, set()).add(row.slave_id)
+            with self._get_bot_chat_state_lock():
+                affinities = getattr(self, "_membership_failure_affinities", None)
+                if affinities is None:
+                    affinities = self._membership_failure_affinities = {}
+                affinities.setdefault(key, set()).add(row.slave_id)
 
         if row.priority == 0 and isinstance(error, telegram.error.RetryAfter):
             retry_after = self._retry_after_seconds(error)
             retry_at = time.monotonic() + retry_after
-            self._bot_chat_disabled_until[key] = retry_at
+            with self._get_bot_chat_state_lock():
+                self._bot_chat_disabled_until[key] = retry_at
             return QueuedCompletionDecision(QueuedCompletionKind.RETRY_EVENTUAL, retry_at)
 
         cooldown_seconds = self._rate_limit_retry_after_seconds(cast(Exception, error))
         if cooldown_seconds is not None:
-            self._bot_chat_disabled_until[key] = time.monotonic() + cooldown_seconds
+            with self._get_bot_chat_state_lock():
+                self._bot_chat_disabled_until[key] = time.monotonic() + cooldown_seconds
         self._finish_queued_database_update(getattr(row, "id", None))
         return QueuedCompletionDecision(QueuedCompletionKind.TERMINAL_FAILURE)
 
@@ -1376,13 +1450,15 @@ class TelegramBotManager(LocaleMixin):
     ) -> None:
         """Record a sender/chat cooldown without completing the queued database update."""
         retry_at = time.monotonic() + self._retry_after_seconds(error)
-        self._bot_chat_disabled_until[(selection.sender_bot_id, row.telegram_chat_id)] = retry_at
+        with self._get_bot_chat_state_lock():
+            self._bot_chat_disabled_until[(selection.sender_bot_id, row.telegram_chat_id)] = retry_at
 
     def remove_confirmed_non_member_affinity_for_sender_chat(
         self, sender_bot_id: str, telegram_chat_id: int
     ) -> None:
-        affinities = getattr(self, "_membership_failure_affinities", {})
-        slave_ids = affinities.pop((sender_bot_id, telegram_chat_id), set())
+        with self._get_bot_chat_state_lock():
+            affinities = getattr(self, "_membership_failure_affinities", {})
+            slave_ids = affinities.pop((sender_bot_id, telegram_chat_id), set())
         if self.bot_pool:
             for slave_id in slave_ids:
                 self.bot_pool.remove_failed_membership_affinity(slave_id, sender_bot_id)
@@ -1878,10 +1954,7 @@ class TelegramBotManager(LocaleMixin):
         # Stop the queued send worker first
         self.stop_queued_worker()
 
-        metrics_httpd = getattr(self, '_metrics_httpd', None)
-        if metrics_httpd:
-            metrics_httpd.shutdown()
-            metrics_httpd.server_close()
+        TelegramBotManager._stop_metrics_server(self)
 
         # Shut down auxiliary bot pool
         if self.bot_pool:
@@ -1949,6 +2022,21 @@ class TelegramBotManager(LocaleMixin):
             else:
                 self._runtime.clear_loop()
         self.logger.info("Graceful shutdown completed")
+
+    def _stop_metrics_server(self) -> None:
+        """Stop the serving metrics thread without joining an unstarted thread."""
+        metrics_httpd = getattr(self, '_metrics_httpd', None)
+        if metrics_httpd is None:
+            return
+        self._metrics_httpd = None
+        thread = getattr(metrics_httpd, 'thread', None)
+        try:
+            if thread is not None and thread.is_alive():
+                metrics_httpd.shutdown()
+        finally:
+            metrics_httpd.server_close()
+        if thread is not None and thread.is_alive() and thread.ident != threading.get_ident():
+            thread.join(timeout=self.SHUTDOWN_JOIN_GRACE)
 
     def __del__(self):
         """Ensure cleanup on object destruction"""

--- a/efb_telegram_master/bot_pool.py
+++ b/efb_telegram_master/bot_pool.py
@@ -131,6 +131,27 @@ class BotPool:
             while bot.has_pending_probes() and time.monotonic() < deadline:
                 time.sleep(0.1)
 
+    def auxiliary_count_snapshot(self) -> dict[str, int]:
+        """Return configured auxiliary counts grouped by enabled state."""
+        enabled = sum(1 for bot in self._bots if not bot.disabled)
+        return {"enabled": enabled, "disabled": len(self._bots) - enabled}
+
+    def membership_cache_snapshot(self) -> dict[str, int]:
+        """Combine auxiliary membership-cache counts without retaining identities."""
+        totals = {"member": 0, "not_member": 0, "unknown_probe_pending": 0}
+        for bot in self._bots:
+            for state, count in bot.get_membership_cache_snapshot().items():
+                totals[state] += count
+        return totals
+
+    def rate_limit_occupancy_snapshot(self) -> dict[str, float]:
+        """Return the highest current auxiliary occupancy for each limiter scope."""
+        occupancy = {"global": 0.0, "chat": 0.0}
+        for bot in self._bots:
+            for scope, value in bot.rate_limit_occupancy_snapshot().items():
+                occupancy[scope] = max(occupancy[scope], value)
+        return occupancy
+
     def __bool__(self) -> bool:
         return bool(self._bots)
 

--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -5,8 +5,8 @@ import logging
 import pickle
 import time
 from contextlib import suppress
-from functools import partial
-from typing import Collection, Dict, List, Optional, Tuple, TYPE_CHECKING, cast
+from functools import partial, wraps
+from typing import Callable, Collection, Dict, List, Optional, Protocol, Tuple, TYPE_CHECKING, cast
 from pathlib import Path
 
 from peewee import (
@@ -40,6 +40,38 @@ if TYPE_CHECKING:
     from .chat import ETMChatMember, ETMChatType
 
 database = DatabaseProxy()
+
+
+class DatabaseMetrics(Protocol):
+    """Metrics interface injected by the bot manager after construction."""
+
+    def record_database_method_call(self, method: str, seconds: float, outcome: str) -> None:
+        ...
+
+
+def observe_database_method(method: str):
+    """Measure one public database operation with a statically bounded method label."""
+    def decorate(call: Callable):
+        @wraps(call)
+        def wrapped(manager: 'DatabaseManager', *args, **kwargs):
+            started = time.perf_counter()
+            outcome = "success"
+            try:
+                return call(manager, *args, **kwargs)
+            except Exception:
+                outcome = "failure"
+                raise
+            finally:
+                metrics = getattr(manager, "_metrics", None)
+                if metrics is not None:
+                    try:
+                        metrics.record_database_method_call(method, time.perf_counter() - started, outcome)
+                    except Exception:
+                        manager.logger.exception("Unable to record database method metric: %s", method)
+
+        return wrapped
+
+    return decorate
 
 PickledDict = TypedDict('PickledDict', {
     "target": TgChatMsgIDStr,
@@ -226,6 +258,7 @@ class DatabaseManager:
     )
 
     def __init__(self, channel: 'TelegramChannel'):
+        self._metrics: Optional[DatabaseMetrics] = None
         base_path = utils.get_data_path(channel.channel_id)
         self._base_path = base_path
 
@@ -289,6 +322,11 @@ class DatabaseManager:
         self.logger.debug("Database migration finished...")
         self._observe_legacy_outbound_rows()
 
+    def set_metrics(self, metrics: DatabaseMetrics) -> None:
+        """Attach the metrics recorder created after the database manager."""
+        self._metrics = metrics
+
+    @observe_database_method("stop_worker")
     def stop_worker(self):
         stop = getattr(database.obj, "stop", None)
         if callable(stop):
@@ -493,6 +531,7 @@ class DatabaseManager:
                 state_summary,
             )
 
+    @observe_database_method("add_chat_assoc")
     def add_chat_assoc(self, master_uid: EFBChannelChatIDStr,
                        slave_uid: EFBChannelChatIDStr,
                        multiple_slave: bool = False):
@@ -510,8 +549,8 @@ class DatabaseManager:
         self.remove_chat_assoc(slave_uid=slave_uid)
         return ChatAssoc.create(master_uid=master_uid, slave_uid=slave_uid)
 
-    @staticmethod
-    def remove_chat_assoc(master_uid: Optional[EFBChannelChatIDStr] = None,
+    @observe_database_method("remove_chat_assoc")
+    def remove_chat_assoc(self, master_uid: Optional[EFBChannelChatIDStr] = None,
                           slave_uid: Optional[EFBChannelChatIDStr] = None):
         """
         Remove chat associations (chat links).
@@ -540,8 +579,8 @@ class DatabaseManager:
         except DoesNotExist:
             return 0
 
-    @staticmethod
-    def get_master_msg_id(message: EFBMessage) -> Optional[TgChatMsgIDStr]:
+    @observe_database_method("get_master_msg_id")
+    def get_master_msg_id(self, message: EFBMessage) -> Optional[TgChatMsgIDStr]:
         """Get master message ID from a message object."""
         log: Optional[MsgLog] = MsgLog.get_or_none(
             MsgLog.slave_origin_uid == chat_id_to_str(chat=message.chat),
@@ -591,8 +630,8 @@ class DatabaseManager:
             return pickle.dumps(data)
         return None
 
-    @staticmethod
-    def get_chat_assoc(master_uid: Optional[EFBChannelChatIDStr] = None,
+    @observe_database_method("get_chat_assoc")
+    def get_chat_assoc(self, master_uid: Optional[EFBChannelChatIDStr] = None,
                        slave_uid: Optional[EFBChannelChatIDStr] = None
                        ) -> List[EFBChannelChatIDStr]:
         """
@@ -626,6 +665,7 @@ class DatabaseManager:
         except DoesNotExist:
             return []
 
+    @observe_database_method("add_topic_assoc")
     def add_topic_assoc(self, topic_chat_id: TelegramChatID,
                        message_thread_id: TelegramTopicID,
                        slave_uid: EFBChannelChatIDStr, ):
@@ -642,8 +682,8 @@ class DatabaseManager:
         self.remove_topic_assoc(topic_chat_id=topic_chat_id, message_thread_id=TelegramTopicID(int(message_thread_id)))
         return TopicAssoc.create(topic_chat_id=topic_chat_id, message_thread_id=message_thread_id, slave_uid=slave_uid)
 
-    @staticmethod
-    def get_topic_thread_id(slave_uid: EFBChannelChatIDStr, topic_chat_id: Optional[TelegramChatID] = None) -> Optional[TelegramTopicID]:
+    @observe_database_method("get_topic_thread_id")
+    def get_topic_thread_id(self, slave_uid: EFBChannelChatIDStr, topic_chat_id: Optional[TelegramChatID] = None) -> Optional[TelegramTopicID]:
         """
         Get topic association (topic link) information.
         Only one parameter is to be provided.
@@ -670,8 +710,8 @@ class DatabaseManager:
             pass
         return None
 
-    @staticmethod
-    def get_topic_slave(topic_chat_id: TelegramChatID,
+    @observe_database_method("get_topic_slave")
+    def get_topic_slave(self, topic_chat_id: TelegramChatID,
                         message_thread_id: Optional[TelegramTopicID] = None,
                         ) -> Optional[EFBChannelChatIDStr]:
         """
@@ -697,8 +737,8 @@ class DatabaseManager:
         except AttributeError:
             return None
 
-    @staticmethod
-    def get_topic_slaves(topic_chat_id: TelegramChatID) -> Optional[List[Tuple[EFBChannelChatIDStr, TelegramTopicID]]]:
+    @observe_database_method("get_topic_slaves")
+    def get_topic_slaves(self, topic_chat_id: TelegramChatID) -> Optional[List[Tuple[EFBChannelChatIDStr, TelegramTopicID]]]:
         """
         Get topic association (topic link) information.
         Only one parameter is to be provided.
@@ -718,8 +758,8 @@ class DatabaseManager:
         except AttributeError:
             return None
 
-    @staticmethod
-    def remove_topic_assoc(topic_chat_id: Optional[TelegramChatID] = None,
+    @observe_database_method("remove_topic_assoc")
+    def remove_topic_assoc(self, topic_chat_id: Optional[TelegramChatID] = None,
                            message_thread_id: Optional[TelegramTopicID] = None,
                            slave_uid: Optional[EFBChannelChatIDStr] = None):
         """
@@ -743,6 +783,7 @@ class DatabaseManager:
         except DoesNotExist:
             return 0
 
+    @observe_database_method("add_or_update_message_log")
     def add_or_update_message_log(self,
                                   msg: ETMMsg,
                                   master_message: Message,
@@ -801,8 +842,8 @@ class DatabaseManager:
         result = save()
         self.logger.debug("[%s] Database insert/update outcome: %s", master_msg_id, result)
 
-    @staticmethod
-    def get_msg_log(master_msg_id: Optional[TgChatMsgIDStr] = None,
+    @observe_database_method("get_msg_log")
+    def get_msg_log(self, master_msg_id: Optional[TgChatMsgIDStr] = None,
                     slave_msg_id: Optional[MessageID] = None,
                     slave_origin_uid: Optional[EFBChannelChatIDStr] = None) -> Optional[MsgLog]:
         """Get message log by message ID.
@@ -831,8 +872,8 @@ class DatabaseManager:
         except DoesNotExist:
             return None
 
-    @staticmethod
-    def delete_msg_log(master_msg_id: Optional[TgChatMsgIDStr] = None,
+    @observe_database_method("delete_msg_log")
+    def delete_msg_log(self, master_msg_id: Optional[TgChatMsgIDStr] = None,
                        slave_msg_id: Optional[EFBChannelChatIDStr] = None,
                        slave_origin_uid: Optional[EFBChannelChatIDStr] = None):
         """Remove a message log by message ID.
@@ -857,8 +898,8 @@ class DatabaseManager:
         except DoesNotExist:
             return
 
-    @staticmethod
-    def get_slave_chat_info(slave_channel_id: Optional[ModuleID] = None,
+    @observe_database_method("get_slave_chat_info")
+    def get_slave_chat_info(self, slave_channel_id: Optional[ModuleID] = None,
                             slave_chat_uid: Optional[ChatID] = None,
                             slave_chat_group_id: Optional[ChatID] = None
                             ) -> Optional[SlaveChatInfo]:
@@ -878,6 +919,7 @@ class DatabaseManager:
         except DoesNotExist:
             return None
 
+    @observe_database_method("set_slave_chat_info")
     def set_slave_chat_info(self, chat_object: 'ETMChatType') -> SlaveChatInfo:
         """
         Insert or update slave chat info entry
@@ -922,15 +964,15 @@ class DatabaseManager:
                                         slave_chat_type=slave_chat_type,
                                         pickle=chat_object.pickle)
 
-    @staticmethod
-    def delete_slave_chat_info(slave_channel_id: ModuleID, slave_chat_uid: ChatID, slave_chat_group_id: Optional[ChatID] = None):
+    @observe_database_method("delete_slave_chat_info")
+    def delete_slave_chat_info(self, slave_channel_id: ModuleID, slave_chat_uid: ChatID, slave_chat_group_id: Optional[ChatID] = None):
         return SlaveChatInfo.delete() \
             .where((SlaveChatInfo.slave_channel_id == slave_channel_id) &
                    (SlaveChatInfo.slave_chat_uid == slave_chat_uid) &
                    (SlaveChatInfo.slave_chat_group_id == slave_chat_group_id)).execute()
 
-    @staticmethod
-    def get_recent_slave_chats(master_chat_id: TelegramChatID, limit=5) -> List[EFBChannelChatIDStr]:
+    @observe_database_method("get_recent_slave_chats")
+    def get_recent_slave_chats(self, master_chat_id: TelegramChatID, limit=5) -> List[EFBChannelChatIDStr]:
         query = MsgLog \
             .select(MsgLog.slave_origin_uid, fn.MAX(MsgLog.time)) \
             .where(MsgLog.master_msg_id.startswith("{}.".format(master_chat_id))) \
@@ -940,8 +982,8 @@ class DatabaseManager:
 
         return [EFBChannelChatIDStr(i.slave_origin_uid) for i in query]
 
-    @staticmethod
-    def get_last_message(slave_chat_id: EFBChannelChatIDStr) -> Optional[MsgLog]:
+    @observe_database_method("get_last_message")
+    def get_last_message(self, slave_chat_id: EFBChannelChatIDStr) -> Optional[MsgLog]:
         try:
             return MsgLog.select().where(
                 MsgLog.slave_origin_uid == slave_chat_id
@@ -949,8 +991,8 @@ class DatabaseManager:
         except DoesNotExist:
             return None
 
-    @staticmethod
-    def get_recent_messages(slave_chat_id: EFBChannelChatIDStr, limit: int = 1000) -> List[MsgLog]:
+    @observe_database_method("get_recent_messages")
+    def get_recent_messages(self, slave_chat_id: EFBChannelChatIDStr, limit: int = 1000) -> List[MsgLog]:
         """Get recent messages from a specific slave chat for migration purposes.
 
         Args:
@@ -987,14 +1029,15 @@ class DatabaseManager:
             return base_filter & HistoryMigrationEntry.message_thread_id.is_null(True)
         return base_filter & (HistoryMigrationEntry.message_thread_id == thread_value)
 
-    @staticmethod
+    @observe_database_method("replace_history_migration_entries")
     def replace_history_migration_entries(
+        self,
         slave_chat_id: EFBChannelChatIDStr,
         target_chat_id: int,
         message_thread_id: Optional[TelegramTopicID],
         entries: List[Dict[str, object]],
     ) -> int:
-        target_filter = DatabaseManager._history_migration_target_filter(
+        target_filter = self._history_migration_target_filter(
             slave_chat_id,
             target_chat_id,
             message_thread_id,
@@ -1005,25 +1048,26 @@ class DatabaseManager:
                 HistoryMigrationEntry.insert_many(entries).execute()
         return len(entries)
 
-    @staticmethod
-    def has_pending_history_migrations() -> bool:
+    @observe_database_method("has_pending_history_migrations")
+    def has_pending_history_migrations(self) -> bool:
         return HistoryMigrationEntry.select().exists()
 
-    @staticmethod
-    def get_next_history_migration_target() -> Optional[HistoryMigrationEntry]:
+    @observe_database_method("get_next_history_migration_target")
+    def get_next_history_migration_target(self) -> Optional[HistoryMigrationEntry]:
         return (
             HistoryMigrationEntry.select()
             .order_by(HistoryMigrationEntry.id.asc())
             .first()
         )
 
-    @staticmethod
+    @observe_database_method("get_history_migration_entries")
     def get_history_migration_entries(
+        self,
         slave_chat_id: EFBChannelChatIDStr,
         target_chat_id: int,
         message_thread_id: Optional[TelegramTopicID] = None,
     ) -> List[HistoryMigrationEntry]:
-        target_filter = DatabaseManager._history_migration_target_filter(
+        target_filter = self._history_migration_target_filter(
             slave_chat_id,
             target_chat_id,
             message_thread_id,
@@ -1034,8 +1078,8 @@ class DatabaseManager:
             .order_by(HistoryMigrationEntry.position.asc(), HistoryMigrationEntry.id.asc())
         )
 
-    @staticmethod
-    def delete_history_migration_entry(entry_id: int) -> int:
+    @observe_database_method("delete_history_migration_entry")
+    def delete_history_migration_entry(self, entry_id: int) -> int:
         return int(
             HistoryMigrationEntry.delete()
             .where(HistoryMigrationEntry.id == entry_id)

--- a/efb_telegram_master/etm_metrics.py
+++ b/efb_telegram_master/etm_metrics.py
@@ -1,8 +1,15 @@
-"""Prometheus instrumentation for the dequeue-only outbound queue."""
+"""Bounded Prometheus instrumentation for ETM's outbound delivery model."""
 
 from __future__ import annotations
 
+import math
+import threading
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Metric
 
 from .outbound import QUEUED_OPERATIONS
 
@@ -11,14 +18,102 @@ _PRIORITIES = frozenset({"blocking", "normal"})
 _SENDER_KINDS = frozenset({"main", "auxiliary"})
 _REMOVAL_OUTCOMES = frozenset({"submitted", "terminal_discard"})
 _COMPLETION_OUTCOMES = frozenset({"success", "failure"})
+_DISPATCH_OUTCOMES = frozenset({"submitted", "deferred", "failed"})
+_RETRY_REASONS = frozenset({"rate_limit", "membership", "worker_capacity"})
+_FAILURE_STAGES = frozenset({"dispatch", "execution", "terminal"})
+_AUXILIARY_STATES = frozenset({"enabled", "disabled"})
+_MEMBERSHIP_CACHE_STATES = frozenset({"member", "not_member", "unknown_probe_pending"})
+_MEMBERSHIP_PROBE_OUTCOMES = frozenset({"ok_member", "ok_not_member", "forbidden", "bad_request", "error"})
+_RATE_LIMIT_SCOPES = frozenset({"global", "chat"})
+_DATABASE_METHODS = frozenset({
+    "stop_worker",
+    "add_chat_assoc",
+    "remove_chat_assoc",
+    "get_master_msg_id",
+    "get_chat_assoc",
+    "add_topic_assoc",
+    "get_topic_thread_id",
+    "get_topic_slave",
+    "get_topic_slaves",
+    "remove_topic_assoc",
+    "add_or_update_message_log",
+    "get_msg_log",
+    "delete_msg_log",
+    "get_slave_chat_info",
+    "set_slave_chat_info",
+    "delete_slave_chat_info",
+    "get_recent_slave_chats",
+    "get_last_message",
+    "get_recent_messages",
+    "replace_history_migration_entries",
+    "has_pending_history_migrations",
+    "get_next_history_migration_target",
+    "get_history_migration_entries",
+    "delete_history_migration_entry",
+})
+_DATABASE_OUTCOMES = frozenset({"success", "failure"})
+
+
+@dataclass(frozen=True)
+class DestinationQueueSnapshot:
+    """One destination's current queue state, supplied by a scrape callback."""
+
+    destination: str
+    depth: int
+    oldest_age_seconds: float | None
+
+
+@dataclass(frozen=True)
+class WorkerSnapshot:
+    """Aggregate liveness and work ownership supplied by a scrape callback."""
+
+    healthy: bool
+    in_flight: int
+
+
+class _CallbackCollector:
+    """Expose a bounded callback snapshot without retaining application objects."""
+
+    def __init__(self, collect: Callable[[], Iterable[Metric]]) -> None:
+        self._collect = collect
+
+    def collect(self) -> Iterable[Metric]:
+        return self._collect()
+
+
+class MetricsServer:
+    """Serving-thread handle with the WSGI server's shutdown compatibility methods."""
+
+    def __init__(self, server: Any, thread: threading.Thread) -> None:
+        self._server = server
+        self.thread = thread
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+
+    def server_close(self) -> None:
+        self._server.server_close()
+
+    @property
+    def server_address(self) -> tuple[str, int]:
+        return self._server.server_address
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._server, name)
 
 
 class Metrics:
-    """Expose only bounded queue lifecycle metrics defined by the queue contract."""
+    """Expose bounded queue lifecycle metrics and pull-based runtime snapshots."""
 
-    def __init__(self, namespace: str = "etm") -> None:
+    def __init__(
+        self,
+        namespace: str = "etm",
+        process_factory: Callable[[], Any] | None = None,
+        network_io_counters: Callable[[], Any] | None = None,
+    ) -> None:
         self.registry = CollectorRegistry()
         self.namespace = namespace
+        self._collectors: list[_CallbackCollector] = []
         self.enqueued = Counter(
             f"{namespace}_outbound_enqueued_total",
             "Queued rows whose insert transaction committed.",
@@ -62,10 +157,65 @@ class Metrics:
         )
         self.completions = Counter(
             f"{namespace}_outbound_completions_total",
-            "Harvested executor completions.",
+            "Terminal outbound delivery outcomes.",
             ["priority", "operation", "sender_kind", "outcome"],
             registry=self.registry,
         )
+        self.queue_dispatches = Counter(
+            f"{namespace}_outbound_queue_dispatches_total",
+            "Scheduler dispatch decisions by bounded outcome.",
+            ["outcome"],
+            registry=self.registry,
+        )
+        self.queue_wait = Histogram(
+            f"{namespace}_outbound_queue_wait_seconds",
+            "Seconds a queued call waits before a dispatch attempt.",
+            ["priority", "operation"],
+            registry=self.registry,
+        )
+        self.executor_attempt_duration = Histogram(
+            f"{namespace}_outbound_executor_attempt_duration_seconds",
+            "Seconds from executor submission until one attempt completes.",
+            ["priority", "operation", "outcome"],
+            registry=self.registry,
+        )
+        self.queue_lifetime = Histogram(
+            f"{namespace}_outbound_queue_lifetime_seconds",
+            "Seconds from enqueue until terminal completion.",
+            ["priority", "operation", "outcome"],
+            registry=self.registry,
+        )
+        self.retries = Counter(
+            f"{namespace}_outbound_retries_total",
+            "Queue retries by bounded reason.",
+            ["priority", "operation", "reason"],
+            registry=self.registry,
+        )
+        self.failures = Counter(
+            f"{namespace}_outbound_failures_total",
+            "Outbound failures by bounded stage.",
+            ["priority", "operation", "stage"],
+            registry=self.registry,
+        )
+        self.membership_probes = Counter(
+            f"{namespace}_auxiliary_membership_probes_total",
+            "Auxiliary membership probes by bounded outcome.",
+            ["outcome"],
+            registry=self.registry,
+        )
+        self.database_method_duration = Histogram(
+            f"{namespace}_database_method_duration_seconds",
+            "Elapsed seconds for a DatabaseManager method call.",
+            ["method"],
+            registry=self.registry,
+        )
+        self.database_method_failures = Counter(
+            f"{namespace}_database_method_failures_total",
+            "DatabaseManager method calls that raised an exception.",
+            ["method"],
+            registry=self.registry,
+        )
+        self.register_process_collector(process_factory, network_io_counters)
 
     @staticmethod
     def _priority(priority: str | bool | int) -> str:
@@ -88,35 +238,38 @@ class Metrics:
         return sender_kind
 
     @staticmethod
-    def _removal_outcome(outcome: str) -> str:
-        if outcome not in _REMOVAL_OUTCOMES:
-            raise ValueError("removal outcome must be submitted or terminal_discard")
-        return outcome
+    def _non_negative(value: float, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+            raise ValueError(f"{name} must be a finite non-negative number")
+        return float(value)
+
+    @classmethod
+    def _count(cls, value: int, name: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+        return value
 
     @staticmethod
-    def _completion_outcome(outcome: str) -> str:
-        if outcome not in _COMPLETION_OUTCOMES:
-            raise ValueError("completion outcome must be success or failure")
-        return outcome
+    def _bounded(value: str, allowed: frozenset[str], name: str) -> str:
+        if value not in allowed:
+            raise ValueError(f"{name} is invalid")
+        return value
 
     def record_enqueued(self, priority: str | bool | int, operation: str) -> None:
         self.enqueued.labels(self._priority(priority), self._operation(operation)).inc()
 
     def set_queue_depth(self, depth: int) -> None:
-        if isinstance(depth, bool) or not isinstance(depth, int) or depth < 0:
-            raise ValueError("queue depth must be a non-negative integer")
-        self.queue_depth.set(depth)
+        self.queue_depth.set(self._count(depth, "queue depth"))
 
     def record_removal(
         self, priority: str | bool | int, operation: str, outcome: str, residence_seconds: float
     ) -> None:
-        normalized_priority = self._priority(priority)
-        normalized_operation = self._operation(operation)
-        normalized_outcome = self._removal_outcome(outcome)
-        if residence_seconds < 0:
-            raise ValueError("queue residence must not be negative")
-        labels = (normalized_priority, normalized_operation, normalized_outcome)
-        self.queue_residence.labels(*labels).observe(residence_seconds)
+        labels = (
+            self._priority(priority),
+            self._operation(operation),
+            self._bounded(outcome, _REMOVAL_OUTCOMES, "removal outcome"),
+        )
+        self.queue_residence.labels(*labels).observe(self._non_negative(residence_seconds, "queue residence"))
         self.removals.labels(*labels).inc()
 
     def record_dequeued(self, priority: str | bool | int, operation: str) -> None:
@@ -125,16 +278,12 @@ class Metrics:
     def record_dispatch_failure(self, priority: str | bool | int, operation: str) -> None:
         self.dispatch_failures.labels(self._priority(priority), self._operation(operation)).inc()
 
-    def increment_in_flight(
-        self, priority: str | bool | int, operation: str, sender_kind: str
-    ) -> None:
+    def increment_in_flight(self, priority: str | bool | int, operation: str, sender_kind: str) -> None:
         self.in_flight.labels(
             self._priority(priority), self._operation(operation), self._sender_kind(sender_kind)
         ).inc()
 
-    def decrement_in_flight(
-        self, priority: str | bool | int, operation: str, sender_kind: str
-    ) -> None:
+    def decrement_in_flight(self, priority: str | bool | int, operation: str, sender_kind: str) -> None:
         self.in_flight.labels(
             self._priority(priority), self._operation(operation), self._sender_kind(sender_kind)
         ).dec()
@@ -146,17 +295,289 @@ class Metrics:
             self._priority(priority),
             self._operation(operation),
             self._sender_kind(sender_kind),
-            self._completion_outcome(outcome),
+            self._bounded(outcome, _COMPLETION_OUTCOMES, "completion outcome"),
         ).inc()
 
+    def record_queue_dispatch(self, outcome: str) -> None:
+        self.queue_dispatches.labels(self._bounded(outcome, _DISPATCH_OUTCOMES, "dispatch outcome")).inc()
 
-def start_metrics_server(host: str, port: int, registry) -> object:
-    """Start a daemon WSGI server exposing the supplied registry."""
+    def record_queue_wait(self, priority: str | bool | int, operation: str, seconds: float) -> None:
+        self.queue_wait.labels(self._priority(priority), self._operation(operation)).observe(
+            self._non_negative(seconds, "queue wait")
+        )
+
+    def record_executor_attempt_duration(
+        self, priority: str | bool | int, operation: str, outcome: str, seconds: float
+    ) -> None:
+        self.executor_attempt_duration.labels(
+            self._priority(priority), self._operation(operation),
+            self._bounded(outcome, _COMPLETION_OUTCOMES, "completion outcome"),
+        ).observe(self._non_negative(seconds, "executor attempt duration"))
+
+    def record_queue_lifetime(
+        self, priority: str | bool | int, operation: str, outcome: str, seconds: float
+    ) -> None:
+        self.queue_lifetime.labels(
+            self._priority(priority), self._operation(operation),
+            self._bounded(outcome, _COMPLETION_OUTCOMES, "completion outcome"),
+        ).observe(self._non_negative(seconds, "queue lifetime"))
+
+    def record_retry(self, priority: str | bool | int, operation: str, reason: str) -> None:
+        self.retries.labels(
+            self._priority(priority), self._operation(operation),
+            self._bounded(reason, _RETRY_REASONS, "retry reason"),
+        ).inc()
+
+    def record_failure(self, priority: str | bool | int, operation: str, stage: str) -> None:
+        self.failures.labels(
+            self._priority(priority), self._operation(operation),
+            self._bounded(stage, _FAILURE_STAGES, "failure stage"),
+        ).inc()
+
+    def record_membership_probe(self, outcome: str) -> None:
+        self.membership_probes.labels(
+            self._bounded(outcome, _MEMBERSHIP_PROBE_OUTCOMES, "membership probe outcome")
+        ).inc()
+
+    def record_database_method_call(self, method: str, seconds: float, outcome: str) -> None:
+        """Record one DatabaseManager call using only statically bounded method names."""
+        labels = (self._bounded(method, _DATABASE_METHODS, "database method"),)
+        self.database_method_duration.labels(*labels).observe(
+            self._non_negative(seconds, "database method duration")
+        )
+        if self._bounded(outcome, _DATABASE_OUTCOMES, "database method outcome") == "failure":
+            self.database_method_failures.labels(*labels).inc()
+
+    def membership_probe(self, _bot_id: object, _username: object, outcome: str) -> None:
+        """Compatibility entry point for auxiliary probes; bot identity is intentionally unlabelled."""
+        self.record_membership_probe(outcome)
+
+    def _register_collector(self, collect: Callable[[], Iterable[Metric]]) -> None:
+        collector = _CallbackCollector(collect)
+        self.registry.register(collector)
+        self._collectors.append(collector)
+
+    def register_process_collector(
+        self,
+        process_factory: Callable[[], Any] | None = None,
+        network_io_counters: Callable[[], Any] | None = None,
+    ) -> None:
+        """Register scrape-time process and host resource observations.
+
+        ``cpu_percent(None)`` is sampled once during registration to establish
+        psutil's baseline. Each scrape then reports utilization since the prior
+        sample as a Prometheus ratio. Unsupported process I/O sources are
+        omitted, and a failure from one source leaves the other observations
+        available for that scrape.
+        """
+        if process_factory is None or network_io_counters is None:
+            try:
+                import psutil
+            except ImportError:
+                if process_factory is None:
+                    return
+            else:
+                if process_factory is None:
+                    process_factory = psutil.Process
+                if network_io_counters is None:
+                    network_io_counters = psutil.net_io_counters
+
+        try:
+            process = process_factory()
+        except Exception:
+            return
+        try:
+            process.cpu_percent(interval=None)
+        except Exception:
+            pass
+
+        def collect() -> Iterable[Metric]:
+            metrics: list[Metric] = []
+
+            try:
+                cpu_percent = self._non_negative(process.cpu_percent(interval=None), "process CPU percent")
+                cpu = GaugeMetricFamily(
+                    f"{self.namespace}_process_cpu_utilization_ratio",
+                    "Process CPU utilization since the previous psutil sample, as a ratio.",
+                )
+                cpu.add_metric([], cpu_percent / 100)
+                metrics.append(cpu)
+            except Exception:
+                pass
+
+            try:
+                memory = process.memory_info()
+                resident_memory = self._non_negative(memory.rss, "process resident memory")
+                resident = GaugeMetricFamily(
+                    f"{self.namespace}_process_resident_memory_bytes",
+                    "Resident memory currently used by this process in bytes.",
+                )
+                resident.add_metric([], resident_memory)
+                metrics.append(resident)
+            except Exception:
+                pass
+
+            try:
+                disk = process.io_counters()
+                disk_read = CounterMetricFamily(
+                    f"{self.namespace}_process_disk_read_bytes_total",
+                    "Cumulative bytes read by this process from disk.",
+                )
+                disk_read.add_metric([], self._non_negative(disk.read_bytes, "process disk read bytes"))
+                disk_write = CounterMetricFamily(
+                    f"{self.namespace}_process_disk_write_bytes_total",
+                    "Cumulative bytes written by this process to disk.",
+                )
+                disk_write.add_metric([], self._non_negative(disk.write_bytes, "process disk write bytes"))
+                metrics.extend((disk_read, disk_write))
+            except Exception:
+                pass
+
+            if network_io_counters is not None:
+                try:
+                    network_counters = network_io_counters()
+                    network_receive = CounterMetricFamily(
+                        f"{self.namespace}_host_network_receive_bytes_total",
+                        "Cumulative network bytes received by the host.",
+                    )
+                    network_receive.add_metric(
+                        [], self._non_negative(network_counters.bytes_recv, "host network received bytes")
+                    )
+                    network_transmit = CounterMetricFamily(
+                        f"{self.namespace}_host_network_transmit_bytes_total",
+                        "Cumulative network bytes transmitted by the host.",
+                    )
+                    network_transmit.add_metric(
+                        [], self._non_negative(network_counters.bytes_sent, "host network transmitted bytes")
+                    )
+                    metrics.extend((network_receive, network_transmit))
+                except Exception:
+                    pass
+
+            return tuple(metrics)
+
+        self._register_collector(collect)
+
+    def register_destination_queue_collector(
+        self, snapshot: Callable[[], Iterable[DestinationQueueSnapshot]], top_n: int
+    ) -> None:
+        """Register a scrape-time top-N destination snapshot with no retained destination state."""
+        cap = self._count(top_n, "destination top_n")
+
+        def collect() -> Iterable[GaugeMetricFamily]:
+            depth = GaugeMetricFamily(
+                f"{self.namespace}_outbound_destination_queue_depth",
+                "Current queued rows for the deepest destinations in this scrape.",
+                labels=["destination"],
+            )
+            oldest = GaugeMetricFamily(
+                f"{self.namespace}_outbound_destination_oldest_age_seconds",
+                "Oldest queued-row age for the deepest destinations in this scrape.",
+                labels=["destination"],
+            )
+            samples = list(snapshot())
+            for item in sorted(samples, key=lambda value: value.depth, reverse=True)[:cap]:
+                if not isinstance(item.destination, str) or not item.destination:
+                    raise ValueError("destination must be a non-empty string")
+                depth.add_metric([item.destination], self._count(item.depth, "destination depth"))
+                if item.oldest_age_seconds is not None:
+                    oldest.add_metric(
+                        [item.destination], self._non_negative(item.oldest_age_seconds, "destination oldest age")
+                    )
+            return (depth, oldest)
+
+        self._register_collector(collect)
+
+    def register_worker_collector(self, snapshot: Callable[[], WorkerSnapshot]) -> None:
+        """Register aggregate worker liveness and in-flight state."""
+        def collect() -> Iterable[GaugeMetricFamily]:
+            health = GaugeMetricFamily(
+                f"{self.namespace}_outbound_worker_healthy", "Whether the outbound worker is alive."
+            )
+            in_flight = GaugeMetricFamily(
+                f"{self.namespace}_outbound_worker_in_flight", "Calls currently owned by the outbound worker."
+            )
+            value = snapshot()
+            health.add_metric([], int(value.healthy))
+            in_flight.add_metric([], self._count(value.in_flight, "worker in-flight"))
+            return (health, in_flight)
+
+        self._register_collector(collect)
+
+    def register_cooldown_collector(self, snapshot: Callable[[], Mapping[str, float]]) -> None:
+        self._register_bounded_gauge_collector(
+            f"{self.namespace}_outbound_cooldown_seconds",
+            "Remaining sender cooldown, aggregated by sender kind.",
+            "sender_kind",
+            _SENDER_KINDS,
+            snapshot,
+            lambda value: self._non_negative(value, "cooldown"),
+        )
+
+    def register_auxiliary_count_collector(self, snapshot: Callable[[], Mapping[str, int]]) -> None:
+        self._register_bounded_gauge_collector(
+            f"{self.namespace}_auxiliary_bots",
+            "Configured auxiliary bots by enabled state.",
+            "state",
+            _AUXILIARY_STATES,
+            snapshot,
+            lambda value: self._count(value, "auxiliary count"),
+        )
+
+    def register_membership_cache_collector(self, snapshot: Callable[[], Mapping[str, int]]) -> None:
+        self._register_bounded_gauge_collector(
+            f"{self.namespace}_auxiliary_membership_cache_entries",
+            "Aggregate auxiliary membership-cache entries by state.",
+            "state",
+            _MEMBERSHIP_CACHE_STATES,
+            snapshot,
+            lambda value: self._count(value, "membership cache count"),
+        )
+
+    def register_rate_limit_occupancy_collector(self, snapshot: Callable[[], Mapping[str, float]]) -> None:
+        self._register_bounded_gauge_collector(
+            f"{self.namespace}_rate_limit_occupancy",
+            "Current rate-limit occupancy ratio by aggregate scope.",
+            "scope",
+            _RATE_LIMIT_SCOPES,
+            snapshot,
+            self._rate_limit_occupancy_value,
+        )
+
+    def _rate_limit_occupancy_value(self, value: float) -> float:
+        value = self._non_negative(value, "rate-limit occupancy")
+        if value > 1:
+            raise ValueError("rate-limit occupancy must not exceed 1")
+        return value
+
+    def _register_bounded_gauge_collector(
+        self,
+        name: str,
+        documentation: str,
+        label: str,
+        allowed: frozenset[str],
+        snapshot: Callable[[], Mapping[str, Any]],
+        normalize: Callable[[Any], float | int],
+    ) -> None:
+        def collect() -> Iterable[GaugeMetricFamily]:
+            metric = GaugeMetricFamily(name, documentation, labels=[label])
+            for key, value in snapshot().items():
+                metric.add_metric([self._bounded(key, allowed, label)], normalize(value))
+            return (metric,)
+
+        self._register_collector(collect)
+
+
+def start_metrics_server(host: str, port: int, registry: CollectorRegistry) -> MetricsServer:
+    """Start a daemon WSGI serving thread and return its bounded-shutdown handle."""
     from prometheus_client import make_wsgi_app
     from wsgiref.simple_server import WSGIRequestHandler, make_server
 
     class QuietHandler(WSGIRequestHandler):
-        def log_message(self, *_args):
+        def log_message(self, *_args: object) -> None:
             return
 
-    return make_server(host, port, make_wsgi_app(registry), handler_class=QuietHandler)
+    server = make_server(host, port, make_wsgi_app(registry), handler_class=QuietHandler)
+    thread = threading.Thread(target=server.serve_forever, name="ETM metrics server", daemon=True)
+    thread.start()
+    return MetricsServer(server, thread)

--- a/efb_telegram_master/outbound.py
+++ b/efb_telegram_master/outbound.py
@@ -157,6 +157,7 @@ class SubmittedCall:
     row: QueuedCall
     selection: SenderSelection
     future: Future
+    dispatched_at: float
 
 
 @dataclass(frozen=True)
@@ -258,6 +259,26 @@ class QueueMetrics(Protocol):
         ...
 
     def record_completion(self, priority: int, operation: str, sender_kind: str, outcome: str) -> None:
+        ...
+
+    def record_queue_dispatch(self, outcome: str) -> None:
+        ...
+
+    def record_queue_wait(self, priority: int, operation: str, seconds: float) -> None:
+        ...
+
+    def record_executor_attempt_duration(
+        self, priority: int, operation: str, outcome: str, seconds: float
+    ) -> None:
+        ...
+
+    def record_queue_lifetime(self, priority: int, operation: str, outcome: str, seconds: float) -> None:
+        ...
+
+    def record_retry(self, priority: int, operation: str, reason: str) -> None:
+        ...
+
+    def record_failure(self, priority: int, operation: str, stage: str) -> None:
         ...
 
 
@@ -664,6 +685,19 @@ class OutboundQueue:
             heads.append(QueuedCall(*row))
         return heads
 
+    def destination_snapshot(self) -> list[tuple[str, int, float]]:
+        """Return ranked queue destinations without exposing Telegram chat IDs."""
+        with self._lock:
+            rows = self.connection.execute(
+                "SELECT telegram_chat_id, COUNT(*), MIN(created_at) FROM outbound_queue "
+                "GROUP BY telegram_chat_id ORDER BY COUNT(*) DESC, telegram_chat_id ASC"
+            ).fetchall()
+        now = time.time()
+        return [
+            (f"rank_{rank}", int(depth), max(0.0, now - float(oldest_created_at)))
+            for rank, (_chat_id, depth, oldest_created_at) in enumerate(rows, start=1)
+        ]
+
     def delete(self, row_id: int) -> None:
         with self._lock:
             try:
@@ -710,6 +744,10 @@ class OutboundQueueScheduler:
     def _sender_kind(selection: SenderSelection) -> str:
         return "main" if selection.sender_bot_id is None else "auxiliary"
 
+    @staticmethod
+    def _expected_sender_kind(row: QueuedCall) -> str:
+        return "auxiliary" if row.required_sender_bot_id is not None else "main"
+
     def _record_submitted_removal(self, row: QueuedCall) -> None:
         self.queue.record_removal(row, "submitted")
         if self.queue.metrics is not None:
@@ -717,6 +755,48 @@ class OutboundQueueScheduler:
 
     def _record_terminal_discard(self, row: QueuedCall) -> None:
         self.queue.record_removal(row, "terminal_discard")
+
+    def _record_dispatch(self, outcome: str) -> None:
+        if self.queue.metrics is not None:
+            self.queue.metrics.record_queue_dispatch(outcome)
+
+    def _record_dispatch_attempt(self, row: QueuedCall) -> float:
+        dispatched_at = time.monotonic()
+        if self.queue.metrics is not None:
+            self.queue.metrics.record_queue_wait(
+                row.priority, row.operation, max(0.0, time.time() - row.created_at)
+            )
+        return dispatched_at
+
+    def _record_executor_attempt_duration(self, submitted: SubmittedCall, outcome: str) -> None:
+        if self.queue.metrics is None:
+            return
+        self.queue.metrics.record_executor_attempt_duration(
+            submitted.row.priority,
+            submitted.row.operation,
+            outcome,
+            max(0.0, time.monotonic() - submitted.dispatched_at),
+        )
+
+    def _record_terminal_completion(
+        self, row: QueuedCall, selection: SenderSelection | None, outcome: str
+    ) -> None:
+        if self.queue.metrics is None:
+            return
+        sender_kind = self._sender_kind(selection) if selection is not None else self._expected_sender_kind(row)
+        self.queue.metrics.record_completion(
+            row.priority,
+            row.operation,
+            sender_kind,
+            outcome,
+        )
+        self.queue.metrics.record_queue_lifetime(
+            row.priority, row.operation, outcome, max(0.0, time.time() - row.created_at)
+        )
+
+    def in_flight_count(self) -> int:
+        with self._lock:
+            return len(self.in_flight)
 
     def _schedule_retry(self, retry_at: float) -> None:
         self.next_deadline = min(self.next_deadline, retry_at) if self.next_deadline else retry_at
@@ -746,10 +826,8 @@ class OutboundQueueScheduler:
         self.adapter.record_queued_failure(retry.row, error, retry.selection)
         self.queue.fail_waiter(retry.row.id, error)
         if self.queue.metrics is not None:
-            self.queue.metrics.record_completion(
-                retry.row.priority, retry.row.operation,
-                self._sender_kind(retry.selection), "failure"
-            )
+            self.queue.metrics.record_failure(retry.row.priority, retry.row.operation, "terminal")
+        self._record_terminal_completion(retry.row, retry.selection, "failure")
 
     def _schedule_blocking_retry_before_deadline(
         self, retry: BlockingMediaRetry, retry_at: Optional[float] = None
@@ -776,17 +854,22 @@ class OutboundQueueScheduler:
                 self._schedule_blocking_retry_before_deadline(retry)
                 continue
             if not self._permits.acquire(blocking=False):
+                self._record_dispatch("deferred")
+                if self.queue.metrics is not None:
+                    self.queue.metrics.record_retry(retry.row.priority, retry.row.operation, "worker_capacity")
                 self._schedule_blocking_retry_before_deadline(retry)
                 continue
             decision = self.adapter.select_sender(retry.row, now)
             if decision.terminal_error_class is not None:
                 self._permits.release()
+                self._record_dispatch("failed")
                 self._fail_blocking_retry(
                     retry, RequiredSenderUnavailableError(decision.terminal_error_class)
                 )
                 continue
             if decision.selection is None:
                 self._permits.release()
+                self._record_dispatch("deferred")
                 if decision.retry_at is not None:
                     self._schedule_blocking_retry_before_deadline(retry, decision.retry_at)
                 continue
@@ -795,24 +878,33 @@ class OutboundQueueScheduler:
                 or decision.selection.sender_bot_id != retry.selection.sender_bot_id
             ):
                 self._permits.release()
+                self._record_dispatch("failed")
                 self._fail_blocking_retry(retry, retry.error)
                 continue
             if not self.adapter.acquire_sender_limits(retry.selection, retry.row.telegram_chat_id):
                 self._permits.release()
+                self._record_dispatch("deferred")
+                if self.queue.metrics is not None:
+                    self.queue.metrics.record_retry(retry.row.priority, retry.row.operation, "rate_limit")
                 self._schedule_blocking_retry_before_deadline(retry, now + 0.25)
                 continue
             try:
                 args, kwargs = self.queue.decode_payload(retry.row.payload)
+                dispatched_at = self._record_dispatch_attempt(retry.row)
                 future = self.executor.submit(
                     self.adapter.execute_queued_call, retry.row, args, kwargs, retry.selection
                 )
             except BaseException as error:
                 self._permits.release()
+                self._record_dispatch("failed")
+                if self.queue.metrics is not None:
+                    self.queue.metrics.record_failure(retry.row.priority, retry.row.operation, "dispatch")
                 self._fail_blocking_retry(retry, error)
                 continue
             self.blocking_media_retries.pop(row_id, None)
+            self._record_dispatch("submitted")
             future.add_done_callback(self._wake_on_future_completion)
-            self.in_flight[row_id] = SubmittedCall(retry.row, retry.selection, future)
+            self.in_flight[row_id] = SubmittedCall(retry.row, retry.selection, future, dispatched_at)
             self.in_flight_destinations.add(retry.row.telegram_chat_id)
             if self.queue.metrics is not None:
                 self.queue.metrics.increment_in_flight(
@@ -851,9 +943,16 @@ class OutboundQueueScheduler:
                         self._stop_for_persistence_error(delete_error)
                         return
                     self._record_terminal_discard(row)
+                    self._record_dispatch("failed")
+                    if self.queue.metrics is not None:
+                        self.queue.metrics.record_failure(row.priority, row.operation, "terminal")
+                    self._record_terminal_completion(row, None, "failure")
                     self.queue.fail_waiter(row.id, error)
                     continue
                 if not self._permits.acquire(blocking=False):
+                    self._record_dispatch("deferred")
+                    if self.queue.metrics is not None:
+                        self.queue.metrics.record_retry(row.priority, row.operation, "worker_capacity")
                     continue
                 now = time.monotonic()
                 decision = self.adapter.select_sender(row, now)
@@ -865,16 +964,24 @@ class OutboundQueueScheduler:
                         self._stop_for_persistence_error(delete_error)
                         return
                     self._record_terminal_discard(row)
+                    self._record_dispatch("failed")
+                    if self.queue.metrics is not None:
+                        self.queue.metrics.record_failure(row.priority, row.operation, "terminal")
                     unavailable_error = RequiredSenderUnavailableError(decision.terminal_error_class)
+                    self._record_terminal_completion(row, None, "failure")
                     self.queue.fail_waiter(row.id, unavailable_error)
                     continue
                 if decision.selection is None:
                     self._permits.release()
+                    self._record_dispatch("deferred")
                     if decision.retry_at is not None:
                         self._schedule_retry(decision.retry_at)
                     continue
                 if not self.adapter.acquire_sender_limits(decision.selection, row.telegram_chat_id):
                     self._permits.release()
+                    self._record_dispatch("deferred")
+                    if self.queue.metrics is not None:
+                        self.queue.metrics.record_retry(row.priority, row.operation, "rate_limit")
                     retry_at = now + 0.25
                     self._schedule_retry(retry_at)
                     continue
@@ -888,21 +995,26 @@ class OutboundQueueScheduler:
                         return
                     self._record_submitted_removal(row)
                 try:
+                    dispatched_at = self._record_dispatch_attempt(row)
                     future = self.executor.submit(
                         self.adapter.execute_queued_call, row, args, kwargs, decision.selection
                     )
                 except Exception as error:
                     self._permits.release()
+                    self._record_dispatch("failed")
                     if self.queue.metrics is not None:
                         self.queue.metrics.record_dispatch_failure(row.priority, row.operation)
+                        self.queue.metrics.record_failure(row.priority, row.operation, "dispatch")
                     if retained:
                         self._schedule_retry(now + 0.25)
                     else:
                         error = ExecutorSubmitError("Unable to submit queued Telegram call.")
+                        self._record_terminal_completion(row, decision.selection, "failure")
                         self.queue.fail_waiter(row.id, error)
                     continue
+                self._record_dispatch("submitted")
                 future.add_done_callback(self._wake_on_future_completion)
-                self.in_flight[row.id] = SubmittedCall(row, decision.selection, future)
+                self.in_flight[row.id] = SubmittedCall(row, decision.selection, future, dispatched_at)
                 self.in_flight_destinations.add(row.telegram_chat_id)
                 if self.queue.metrics is not None:
                     self.queue.metrics.increment_in_flight(
@@ -926,6 +1038,11 @@ class OutboundQueueScheduler:
                 try:
                     result = submitted.future.result()
                 except BaseException as error:
+                    self._record_executor_attempt_duration(submitted, "failure")
+                    if self.queue.metrics is not None:
+                        self.queue.metrics.record_failure(
+                            submitted.row.priority, submitted.row.operation, "execution"
+                        )
                     if self._is_blocking_media_retry(submitted.row, error):
                         assert isinstance(error, RetryAfter)
                         retry_after = self._retry_after_seconds(error)
@@ -939,6 +1056,10 @@ class OutboundQueueScheduler:
                                 submitted.row, submitted.selection, retry_at, deadline, error
                             )
                             self._schedule_retry(retry_at)
+                            if self.queue.metrics is not None:
+                                self.queue.metrics.record_retry(
+                                    submitted.row.priority, submitted.row.operation, "rate_limit"
+                                )
                             continue
                     decision = self.adapter.record_queued_failure(submitted.row, error, submitted.selection)
                     if decision.kind == "retry_eventual" and submitted.row.priority == 0:
@@ -948,6 +1069,11 @@ class OutboundQueueScheduler:
                         if decision.retry_at is None:
                             raise RuntimeError("Retry decision requires a retry deadline.")
                         self._schedule_retry(decision.retry_at)
+                        if self.queue.metrics is not None:
+                            self.queue.metrics.record_retry(
+                                submitted.row.priority, submitted.row.operation,
+                                "rate_limit" if isinstance(error, RetryAfter) else "membership"
+                            )
                         continue
                     if submitted.row.priority == 0:
                         try:
@@ -958,11 +1084,12 @@ class OutboundQueueScheduler:
                         self._record_terminal_discard(submitted.row)
                     self.queue.fail_waiter(row_id, error)
                     if self.queue.metrics is not None:
-                        self.queue.metrics.record_completion(
-                            submitted.row.priority, submitted.row.operation,
-                            self._sender_kind(submitted.selection), "failure"
+                        self.queue.metrics.record_failure(
+                            submitted.row.priority, submitted.row.operation, "terminal"
                         )
+                    self._record_terminal_completion(submitted.row, submitted.selection, "failure")
                 else:
+                    self._record_executor_attempt_duration(submitted, "success")
                     self.adapter.record_queued_success(submitted.row, result, submitted.selection)
                     if submitted.row.priority == 0:
                         try:
@@ -974,11 +1101,7 @@ class OutboundQueueScheduler:
                     waiter = self.queue.waiters.pop(row_id, None)
                     if waiter is not None and not waiter.done():
                         waiter.set_result(result)
-                    if self.queue.metrics is not None:
-                        self.queue.metrics.record_completion(
-                            submitted.row.priority, submitted.row.operation,
-                            self._sender_kind(submitted.selection), "success"
-                        )
+                    self._record_terminal_completion(submitted.row, submitted.selection, "success")
             if any_harvested:
                 self.wake_event.set()
 

--- a/efb_telegram_master/rate_limiter.py
+++ b/efb_telegram_master/rate_limiter.py
@@ -103,6 +103,17 @@ class SlidingWindowRateLimiter:
             self._leak(chat_bucket)
             return chat_bucket.count(), self._global_bucket.count()
 
+    def occupancy_snapshot(self) -> dict[str, float]:
+        """Return aggregate limiter occupancy without exposing chat identities."""
+        with self._lock:
+            self._leak(self._global_bucket)
+            global_occupancy = self._global_bucket.count() / GLOBAL_LIMIT
+            chat_occupancy = 0.0
+            for bucket in self._chat_buckets.values():
+                self._leak(bucket)
+                chat_occupancy = max(chat_occupancy, bucket.count() / CHAT_LIMIT)
+            return {"global": global_occupancy, "chat": chat_occupancy}
+
     def _delay(self, bucket: InMemoryBucket, limit: int, seconds: float) -> float:
         self._leak(bucket)
         if bucket.count() < limit:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "humanize",
         "typing-extensions>=3.7.4.1",
         "prometheus_client",
+        "psutil>=5.9,<8",
         "pyrate-limiter>=3.9.0",
     ],
     extras_require={

--- a/tests/unit/test_bot_manager.py
+++ b/tests/unit/test_bot_manager.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 import telegram.error
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputFile
+from prometheus_client import generate_latest
 
 from efb_telegram_master.bot_manager import (
     QueuedDbLogContext,
@@ -21,6 +22,7 @@ from efb_telegram_master.bot_manager import (
     TelegramBotManager,
 )
 from efb_telegram_master.bot_manager import AsyncTelegramRuntime
+from efb_telegram_master.etm_metrics import Metrics
 from efb_telegram_master.outbound import OutboundQueue, QueueEnqueueError, QueueRequest, SenderSelection
 
 
@@ -326,6 +328,7 @@ def test_queued_failure_decision_retries_only_eventual_retry_after(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = object.__new__(TelegramBotManager)
+    manager._bot_chat_state_lock = threading.Lock()
     manager._bot_chat_disabled_until = {("10", 100): 1_111.0}
     manager.bot_pool = None
     task = SimpleNamespace(telegram_chat_id=100, slave_id=None, priority=0)
@@ -346,6 +349,7 @@ def test_queued_failure_decision_retries_only_eventual_retry_after(
 
 def test_terminal_eventual_failure_does_not_clear_existing_cooldown() -> None:
     manager = object.__new__(TelegramBotManager)
+    manager._bot_chat_state_lock = threading.Lock()
     manager._bot_chat_disabled_until = {("10", 100): 1_025.0}
     manager.bot_pool = None
     task = SimpleNamespace(telegram_chat_id=100, slave_id=None, priority=0)
@@ -781,6 +785,7 @@ def test_terminal_queued_failure_releases_deferred_mapping_callback():
     on_complete = Mock()
     manager._queued_db_log_contexts = {7: QueuedDbLogContext(Mock(), None, on_complete)}
     manager._queued_db_log_context_lock = threading.Lock()
+    manager._bot_chat_state_lock = threading.Lock()
     manager._bot_chat_disabled_until = {}
     manager.bot_pool = None
     row = SimpleNamespace(id=7, priority=0, telegram_chat_id=123, slave_id=None)
@@ -795,6 +800,81 @@ def test_terminal_queued_failure_releases_deferred_mapping_callback():
     assert decision.kind.name == "TERMINAL_FAILURE"
     on_complete.assert_called_once_with()
     assert manager._queued_db_log_contexts == {}
+
+
+def test_cooldown_metrics_snapshot_blocks_mutation_until_iteration_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BlockingCooldowns(dict):
+        def __init__(self) -> None:
+            super().__init__({(None, 100): 1_020.0})
+            self.snapshot_started = threading.Event()
+            self.allow_iteration = threading.Event()
+
+        def items(self):
+            iterator = iter(super().items())
+            self.snapshot_started.set()
+            assert self.allow_iteration.wait(timeout=1)
+            return iterator
+
+    class TrackingLock:
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self._acquire_count = 0
+            self._count_lock = threading.Lock()
+            self.second_acquire_attempted = threading.Event()
+
+        def __enter__(self):
+            with self._count_lock:
+                self._acquire_count += 1
+                if self._acquire_count == 2:
+                    self.second_acquire_attempted.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback) -> None:
+            self._lock.release()
+
+    manager = object.__new__(TelegramBotManager)
+    cooldowns = BlockingCooldowns()
+    lock = TrackingLock()
+    manager._bot_chat_state_lock = lock
+    manager._bot_chat_disabled_until = cooldowns
+    metrics = Metrics()
+    metrics.register_cooldown_collector(manager._cooldown_snapshot)
+    rendered: list[bytes] = []
+    errors: list[BaseException] = []
+
+    def render_metrics() -> None:
+        try:
+            rendered.append(generate_latest(metrics.registry))
+        except BaseException as error:
+            errors.append(error)
+
+    def record_cooldown() -> None:
+        manager.record_queued_retry_after(
+            SimpleNamespace(telegram_chat_id=200),
+            telegram.error.RetryAfter(20),
+            SimpleNamespace(sender_bot_id="10"),
+        )
+
+    monkeypatch.setattr("efb_telegram_master.bot_manager.time.monotonic", lambda: 1_000.0)
+    snapshot_thread = threading.Thread(target=render_metrics)
+    snapshot_thread.start()
+    assert cooldowns.snapshot_started.wait(timeout=1)
+
+    mutation_thread = threading.Thread(target=record_cooldown)
+    mutation_thread.start()
+    assert lock.second_acquire_attempted.wait(timeout=1)
+
+    cooldowns.allow_iteration.set()
+    snapshot_thread.join(timeout=1)
+    mutation_thread.join(timeout=1)
+
+    assert not snapshot_thread.is_alive()
+    assert not mutation_thread.is_alive()
+    assert errors == []
+    assert b'etm_outbound_cooldown_seconds{sender_kind="main"} 20.0' in rendered[0]
 
 
 @pytest.mark.parametrize(
@@ -1169,7 +1249,10 @@ def test_graceful_stop_signals_manual_event_on_event_loop_when_runtime_loop_miss
 def test_graceful_stop_shuts_down_metrics_server():
     shutdown_complete_event = threading.Event()
     shutdown_complete_event.set()
-    metrics_httpd = Mock()
+    metrics_thread = Mock()
+    metrics_thread.is_alive.side_effect = [True, False]
+    metrics_thread.ident = -1
+    metrics_httpd = Mock(thread=metrics_thread)
     manager = SimpleNamespace(
         logger=Mock(),
         stop_queued_worker=Mock(),
@@ -1192,6 +1275,22 @@ def test_graceful_stop_shuts_down_metrics_server():
 
     metrics_httpd.shutdown.assert_called_once_with()
     metrics_httpd.server_close.assert_called_once_with()
+    metrics_thread.join.assert_not_called()
+    assert manager._metrics_httpd is None
+
+
+def test_metrics_server_stop_closes_unstarted_server_without_shutdown_or_join():
+    metrics_thread = Mock()
+    metrics_thread.is_alive.return_value = False
+    metrics_httpd = Mock(thread=metrics_thread)
+    manager = SimpleNamespace(_metrics_httpd=metrics_httpd, SHUTDOWN_JOIN_GRACE=1.0)
+
+    TelegramBotManager._stop_metrics_server(manager)
+    TelegramBotManager._stop_metrics_server(manager)
+
+    metrics_httpd.shutdown.assert_not_called()
+    metrics_httpd.server_close.assert_called_once_with()
+    metrics_thread.join.assert_not_called()
 
 
 def test_stop_worker_join_covers_outbound_drain_deadline():

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from prometheus_client import generate_latest
 
 from ehforwarderbot import Message, MsgType
 from ehforwarderbot.types import MessageID
@@ -23,6 +24,7 @@ from efb_telegram_master.db import (
     database,
 )
 from efb_telegram_master.message import ETMMsg
+from efb_telegram_master.etm_metrics import Metrics
 from efb_telegram_master.msg_type import TGMsgType
 from efb_telegram_master.utils import TelegramChatID, TelegramMessageID, TelegramTopicID
 
@@ -33,6 +35,26 @@ def test_msglog_schema_has_sender_bot_id(channel):
         from efb_telegram_master.db import database
         columns = {column.name for column in database.get_columns("msglog")}
     assert "sender_bot_id" in columns
+
+
+def test_database_method_metrics_record_success_failure_and_bounded_labels(channel):
+    metrics = Metrics()
+    channel.db.set_metrics(metrics)
+
+    assert channel.db.get_chat_assoc(master_uid="metrics-master") == []
+    with pytest.raises(ValueError, match="mutual exclusive"):
+        channel.db.get_msg_log()
+    with pytest.raises(ValueError, match="database method is invalid"):
+        metrics.record_database_method_call("SELECT * FROM msglog", 0.1, "success")
+
+    rendered = generate_latest(metrics.registry).decode()
+
+    assert 'etm_database_method_duration_seconds_count{method="get_chat_assoc"} 1.0' in rendered
+    assert 'etm_database_method_duration_seconds_sum{method="get_chat_assoc"}' in rendered
+    assert 'etm_database_method_duration_seconds_count{method="get_msg_log"} 1.0' in rendered
+    assert 'etm_database_method_failures_total{method="get_msg_log"} 1.0' in rendered
+    assert "metrics-master" not in rendered
+    assert "SELECT * FROM msglog" not in rendered
 
 
 def test_history_migration_entry_table_exists():

--- a/tests/unit/test_etm_metrics.py
+++ b/tests/unit/test_etm_metrics.py
@@ -1,11 +1,118 @@
+from types import SimpleNamespace
+from urllib.request import urlopen
+
 import pytest
 from prometheus_client import generate_latest
 
-from efb_telegram_master.etm_metrics import Metrics
+from efb_telegram_master.etm_metrics import (
+    DestinationQueueSnapshot,
+    Metrics,
+    WorkerSnapshot,
+    start_metrics_server,
+)
 
 
 def _render(metrics: Metrics) -> str:
     return generate_latest(metrics.registry).decode()
+
+
+class _SupportedProcess:
+    def __init__(self) -> None:
+        self.cpu_percent_values = iter((0.0, 12.5))
+
+    def cpu_percent(self, interval: None) -> float:
+        assert interval is None
+        return next(self.cpu_percent_values)
+
+    @staticmethod
+    def memory_info() -> SimpleNamespace:
+        return SimpleNamespace(rss=4096)
+
+    @staticmethod
+    def io_counters() -> SimpleNamespace:
+        return SimpleNamespace(read_bytes=1024, write_bytes=2048)
+
+
+def _supported_host_network_counters() -> SimpleNamespace:
+    return SimpleNamespace(bytes_recv=3072, bytes_sent=4096)
+
+
+def test_process_collector_renders_supported_process_observations():
+    metrics = Metrics(
+        process_factory=_SupportedProcess,
+        network_io_counters=_supported_host_network_counters,
+    )
+
+    rendered = _render(metrics)
+
+    assert "etm_process_cpu_utilization_ratio 0.125" in rendered
+    assert "etm_process_resident_memory_bytes 4096.0" in rendered
+    assert "etm_process_disk_read_bytes_total 1024.0" in rendered
+    assert "etm_process_disk_write_bytes_total 2048.0" in rendered
+    assert "etm_host_network_receive_bytes_total 3072.0" in rendered
+    assert "etm_host_network_transmit_bytes_total 4096.0" in rendered
+    assert "# HELP etm_host_network_receive_bytes_total Cumulative network bytes received by the host." in rendered
+
+
+class _UnsupportedIoProcess:
+    def cpu_percent(self, interval: None) -> float:
+        assert interval is None
+        return 0.0
+
+    @staticmethod
+    def memory_info() -> SimpleNamespace:
+        return SimpleNamespace(rss=1024)
+
+    @staticmethod
+    def io_counters() -> SimpleNamespace:
+        raise NotImplementedError
+
+
+def test_process_collector_omits_unsupported_io_observations():
+    def unsupported_network_io_counters() -> SimpleNamespace:
+        raise NotImplementedError
+
+    rendered = _render(
+        Metrics(
+            process_factory=_UnsupportedIoProcess,
+            network_io_counters=unsupported_network_io_counters,
+        )
+    )
+
+    assert "etm_process_resident_memory_bytes 1024.0" in rendered
+    assert "etm_process_disk_read_bytes_total" not in rendered
+    assert "etm_process_disk_write_bytes_total" not in rendered
+    assert "etm_host_network_receive_bytes_total" not in rendered
+    assert "etm_host_network_transmit_bytes_total" not in rendered
+
+
+class _PartiallyFailingProcess:
+    def cpu_percent(self, interval: None) -> float:
+        assert interval is None
+        raise OSError("process exited")
+
+    @staticmethod
+    def memory_info() -> SimpleNamespace:
+        return SimpleNamespace(rss=2048)
+
+    @staticmethod
+    def io_counters() -> SimpleNamespace:
+        raise OSError("I/O unavailable")
+
+
+def test_process_collector_isolates_metric_source_errors():
+    rendered = _render(
+        Metrics(
+            process_factory=_PartiallyFailingProcess,
+            network_io_counters=_supported_host_network_counters,
+        )
+    )
+
+    assert "etm_process_cpu_utilization_ratio" not in rendered
+    assert "etm_process_resident_memory_bytes 2048.0" in rendered
+    assert "etm_process_disk_read_bytes_total" not in rendered
+    assert "etm_host_network_receive_bytes_total 3072.0" in rendered
+    assert "etm_host_network_transmit_bytes_total 4096.0" in rendered
 
 
 def test_queue_metrics_render_every_closed_matrix_event():
@@ -19,6 +126,12 @@ def test_queue_metrics_render_every_closed_matrix_event():
     metrics.increment_in_flight("blocking", "send_message", "main")
     metrics.decrement_in_flight("blocking", "send_message", "main")
     metrics.record_completion("blocking", "send_message", "main", "failure")
+    metrics.record_queue_dispatch("submitted")
+    metrics.record_queue_wait("blocking", "send_message", 0.25)
+    metrics.record_executor_attempt_duration("blocking", "send_message", "failure", 0.5)
+    metrics.record_queue_lifetime("blocking", "send_message", "failure", 1.0)
+    metrics.record_retry("blocking", "send_message", "rate_limit")
+    metrics.record_failure("blocking", "send_message", "execution")
 
     rendered = _render(metrics)
 
@@ -30,6 +143,79 @@ def test_queue_metrics_render_every_closed_matrix_event():
     assert 'etm_outbound_dispatch_failures_total{operation="delete_message",priority="normal"} 1.0' in rendered
     assert 'etm_outbound_in_flight{operation="send_message",priority="blocking",sender_kind="main"} 0.0' in rendered
     assert 'etm_outbound_completions_total{operation="send_message",outcome="failure",priority="blocking",sender_kind="main"} 1.0' in rendered
+    assert 'etm_outbound_queue_dispatches_total{outcome="submitted"} 1.0' in rendered
+    assert 'etm_outbound_queue_wait_seconds_count{operation="send_message",priority="blocking"} 1.0' in rendered
+    assert 'etm_outbound_executor_attempt_duration_seconds_count{operation="send_message",outcome="failure",priority="blocking"} 1.0' in rendered
+    assert 'etm_outbound_queue_lifetime_seconds_count{operation="send_message",outcome="failure",priority="blocking"} 1.0' in rendered
+    assert 'etm_outbound_retries_total{operation="send_message",priority="blocking",reason="rate_limit"} 1.0' in rendered
+    assert 'etm_outbound_failures_total{operation="send_message",priority="blocking",stage="execution"} 1.0' in rendered
+
+
+def test_snapshot_collectors_render_bounded_aggregate_metrics():
+    metrics = Metrics()
+    metrics.register_destination_queue_collector(
+        lambda: (
+            DestinationQueueSnapshot("least", 1, 3.0),
+            DestinationQueueSnapshot("deepest", 3, 2.0),
+            DestinationQueueSnapshot("middle", 2, None),
+        ),
+        top_n=2,
+    )
+    metrics.register_worker_collector(lambda: WorkerSnapshot(healthy=True, in_flight=4))
+    metrics.register_cooldown_collector(lambda: {"main": 1.5, "auxiliary": 0.0})
+    metrics.register_auxiliary_count_collector(lambda: {"enabled": 2, "disabled": 1})
+    metrics.register_membership_cache_collector(
+        lambda: {"member": 4, "not_member": 2, "unknown_probe_pending": 1}
+    )
+    metrics.register_rate_limit_occupancy_collector(lambda: {"global": 0.5, "chat": 0.25})
+
+    rendered = _render(metrics)
+
+    assert 'etm_outbound_destination_queue_depth{destination="deepest"} 3.0' in rendered
+    assert 'etm_outbound_destination_queue_depth{destination="middle"} 2.0' in rendered
+    assert 'etm_outbound_destination_queue_depth{destination="least"}' not in rendered
+    assert 'etm_outbound_destination_oldest_age_seconds{destination="deepest"} 2.0' in rendered
+    assert 'etm_outbound_destination_oldest_age_seconds{destination="middle"}' not in rendered
+    assert "etm_outbound_worker_healthy 1.0" in rendered
+    assert "etm_outbound_worker_in_flight 4.0" in rendered
+    assert 'etm_outbound_cooldown_seconds{sender_kind="main"} 1.5' in rendered
+    assert 'etm_auxiliary_bots{state="enabled"} 2.0' in rendered
+    assert 'etm_auxiliary_membership_cache_entries{state="unknown_probe_pending"} 1.0' in rendered
+    assert 'etm_rate_limit_occupancy{scope="chat"} 0.25' in rendered
+
+
+def test_snapshot_collectors_render_empty_snapshots_without_labels():
+    metrics = Metrics()
+    metrics.register_destination_queue_collector(lambda: (), top_n=0)
+    metrics.register_cooldown_collector(lambda: {})
+    metrics.register_auxiliary_count_collector(lambda: {})
+    metrics.register_membership_cache_collector(lambda: {})
+    metrics.register_rate_limit_occupancy_collector(lambda: {})
+
+    rendered = _render(metrics)
+
+    assert "etm_outbound_destination_queue_depth{" not in rendered
+    assert "etm_outbound_cooldown_seconds{" not in rendered
+    assert "etm_auxiliary_bots{" not in rendered
+    assert "etm_auxiliary_membership_cache_entries{" not in rendered
+    assert "etm_rate_limit_occupancy{" not in rendered
+
+
+def test_metrics_server_serves_http_and_thread_stops_after_shutdown():
+    metrics = Metrics()
+    metrics.set_queue_depth(2)
+    server = start_metrics_server("127.0.0.1", 0, metrics.registry)
+    try:
+        host, port = server.server_address
+        with urlopen(f"http://{host}:{port}/metrics", timeout=2) as response:
+            assert response.status == 200
+            assert "etm_outbound_queue_depth 2.0" in response.read().decode()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server.thread.join(timeout=2)
+
+    assert not server.thread.is_alive()
 
 
 @pytest.mark.parametrize(
@@ -41,6 +227,10 @@ def test_queue_metrics_render_every_closed_matrix_event():
         lambda metrics: metrics.increment_in_flight("normal", "send_message", "bot-42"),
         lambda metrics: metrics.record_completion("normal", "send_message", "main", "cancelled"),
         lambda metrics: metrics.set_queue_depth(-1),
+        lambda metrics: metrics.record_queue_dispatch("reserved"),
+        lambda metrics: metrics.record_queue_wait("normal", "send_message", -0.1),
+        lambda metrics: metrics.record_retry("normal", "send_message", "unbounded"),
+        lambda metrics: metrics.record_failure("normal", "send_message", "retry"),
     ],
 )
 def test_queue_metrics_reject_unbounded_or_invalid_values(call):

--- a/tests/unit/test_outbound_queue_runtime_evidence.py
+++ b/tests/unit/test_outbound_queue_runtime_evidence.py
@@ -32,6 +32,7 @@ from efb_telegram_master.outbound import (
     SenderSelection,
     SenderSelectionResult,
 )
+from efb_telegram_master.rate_limiter import SlidingWindowRateLimiter
 
 
 def send_message(chat_id: int, text: str) -> tuple[int, str]:
@@ -727,6 +728,8 @@ def test_blocking_media_edit_retry_exceeding_original_deadline_is_terminal(
     clock = {"monotonic": 100.0, "wall": 1000.0}
     monkeypatch.setattr(outbound.time, "monotonic", lambda: clock["monotonic"])
     monkeypatch.setattr(outbound.time, "time", lambda: clock["wall"])
+    metrics = Metrics()
+    retained_queue.metrics = metrics
     row_id, waiter = _enqueue_blocking_media_edit(retained_queue, io.BufferedReader(io.BytesIO(b"media")))
     executor = ControlledExecutor()
     scheduler = OutboundQueueScheduler(retained_queue, RecordingAdapter(), executor, worker_count=1)
@@ -738,6 +741,10 @@ def test_blocking_media_edit_retry_exceeding_original_deadline_is_terminal(
     with pytest.raises(RetryAfter):
         waiter.result()
     assert row_id not in scheduler.blocking_media_retries
+    rendered = generate_latest(metrics.registry).decode()
+    assert 'etm_outbound_completions_total{operation="edit_message_media",outcome="failure",priority="blocking",sender_kind="main"} 1.0' in rendered
+    assert 'etm_outbound_queue_lifetime_seconds_count{operation="edit_message_media",outcome="failure",priority="blocking"} 1.0' in rendered
+    assert 'etm_outbound_executor_attempt_duration_seconds_count{operation="edit_message_media",outcome="failure",priority="blocking"} 1.0' in rendered
 
 
 def test_repeated_blocking_media_edit_retry_cannot_extend_original_deadline(
@@ -953,7 +960,73 @@ def test_scheduler_publishes_metrics_for_actual_dequeue_and_completion(tmp_path:
     assert 'etm_outbound_dequeued_total{operation="send_message",priority="normal"} 1.0' in rendered
     assert 'etm_outbound_in_flight{operation="send_message",priority="normal",sender_kind="main"} 0.0' in rendered
     assert 'etm_outbound_completions_total{operation="send_message",outcome="success",priority="normal",sender_kind="main"} 1.0' in rendered
+    assert 'etm_outbound_queue_dispatches_total{outcome="submitted"} 1.0' in rendered
+    assert 'etm_outbound_queue_wait_seconds_count{operation="send_message",priority="normal"} 1.0' in rendered
+    assert 'etm_outbound_executor_attempt_duration_seconds_count{operation="send_message",outcome="success",priority="normal"} 1.0' in rendered
+    assert 'etm_outbound_queue_lifetime_seconds_count{operation="send_message",outcome="success",priority="normal"} 1.0' in rendered
     assert row_id not in scheduler.in_flight
+    queue.close()
+
+
+def test_scheduler_records_attempt_failure_and_only_terminal_success_after_retry(tmp_path: Path) -> None:
+    metrics = Metrics()
+    queue = OutboundQueue(tmp_path, metrics=metrics)
+    _row_id, waiter = enqueue(queue, 49, "retry metrics")
+    adapter = RecordingAdapter(failure_decision=CompletionDecision("retry_eventual", retry_at=10.0))
+    executor = ControlledExecutor()
+    scheduler = OutboundQueueScheduler(queue, adapter, executor, worker_count=1)
+
+    scheduler.dispatch_once()
+    executor.submissions[0][2].set_exception(RetryAfter(1))
+    scheduler.harvest_completed()
+
+    assert not waiter.done()
+    rendered = generate_latest(metrics.registry).decode()
+    assert 'etm_outbound_completions_total{operation="send_message",outcome="failure",priority="normal",sender_kind="main"}' not in rendered
+    assert 'etm_outbound_retries_total{operation="send_message",priority="normal",reason="rate_limit"} 1.0' in rendered
+    assert 'etm_outbound_failures_total{operation="send_message",priority="normal",stage="execution"} 1.0' in rendered
+    assert 'etm_outbound_executor_attempt_duration_seconds_count{operation="send_message",outcome="failure",priority="normal"} 1.0' in rendered
+
+    scheduler.dispatch_once()
+    executor.submissions[1][2].set_result("sent")
+    scheduler.harvest_completed()
+
+    assert waiter.result() == "sent"
+    rendered = generate_latest(metrics.registry).decode()
+    assert 'etm_outbound_completions_total{operation="send_message",outcome="success",priority="normal",sender_kind="main"} 1.0' in rendered
+    assert 'etm_outbound_completions_total{operation="send_message",outcome="failure",priority="normal",sender_kind="main"}' not in rendered
+    assert 'etm_outbound_queue_lifetime_seconds_count{operation="send_message",outcome="success",priority="normal"} 1.0' in rendered
+    assert 'etm_outbound_queue_lifetime_seconds_count{operation="send_message",outcome="failure",priority="normal"}' not in rendered
+    assert 'etm_outbound_executor_attempt_duration_seconds_count{operation="send_message",outcome="success",priority="normal"} 1.0' in rendered
+    queue.close()
+
+
+def test_manager_registers_runtime_snapshot_collectors_with_configured_destination_cap(tmp_path: Path) -> None:
+    queue = OutboundQueue(tmp_path)
+    enqueue(queue, 61, "first")
+    enqueue(queue, 61, "second")
+    enqueue(queue, 62, "third")
+    metrics = Metrics()
+    manager = object.__new__(TelegramBotManager)
+    manager._metrics = metrics
+    manager._outbound_queue = queue
+    manager._outbound_scheduler = SimpleNamespace(in_flight_count=lambda: 3)
+    manager._send_worker_thread = SimpleNamespace(is_alive=lambda: True)
+    manager._bot_chat_disabled_until = {(None, 61): outbound.time.monotonic() + 1.0}
+    manager._rate_limiter = SlidingWindowRateLimiter()
+    manager.bot_pool = None
+
+    manager._register_runtime_metric_collectors(top_n=1)
+
+    rendered = generate_latest(metrics.registry).decode()
+    assert 'etm_outbound_destination_queue_depth{destination="rank_1"} 2.0' in rendered
+    assert 'etm_outbound_destination_queue_depth{destination="rank_2"}' not in rendered
+    assert "etm_outbound_worker_healthy 1.0" in rendered
+    assert "etm_outbound_worker_in_flight 3.0" in rendered
+    assert 'etm_outbound_cooldown_seconds{sender_kind="main"}' in rendered
+    assert 'etm_auxiliary_bots{state="enabled"} 0.0' in rendered
+    assert 'etm_auxiliary_membership_cache_entries{state="member"} 0.0' in rendered
+    assert 'etm_rate_limit_occupancy{scope="global"} 0.0' in rendered
     queue.close()
 
 

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -94,3 +94,17 @@ def test_limiter_state_resets_on_process_restart() -> None:
     restarted_process = _make_limiter(clock)
     assert restarted_process.global_delay() == 0.0
     assert restarted_process.try_acquire_global()
+
+
+def test_occupancy_snapshot_is_aggregate_and_leaks_expired_entries() -> None:
+    clock = MonotonicClock()
+    limiter = _make_limiter(clock)
+
+    for _ in range(14):
+        assert limiter.try_acquire_global()
+    for _ in range(9):
+        assert limiter.try_acquire_chat(100)
+
+    assert limiter.occupancy_snapshot() == {"global": 0.5, "chat": 0.5}
+    clock.value = 61.0
+    assert limiter.occupancy_snapshot() == {"global": 0.0, "chat": 0.0}


### PR DESCRIPTION
## Summary
- restore the managed Prometheus HTTP exposition server and bounded outbound/runtime collectors
- add process CPU, memory, disk I/O, and host network I/O metrics through psutil
- add bounded DatabaseManager duration/failure metrics; histogram count/sum support average and p99 PromQL

## Verification
- .venv/bin/python -m pytest -q tests/unit (338 passed, 68 skipped)
- .venv/bin/python -m mypy efb_telegram_master/etm_metrics.py efb_telegram_master/db.py efb_telegram_master/bot_manager.py efb_telegram_master/outbound.py efb_telegram_master/rate_limiter.py efb_telegram_master/auxiliary_bot.py efb_telegram_master/bot_pool.py
- two independent code reviews approved